### PR TITLE
URI Retriever: follow http redirects using Curl by default

### DIFF
--- a/src/JsonSchema/Uri/UriRetriever.php
+++ b/src/JsonSchema/Uri/UriRetriever.php
@@ -12,6 +12,7 @@ namespace JsonSchema\Uri;
 use JsonSchema\Exception\InvalidSchemaMediaTypeException;
 use JsonSchema\Exception\JsonDecodingException;
 use JsonSchema\Exception\ResourceNotFoundException;
+use JsonSchema\Uri\Retrievers\Curl;
 use JsonSchema\Uri\Retrievers\FileGetContents;
 use JsonSchema\Uri\Retrievers\UriRetrieverInterface;
 use JsonSchema\UriRetrieverInterface as BaseUriRetrieverInterface;
@@ -103,7 +104,7 @@ class UriRetriever implements BaseUriRetrieverInterface
     public function getUriRetriever()
     {
         if (is_null($this->uriRetriever)) {
-            $this->setUriRetriever(new FileGetContents());
+            $this->setUriRetriever(\extension_loaded('curl') ? new Curl : new FileGetContents);
         }
 
         return $this->uriRetriever;

--- a/src/JsonSchema/Uri/UriRetriever.php
+++ b/src/JsonSchema/Uri/UriRetriever.php
@@ -104,7 +104,7 @@ class UriRetriever implements BaseUriRetrieverInterface
     public function getUriRetriever()
     {
         if (is_null($this->uriRetriever)) {
-            $this->setUriRetriever(\extension_loaded('curl') ? new Curl : new FileGetContents);
+            $this->setUriRetriever(\extension_loaded('curl') ? new Curl(new FileGetContents) : new FileGetContents);
         }
 
         return $this->uriRetriever;

--- a/tests/Uri/Retrievers/CurlTest.php
+++ b/tests/Uri/Retrievers/CurlTest.php
@@ -29,6 +29,22 @@ namespace JsonSchema\Tests\Uri\Retrievers
             $c = new Curl();
             $c->retrieve(realpath(__DIR__ . '/../../fixtures') . '/foobar-noheader.json');
         }
+
+        public function testCurlFallbackFileGetContents()
+        {
+            $retriever = new Curl(new FileGetContents());
+            $result = $retriever->retrieve(__DIR__.'/../Fixture/child.json');
+            $this->assertNotEmpty($result);
+        }
+
+        /**
+        * @expectedException JsonSchema\Exception\ResourceNotFoundException
+        */
+        public function testFetchMissingFile()
+        {
+            $retriever = new Curl(new FileGetContents());
+            $retriever->retrieve(__DIR__.'/Fixture/missing.json');
+        }
     }
 }
 


### PR DESCRIPTION
The CurlURIRetriever will fallback to the FileGetContents one with relative paths as I understood that file paths and actual URIs were using the same retriever. 

Please let me know if my assumption is false.