### PR TITLE
Increase phpstan level to 8 with baseline to swallow existing errors

### DIFF
--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -23,12 +23,11 @@ jobs:
           coverage: "none"
           extensions: "intl, zip"
           ini-values: "memory_limit=-1"
-          php-version: "7.4"
+          php-version: "7.2"
 
       - name: "Update dependencies"
         run: "composer update ${{ env.COMPOSER_FLAGS }}"
 
       - name: Run PHPStan
         run: |
-          composer require --dev phpstan/phpstan:^1.5 marc-mabe/php-enum-phpstan ${{ env.COMPOSER_FLAGS }}
-          vendor/bin/phpstan analyse
+          composer phpstan

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Bump to minimum PHP 7.2 ([#746](https://github.com/jsonrainbow/json-schema/pull/746))
 - Replace traditional syntax array with short syntax array ([#747](https://github.com/jsonrainbow/json-schema/pull/747))
+- Increase phpstan level to 8 with baseline to swallow existing errors ([#673](https://github.com/jsonrainbow/json-schema/pull/673))
 
 ## [6.0.0] - 2024-07-30
 ### Added

--- a/composer.json
+++ b/composer.json
@@ -35,7 +35,9 @@
         "friendsofphp/php-cs-fixer": "~2.2.20 || ~2.19.0",
         "json-schema/json-schema-test-suite": "1.2.0",
         "phpunit/phpunit": "^8.5",
-        "phpspec/prophecy": "^1.19"
+        "phpspec/prophecy": "^1.19",
+        "phpstan/phpstan": "^1.12",
+        "marc-mabe/php-enum-phpstan": "^2.0"
     },
     "extra": {
         "branch-alias": {
@@ -74,6 +76,7 @@
         "style-check": "php-cs-fixer fix --dry-run --verbose --diff",
         "style-fix": "php-cs-fixer fix --verbose",
         "test": "phpunit",
-        "testOnly": "phpunit --colors --filter"
+        "testOnly": "phpunit --colors --filter",
+        "phpstan": "@php phpstan"
     }
 }

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,12 +1,1157 @@
 parameters:
 	ignoreErrors:
 		-
+			message: "#^Method JsonSchema\\\\Constraints\\\\BaseConstraint\\:\\:addError\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/JsonSchema/Constraints/BaseConstraint.php
+
+		-
+			message: "#^Method JsonSchema\\\\Constraints\\\\BaseConstraint\\:\\:addError\\(\\) has parameter \\$more with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/JsonSchema/Constraints/BaseConstraint.php
+
+		-
+			message: "#^Method JsonSchema\\\\Constraints\\\\BaseConstraint\\:\\:addErrors\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/JsonSchema/Constraints/BaseConstraint.php
+
+		-
+			message: "#^Method JsonSchema\\\\Constraints\\\\BaseConstraint\\:\\:addErrors\\(\\) has parameter \\$errors with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/JsonSchema/Constraints/BaseConstraint.php
+
+		-
+			message: "#^Method JsonSchema\\\\Constraints\\\\BaseConstraint\\:\\:arrayToObjectRecursive\\(\\) has parameter \\$array with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/JsonSchema/Constraints/BaseConstraint.php
+
+		-
+			message: "#^Method JsonSchema\\\\Constraints\\\\BaseConstraint\\:\\:getErrors\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/JsonSchema/Constraints/BaseConstraint.php
+
+		-
+			message: "#^Method JsonSchema\\\\Constraints\\\\BaseConstraint\\:\\:getErrors\\(\\) has parameter \\$errorContext with no type specified\\.$#"
+			count: 1
+			path: src/JsonSchema/Constraints/BaseConstraint.php
+
+		-
+			message: "#^Method JsonSchema\\\\Constraints\\\\BaseConstraint\\:\\:isValid\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/JsonSchema/Constraints/BaseConstraint.php
+
+		-
+			message: "#^Method JsonSchema\\\\Constraints\\\\BaseConstraint\\:\\:numErrors\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/JsonSchema/Constraints/BaseConstraint.php
+
+		-
+			message: "#^Method JsonSchema\\\\Constraints\\\\BaseConstraint\\:\\:numErrors\\(\\) has parameter \\$errorContext with no type specified\\.$#"
+			count: 1
+			path: src/JsonSchema/Constraints/BaseConstraint.php
+
+		-
+			message: "#^Method JsonSchema\\\\Constraints\\\\BaseConstraint\\:\\:reset\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/JsonSchema/Constraints/BaseConstraint.php
+
+		-
+			message: "#^Parameter \\#1 \\$json of function json_decode expects string, string\\|false given\\.$#"
+			count: 1
+			path: src/JsonSchema/Constraints/BaseConstraint.php
+
+		-
+			message: "#^Property JsonSchema\\\\Constraints\\\\BaseConstraint\\:\\:\\$errors type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/JsonSchema/Constraints/BaseConstraint.php
+
+		-
+			message: "#^Ternary operator condition is always true\\.$#"
+			count: 2
+			path: src/JsonSchema/Constraints/BaseConstraint.php
+
+		-
+			message: "#^Cannot access property \\$additionalItems on stdClass\\|null\\.$#"
+			count: 3
+			path: src/JsonSchema/Constraints/CollectionConstraint.php
+
+		-
+			message: "#^Cannot access property \\$items on stdClass\\|null\\.$#"
+			count: 6
+			path: src/JsonSchema/Constraints/CollectionConstraint.php
+
+		-
+			message: "#^Method JsonSchema\\\\Constraints\\\\CollectionConstraint\\:\\:check\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/JsonSchema/Constraints/CollectionConstraint.php
+
+		-
+			message: "#^Method JsonSchema\\\\Constraints\\\\CollectionConstraint\\:\\:validateItems\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/JsonSchema/Constraints/CollectionConstraint.php
+
+		-
+			message: "#^Method JsonSchema\\\\Constraints\\\\CollectionConstraint\\:\\:validateItems\\(\\) has parameter \\$value with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/JsonSchema/Constraints/CollectionConstraint.php
+
+		-
+			message: "#^Parameter \\#1 \\$object_or_class of function property_exists expects object\\|string, stdClass\\|null given\\.$#"
+			count: 1
+			path: src/JsonSchema/Constraints/CollectionConstraint.php
+
+		-
+			message: "#^Parameter \\#2 \\$schema of method JsonSchema\\\\Constraints\\\\CollectionConstraint\\:\\:validateItems\\(\\) expects stdClass\\|null, object given\\.$#"
+			count: 1
+			path: src/JsonSchema/Constraints/CollectionConstraint.php
+
+		-
+			message: "#^Method JsonSchema\\\\Constraints\\\\ConstConstraint\\:\\:check\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/JsonSchema/Constraints/ConstConstraint.php
+
+		-
+			message: "#^Method JsonSchema\\\\Constraints\\\\Constraint\\:\\:checkArray\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/JsonSchema/Constraints/Constraint.php
+
+		-
+			message: "#^Method JsonSchema\\\\Constraints\\\\Constraint\\:\\:checkConst\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/JsonSchema/Constraints/Constraint.php
+
+		-
+			message: "#^Method JsonSchema\\\\Constraints\\\\Constraint\\:\\:checkEnum\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/JsonSchema/Constraints/Constraint.php
+
+		-
+			message: "#^Method JsonSchema\\\\Constraints\\\\Constraint\\:\\:checkFormat\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/JsonSchema/Constraints/Constraint.php
+
+		-
+			message: "#^Method JsonSchema\\\\Constraints\\\\Constraint\\:\\:checkNumber\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/JsonSchema/Constraints/Constraint.php
+
+		-
+			message: "#^Method JsonSchema\\\\Constraints\\\\Constraint\\:\\:checkObject\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/JsonSchema/Constraints/Constraint.php
+
+		-
+			message: "#^Method JsonSchema\\\\Constraints\\\\Constraint\\:\\:checkObject\\(\\) has parameter \\$appliedDefaults with no type specified\\.$#"
+			count: 1
+			path: src/JsonSchema/Constraints/Constraint.php
+
+		-
+			message: "#^Method JsonSchema\\\\Constraints\\\\Constraint\\:\\:checkString\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/JsonSchema/Constraints/Constraint.php
+
+		-
+			message: "#^Method JsonSchema\\\\Constraints\\\\Constraint\\:\\:checkType\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/JsonSchema/Constraints/Constraint.php
+
+		-
+			message: "#^Method JsonSchema\\\\Constraints\\\\Constraint\\:\\:checkUndefined\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/JsonSchema/Constraints/Constraint.php
+
+		-
+			message: "#^Method JsonSchema\\\\Constraints\\\\Constraint\\:\\:checkUndefined\\(\\) has parameter \\$fromDefault with no type specified\\.$#"
+			count: 1
+			path: src/JsonSchema/Constraints/Constraint.php
+
+		-
+			message: "#^Property JsonSchema\\\\Constraints\\\\Constraint\\:\\:\\$inlineSchemaProperty has no type specified\\.$#"
+			count: 1
+			path: src/JsonSchema/Constraints/Constraint.php
+
+		-
+			message: "#^Method JsonSchema\\\\Constraints\\\\ConstraintInterface\\:\\:addError\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/JsonSchema/Constraints/ConstraintInterface.php
+
+		-
+			message: "#^Method JsonSchema\\\\Constraints\\\\ConstraintInterface\\:\\:addError\\(\\) has parameter \\$more with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/JsonSchema/Constraints/ConstraintInterface.php
+
+		-
+			message: "#^Method JsonSchema\\\\Constraints\\\\ConstraintInterface\\:\\:addErrors\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/JsonSchema/Constraints/ConstraintInterface.php
+
+		-
+			message: "#^Method JsonSchema\\\\Constraints\\\\ConstraintInterface\\:\\:addErrors\\(\\) has parameter \\$errors with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/JsonSchema/Constraints/ConstraintInterface.php
+
+		-
+			message: "#^Method JsonSchema\\\\Constraints\\\\ConstraintInterface\\:\\:check\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/JsonSchema/Constraints/ConstraintInterface.php
+
+		-
+			message: "#^Method JsonSchema\\\\Constraints\\\\ConstraintInterface\\:\\:getErrors\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/JsonSchema/Constraints/ConstraintInterface.php
+
+		-
 			message: "#^PHPDoc tag @throws with type JsonSchema\\\\Exception\\\\ExceptionInterface is not subtype of Throwable$#"
 			count: 1
 			path: src/JsonSchema/Constraints/ConstraintInterface.php
 
 		-
+			message: "#^Method JsonSchema\\\\Constraints\\\\EnumConstraint\\:\\:check\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/JsonSchema/Constraints/EnumConstraint.php
+
+		-
+			message: "#^Method JsonSchema\\\\Constraints\\\\Factory\\:\\:addConfig\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/JsonSchema/Constraints/Factory.php
+
+		-
+			message: "#^Method JsonSchema\\\\Constraints\\\\Factory\\:\\:createInstanceFor\\(\\) should return JsonSchema\\\\Constraints\\\\BaseConstraint&JsonSchema\\\\Constraints\\\\ConstraintInterface but returns object\\.$#"
+			count: 1
+			path: src/JsonSchema/Constraints/Factory.php
+
+		-
+			message: "#^Method JsonSchema\\\\Constraints\\\\Factory\\:\\:getErrorContext\\(\\) should return 1\\|2 but returns int\\.$#"
+			count: 1
+			path: src/JsonSchema/Constraints/Factory.php
+
+		-
+			message: "#^Method JsonSchema\\\\Constraints\\\\Factory\\:\\:getSchemaStorage\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/JsonSchema/Constraints/Factory.php
+
+		-
+			message: "#^Method JsonSchema\\\\Constraints\\\\Factory\\:\\:getTypeCheck\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/JsonSchema/Constraints/Factory.php
+
+		-
+			message: "#^Method JsonSchema\\\\Constraints\\\\Factory\\:\\:removeConfig\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/JsonSchema/Constraints/Factory.php
+
+		-
+			message: "#^Method JsonSchema\\\\Constraints\\\\Factory\\:\\:setConfig\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/JsonSchema/Constraints/Factory.php
+
+		-
+			message: "#^Method JsonSchema\\\\Constraints\\\\Factory\\:\\:setErrorContext\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/JsonSchema/Constraints/Factory.php
+
+		-
+			message: "#^Property JsonSchema\\\\Constraints\\\\Factory\\:\\:\\$constraintMap type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/JsonSchema/Constraints/Factory.php
+
+		-
+			message: "#^Property JsonSchema\\\\Constraints\\\\Factory\\:\\:\\$instanceCache \\(array\\<JsonSchema\\\\Constraints\\\\ConstraintInterface\\>\\) does not accept array\\<object\\>\\.$#"
+			count: 1
+			path: src/JsonSchema/Constraints/Factory.php
+
+		-
+			message: "#^Property JsonSchema\\\\Constraints\\\\Factory\\:\\:\\$uriRetriever \\(JsonSchema\\\\Uri\\\\UriRetriever\\) does not accept JsonSchema\\\\UriRetrieverInterface\\.$#"
+			count: 1
+			path: src/JsonSchema/Constraints/Factory.php
+
+		-
+			message: "#^Method JsonSchema\\\\Constraints\\\\FormatConstraint\\:\\:check\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/JsonSchema/Constraints/FormatConstraint.php
+
+		-
+			message: "#^Method JsonSchema\\\\Constraints\\\\FormatConstraint\\:\\:validateColor\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/JsonSchema/Constraints/FormatConstraint.php
+
+		-
+			message: "#^Method JsonSchema\\\\Constraints\\\\FormatConstraint\\:\\:validateColor\\(\\) has parameter \\$color with no type specified\\.$#"
+			count: 1
+			path: src/JsonSchema/Constraints/FormatConstraint.php
+
+		-
+			message: "#^Method JsonSchema\\\\Constraints\\\\FormatConstraint\\:\\:validateDateTime\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/JsonSchema/Constraints/FormatConstraint.php
+
+		-
+			message: "#^Method JsonSchema\\\\Constraints\\\\FormatConstraint\\:\\:validateDateTime\\(\\) has parameter \\$datetime with no type specified\\.$#"
+			count: 1
+			path: src/JsonSchema/Constraints/FormatConstraint.php
+
+		-
+			message: "#^Method JsonSchema\\\\Constraints\\\\FormatConstraint\\:\\:validateDateTime\\(\\) has parameter \\$format with no type specified\\.$#"
+			count: 1
+			path: src/JsonSchema/Constraints/FormatConstraint.php
+
+		-
+			message: "#^Method JsonSchema\\\\Constraints\\\\FormatConstraint\\:\\:validateHostname\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/JsonSchema/Constraints/FormatConstraint.php
+
+		-
+			message: "#^Method JsonSchema\\\\Constraints\\\\FormatConstraint\\:\\:validateHostname\\(\\) has parameter \\$host with no type specified\\.$#"
+			count: 1
+			path: src/JsonSchema/Constraints/FormatConstraint.php
+
+		-
+			message: "#^Method JsonSchema\\\\Constraints\\\\FormatConstraint\\:\\:validatePhone\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/JsonSchema/Constraints/FormatConstraint.php
+
+		-
+			message: "#^Method JsonSchema\\\\Constraints\\\\FormatConstraint\\:\\:validatePhone\\(\\) has parameter \\$phone with no type specified\\.$#"
+			count: 1
+			path: src/JsonSchema/Constraints/FormatConstraint.php
+
+		-
+			message: "#^Method JsonSchema\\\\Constraints\\\\FormatConstraint\\:\\:validateRegex\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/JsonSchema/Constraints/FormatConstraint.php
+
+		-
+			message: "#^Method JsonSchema\\\\Constraints\\\\FormatConstraint\\:\\:validateRegex\\(\\) has parameter \\$regex with no type specified\\.$#"
+			count: 1
+			path: src/JsonSchema/Constraints/FormatConstraint.php
+
+		-
+			message: "#^Method JsonSchema\\\\Constraints\\\\FormatConstraint\\:\\:validateStyle\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/JsonSchema/Constraints/FormatConstraint.php
+
+		-
+			message: "#^Method JsonSchema\\\\Constraints\\\\FormatConstraint\\:\\:validateStyle\\(\\) has parameter \\$style with no type specified\\.$#"
+			count: 1
+			path: src/JsonSchema/Constraints/FormatConstraint.php
+
+		-
+			message: "#^Strict comparison using \\=\\=\\= between null and non\\-falsy\\-string\\|false will always evaluate to false\\.$#"
+			count: 1
+			path: src/JsonSchema/Constraints/FormatConstraint.php
+
+		-
+			message: "#^Method JsonSchema\\\\Constraints\\\\NumberConstraint\\:\\:check\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/JsonSchema/Constraints/NumberConstraint.php
+
+		-
+			message: "#^Method JsonSchema\\\\Constraints\\\\NumberConstraint\\:\\:fmod\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/JsonSchema/Constraints/NumberConstraint.php
+
+		-
+			message: "#^Method JsonSchema\\\\Constraints\\\\NumberConstraint\\:\\:fmod\\(\\) has parameter \\$number1 with no type specified\\.$#"
+			count: 1
+			path: src/JsonSchema/Constraints/NumberConstraint.php
+
+		-
+			message: "#^Method JsonSchema\\\\Constraints\\\\NumberConstraint\\:\\:fmod\\(\\) has parameter \\$number2 with no type specified\\.$#"
+			count: 1
+			path: src/JsonSchema/Constraints/NumberConstraint.php
+
+		-
+			message: "#^Argument of an invalid type stdClass supplied for foreach, only iterables are supported\\.$#"
+			count: 1
+			path: src/JsonSchema/Constraints/ObjectConstraint.php
+
+		-
+			message: "#^Argument of an invalid type stdClass\\|null supplied for foreach, only iterables are supported\\.$#"
+			count: 1
+			path: src/JsonSchema/Constraints/ObjectConstraint.php
+
+		-
+			message: "#^Method JsonSchema\\\\Constraints\\\\ObjectConstraint\\:\\:check\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/JsonSchema/Constraints/ObjectConstraint.php
+
+		-
+			message: "#^Method JsonSchema\\\\Constraints\\\\ObjectConstraint\\:\\:check\\(\\) has parameter \\$additionalProp with no type specified\\.$#"
+			count: 1
+			path: src/JsonSchema/Constraints/ObjectConstraint.php
+
+		-
+			message: "#^Method JsonSchema\\\\Constraints\\\\ObjectConstraint\\:\\:check\\(\\) has parameter \\$appliedDefaults with no type specified\\.$#"
+			count: 1
+			path: src/JsonSchema/Constraints/ObjectConstraint.php
+
+		-
+			message: "#^Method JsonSchema\\\\Constraints\\\\ObjectConstraint\\:\\:check\\(\\) has parameter \\$patternProperties with no type specified\\.$#"
+			count: 1
+			path: src/JsonSchema/Constraints/ObjectConstraint.php
+
+		-
+			message: "#^Method JsonSchema\\\\Constraints\\\\ObjectConstraint\\:\\:validateElement\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/JsonSchema/Constraints/ObjectConstraint.php
+
+		-
+			message: "#^Method JsonSchema\\\\Constraints\\\\ObjectConstraint\\:\\:validateElement\\(\\) has parameter \\$matches with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/JsonSchema/Constraints/ObjectConstraint.php
+
+		-
+			message: "#^Method JsonSchema\\\\Constraints\\\\ObjectConstraint\\:\\:validateMinMaxConstraint\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/JsonSchema/Constraints/ObjectConstraint.php
+
+		-
+			message: "#^Method JsonSchema\\\\Constraints\\\\ObjectConstraint\\:\\:validatePatternProperties\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/JsonSchema/Constraints/ObjectConstraint.php
+
+		-
+			message: "#^Method JsonSchema\\\\Constraints\\\\ObjectConstraint\\:\\:validatePatternProperties\\(\\) has parameter \\$element with no type specified\\.$#"
+			count: 1
+			path: src/JsonSchema/Constraints/ObjectConstraint.php
+
+		-
+			message: "#^Method JsonSchema\\\\Constraints\\\\ObjectConstraint\\:\\:validatePatternProperties\\(\\) has parameter \\$patternProperties with no type specified\\.$#"
+			count: 1
+			path: src/JsonSchema/Constraints/ObjectConstraint.php
+
+		-
+			message: "#^Method JsonSchema\\\\Constraints\\\\ObjectConstraint\\:\\:validateProperties\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/JsonSchema/Constraints/ObjectConstraint.php
+
+		-
+			message: "#^Parameter \\#2 \\$objectDefinition of method JsonSchema\\\\Constraints\\\\ObjectConstraint\\:\\:validateMinMaxConstraint\\(\\) expects stdClass, stdClass\\|null given\\.$#"
+			count: 1
+			path: src/JsonSchema/Constraints/ObjectConstraint.php
+
+		-
+			message: "#^Property JsonSchema\\\\Constraints\\\\ObjectConstraint\\:\\:\\$appliedDefaults type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/JsonSchema/Constraints/ObjectConstraint.php
+
+		-
+			message: "#^Method JsonSchema\\\\Constraints\\\\SchemaConstraint\\:\\:check\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/JsonSchema/Constraints/SchemaConstraint.php
+
+		-
+			message: "#^Method JsonSchema\\\\Constraints\\\\StringConstraint\\:\\:check\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/JsonSchema/Constraints/StringConstraint.php
+
+		-
+			message: "#^Method JsonSchema\\\\Constraints\\\\StringConstraint\\:\\:strlen\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/JsonSchema/Constraints/StringConstraint.php
+
+		-
+			message: "#^Method JsonSchema\\\\Constraints\\\\StringConstraint\\:\\:strlen\\(\\) has parameter \\$string with no type specified\\.$#"
+			count: 1
+			path: src/JsonSchema/Constraints/StringConstraint.php
+
+		-
+			message: "#^Parameter \\#2 \\$encoding of function mb_strlen expects string, string\\|false given\\.$#"
+			count: 1
+			path: src/JsonSchema/Constraints/StringConstraint.php
+
+		-
+			message: "#^Method JsonSchema\\\\Constraints\\\\TypeCheck\\\\LooseTypeCheck\\:\\:isArray\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/JsonSchema/Constraints/TypeCheck/LooseTypeCheck.php
+
+		-
+			message: "#^Method JsonSchema\\\\Constraints\\\\TypeCheck\\\\LooseTypeCheck\\:\\:isArray\\(\\) has parameter \\$value with no type specified\\.$#"
+			count: 1
+			path: src/JsonSchema/Constraints/TypeCheck/LooseTypeCheck.php
+
+		-
+			message: "#^Method JsonSchema\\\\Constraints\\\\TypeCheck\\\\LooseTypeCheck\\:\\:isAssociativeArray\\(\\) has parameter \\$arr with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/JsonSchema/Constraints/TypeCheck/LooseTypeCheck.php
+
+		-
+			message: "#^Method JsonSchema\\\\Constraints\\\\TypeCheck\\\\LooseTypeCheck\\:\\:isObject\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/JsonSchema/Constraints/TypeCheck/LooseTypeCheck.php
+
+		-
+			message: "#^Method JsonSchema\\\\Constraints\\\\TypeCheck\\\\LooseTypeCheck\\:\\:isObject\\(\\) has parameter \\$value with no type specified\\.$#"
+			count: 1
+			path: src/JsonSchema/Constraints/TypeCheck/LooseTypeCheck.php
+
+		-
+			message: "#^Method JsonSchema\\\\Constraints\\\\TypeCheck\\\\LooseTypeCheck\\:\\:propertyCount\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/JsonSchema/Constraints/TypeCheck/LooseTypeCheck.php
+
+		-
+			message: "#^Method JsonSchema\\\\Constraints\\\\TypeCheck\\\\LooseTypeCheck\\:\\:propertyCount\\(\\) has parameter \\$value with no type specified\\.$#"
+			count: 1
+			path: src/JsonSchema/Constraints/TypeCheck/LooseTypeCheck.php
+
+		-
+			message: "#^Method JsonSchema\\\\Constraints\\\\TypeCheck\\\\LooseTypeCheck\\:\\:propertyExists\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/JsonSchema/Constraints/TypeCheck/LooseTypeCheck.php
+
+		-
+			message: "#^Method JsonSchema\\\\Constraints\\\\TypeCheck\\\\LooseTypeCheck\\:\\:propertyExists\\(\\) has parameter \\$property with no type specified\\.$#"
+			count: 1
+			path: src/JsonSchema/Constraints/TypeCheck/LooseTypeCheck.php
+
+		-
+			message: "#^Method JsonSchema\\\\Constraints\\\\TypeCheck\\\\LooseTypeCheck\\:\\:propertyExists\\(\\) has parameter \\$value with no type specified\\.$#"
+			count: 1
+			path: src/JsonSchema/Constraints/TypeCheck/LooseTypeCheck.php
+
+		-
+			message: "#^Method JsonSchema\\\\Constraints\\\\TypeCheck\\\\LooseTypeCheck\\:\\:propertyGet\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/JsonSchema/Constraints/TypeCheck/LooseTypeCheck.php
+
+		-
+			message: "#^Method JsonSchema\\\\Constraints\\\\TypeCheck\\\\LooseTypeCheck\\:\\:propertyGet\\(\\) has parameter \\$property with no type specified\\.$#"
+			count: 1
+			path: src/JsonSchema/Constraints/TypeCheck/LooseTypeCheck.php
+
+		-
+			message: "#^Method JsonSchema\\\\Constraints\\\\TypeCheck\\\\LooseTypeCheck\\:\\:propertyGet\\(\\) has parameter \\$value with no type specified\\.$#"
+			count: 1
+			path: src/JsonSchema/Constraints/TypeCheck/LooseTypeCheck.php
+
+		-
+			message: "#^Method JsonSchema\\\\Constraints\\\\TypeCheck\\\\LooseTypeCheck\\:\\:propertySet\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/JsonSchema/Constraints/TypeCheck/LooseTypeCheck.php
+
+		-
+			message: "#^Method JsonSchema\\\\Constraints\\\\TypeCheck\\\\LooseTypeCheck\\:\\:propertySet\\(\\) has parameter \\$data with no type specified\\.$#"
+			count: 1
+			path: src/JsonSchema/Constraints/TypeCheck/LooseTypeCheck.php
+
+		-
+			message: "#^Method JsonSchema\\\\Constraints\\\\TypeCheck\\\\LooseTypeCheck\\:\\:propertySet\\(\\) has parameter \\$property with no type specified\\.$#"
+			count: 1
+			path: src/JsonSchema/Constraints/TypeCheck/LooseTypeCheck.php
+
+		-
+			message: "#^Method JsonSchema\\\\Constraints\\\\TypeCheck\\\\LooseTypeCheck\\:\\:propertySet\\(\\) has parameter \\$value with no type specified\\.$#"
+			count: 1
+			path: src/JsonSchema/Constraints/TypeCheck/LooseTypeCheck.php
+
+		-
+			message: "#^Method JsonSchema\\\\Constraints\\\\TypeCheck\\\\StrictTypeCheck\\:\\:isArray\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/JsonSchema/Constraints/TypeCheck/StrictTypeCheck.php
+
+		-
+			message: "#^Method JsonSchema\\\\Constraints\\\\TypeCheck\\\\StrictTypeCheck\\:\\:isArray\\(\\) has parameter \\$value with no type specified\\.$#"
+			count: 1
+			path: src/JsonSchema/Constraints/TypeCheck/StrictTypeCheck.php
+
+		-
+			message: "#^Method JsonSchema\\\\Constraints\\\\TypeCheck\\\\StrictTypeCheck\\:\\:isObject\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/JsonSchema/Constraints/TypeCheck/StrictTypeCheck.php
+
+		-
+			message: "#^Method JsonSchema\\\\Constraints\\\\TypeCheck\\\\StrictTypeCheck\\:\\:isObject\\(\\) has parameter \\$value with no type specified\\.$#"
+			count: 1
+			path: src/JsonSchema/Constraints/TypeCheck/StrictTypeCheck.php
+
+		-
+			message: "#^Method JsonSchema\\\\Constraints\\\\TypeCheck\\\\StrictTypeCheck\\:\\:propertyCount\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/JsonSchema/Constraints/TypeCheck/StrictTypeCheck.php
+
+		-
+			message: "#^Method JsonSchema\\\\Constraints\\\\TypeCheck\\\\StrictTypeCheck\\:\\:propertyCount\\(\\) has parameter \\$value with no type specified\\.$#"
+			count: 1
+			path: src/JsonSchema/Constraints/TypeCheck/StrictTypeCheck.php
+
+		-
+			message: "#^Method JsonSchema\\\\Constraints\\\\TypeCheck\\\\StrictTypeCheck\\:\\:propertyExists\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/JsonSchema/Constraints/TypeCheck/StrictTypeCheck.php
+
+		-
+			message: "#^Method JsonSchema\\\\Constraints\\\\TypeCheck\\\\StrictTypeCheck\\:\\:propertyExists\\(\\) has parameter \\$property with no type specified\\.$#"
+			count: 1
+			path: src/JsonSchema/Constraints/TypeCheck/StrictTypeCheck.php
+
+		-
+			message: "#^Method JsonSchema\\\\Constraints\\\\TypeCheck\\\\StrictTypeCheck\\:\\:propertyExists\\(\\) has parameter \\$value with no type specified\\.$#"
+			count: 1
+			path: src/JsonSchema/Constraints/TypeCheck/StrictTypeCheck.php
+
+		-
+			message: "#^Method JsonSchema\\\\Constraints\\\\TypeCheck\\\\StrictTypeCheck\\:\\:propertyGet\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/JsonSchema/Constraints/TypeCheck/StrictTypeCheck.php
+
+		-
+			message: "#^Method JsonSchema\\\\Constraints\\\\TypeCheck\\\\StrictTypeCheck\\:\\:propertyGet\\(\\) has parameter \\$property with no type specified\\.$#"
+			count: 1
+			path: src/JsonSchema/Constraints/TypeCheck/StrictTypeCheck.php
+
+		-
+			message: "#^Method JsonSchema\\\\Constraints\\\\TypeCheck\\\\StrictTypeCheck\\:\\:propertyGet\\(\\) has parameter \\$value with no type specified\\.$#"
+			count: 1
+			path: src/JsonSchema/Constraints/TypeCheck/StrictTypeCheck.php
+
+		-
+			message: "#^Method JsonSchema\\\\Constraints\\\\TypeCheck\\\\StrictTypeCheck\\:\\:propertySet\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/JsonSchema/Constraints/TypeCheck/StrictTypeCheck.php
+
+		-
+			message: "#^Method JsonSchema\\\\Constraints\\\\TypeCheck\\\\StrictTypeCheck\\:\\:propertySet\\(\\) has parameter \\$data with no type specified\\.$#"
+			count: 1
+			path: src/JsonSchema/Constraints/TypeCheck/StrictTypeCheck.php
+
+		-
+			message: "#^Method JsonSchema\\\\Constraints\\\\TypeCheck\\\\StrictTypeCheck\\:\\:propertySet\\(\\) has parameter \\$property with no type specified\\.$#"
+			count: 1
+			path: src/JsonSchema/Constraints/TypeCheck/StrictTypeCheck.php
+
+		-
+			message: "#^Method JsonSchema\\\\Constraints\\\\TypeCheck\\\\StrictTypeCheck\\:\\:propertySet\\(\\) has parameter \\$value with no type specified\\.$#"
+			count: 1
+			path: src/JsonSchema/Constraints/TypeCheck/StrictTypeCheck.php
+
+		-
+			message: "#^Method JsonSchema\\\\Constraints\\\\TypeCheck\\\\TypeCheckInterface\\:\\:isArray\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/JsonSchema/Constraints/TypeCheck/TypeCheckInterface.php
+
+		-
+			message: "#^Method JsonSchema\\\\Constraints\\\\TypeCheck\\\\TypeCheckInterface\\:\\:isArray\\(\\) has parameter \\$value with no type specified\\.$#"
+			count: 1
+			path: src/JsonSchema/Constraints/TypeCheck/TypeCheckInterface.php
+
+		-
+			message: "#^Method JsonSchema\\\\Constraints\\\\TypeCheck\\\\TypeCheckInterface\\:\\:isObject\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/JsonSchema/Constraints/TypeCheck/TypeCheckInterface.php
+
+		-
+			message: "#^Method JsonSchema\\\\Constraints\\\\TypeCheck\\\\TypeCheckInterface\\:\\:isObject\\(\\) has parameter \\$value with no type specified\\.$#"
+			count: 1
+			path: src/JsonSchema/Constraints/TypeCheck/TypeCheckInterface.php
+
+		-
+			message: "#^Method JsonSchema\\\\Constraints\\\\TypeCheck\\\\TypeCheckInterface\\:\\:propertyCount\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/JsonSchema/Constraints/TypeCheck/TypeCheckInterface.php
+
+		-
+			message: "#^Method JsonSchema\\\\Constraints\\\\TypeCheck\\\\TypeCheckInterface\\:\\:propertyCount\\(\\) has parameter \\$value with no type specified\\.$#"
+			count: 1
+			path: src/JsonSchema/Constraints/TypeCheck/TypeCheckInterface.php
+
+		-
+			message: "#^Method JsonSchema\\\\Constraints\\\\TypeCheck\\\\TypeCheckInterface\\:\\:propertyExists\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/JsonSchema/Constraints/TypeCheck/TypeCheckInterface.php
+
+		-
+			message: "#^Method JsonSchema\\\\Constraints\\\\TypeCheck\\\\TypeCheckInterface\\:\\:propertyExists\\(\\) has parameter \\$property with no type specified\\.$#"
+			count: 1
+			path: src/JsonSchema/Constraints/TypeCheck/TypeCheckInterface.php
+
+		-
+			message: "#^Method JsonSchema\\\\Constraints\\\\TypeCheck\\\\TypeCheckInterface\\:\\:propertyExists\\(\\) has parameter \\$value with no type specified\\.$#"
+			count: 1
+			path: src/JsonSchema/Constraints/TypeCheck/TypeCheckInterface.php
+
+		-
+			message: "#^Method JsonSchema\\\\Constraints\\\\TypeCheck\\\\TypeCheckInterface\\:\\:propertyGet\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/JsonSchema/Constraints/TypeCheck/TypeCheckInterface.php
+
+		-
+			message: "#^Method JsonSchema\\\\Constraints\\\\TypeCheck\\\\TypeCheckInterface\\:\\:propertyGet\\(\\) has parameter \\$property with no type specified\\.$#"
+			count: 1
+			path: src/JsonSchema/Constraints/TypeCheck/TypeCheckInterface.php
+
+		-
+			message: "#^Method JsonSchema\\\\Constraints\\\\TypeCheck\\\\TypeCheckInterface\\:\\:propertyGet\\(\\) has parameter \\$value with no type specified\\.$#"
+			count: 1
+			path: src/JsonSchema/Constraints/TypeCheck/TypeCheckInterface.php
+
+		-
+			message: "#^Method JsonSchema\\\\Constraints\\\\TypeCheck\\\\TypeCheckInterface\\:\\:propertySet\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/JsonSchema/Constraints/TypeCheck/TypeCheckInterface.php
+
+		-
+			message: "#^Method JsonSchema\\\\Constraints\\\\TypeCheck\\\\TypeCheckInterface\\:\\:propertySet\\(\\) has parameter \\$data with no type specified\\.$#"
+			count: 1
+			path: src/JsonSchema/Constraints/TypeCheck/TypeCheckInterface.php
+
+		-
+			message: "#^Method JsonSchema\\\\Constraints\\\\TypeCheck\\\\TypeCheckInterface\\:\\:propertySet\\(\\) has parameter \\$property with no type specified\\.$#"
+			count: 1
+			path: src/JsonSchema/Constraints/TypeCheck/TypeCheckInterface.php
+
+		-
+			message: "#^Method JsonSchema\\\\Constraints\\\\TypeCheck\\\\TypeCheckInterface\\:\\:propertySet\\(\\) has parameter \\$value with no type specified\\.$#"
+			count: 1
+			path: src/JsonSchema/Constraints/TypeCheck/TypeCheckInterface.php
+
+		-
+			message: "#^Method JsonSchema\\\\Constraints\\\\TypeConstraint\\:\\:check\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/JsonSchema/Constraints/TypeConstraint.php
+
+		-
+			message: "#^Method JsonSchema\\\\Constraints\\\\TypeConstraint\\:\\:implodeWith\\(\\) has parameter \\$elements with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/JsonSchema/Constraints/TypeConstraint.php
+
+		-
+			message: "#^Method JsonSchema\\\\Constraints\\\\TypeConstraint\\:\\:validateType\\(\\) has parameter \\$coerce with no type specified\\.$#"
+			count: 1
+			path: src/JsonSchema/Constraints/TypeConstraint.php
+
+		-
+			message: "#^Method JsonSchema\\\\Constraints\\\\TypeConstraint\\:\\:validateTypeNameWording\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/JsonSchema/Constraints/TypeConstraint.php
+
+		-
+			message: "#^Method JsonSchema\\\\Constraints\\\\TypeConstraint\\:\\:validateTypesArray\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/JsonSchema/Constraints/TypeConstraint.php
+
+		-
+			message: "#^Method JsonSchema\\\\Constraints\\\\TypeConstraint\\:\\:validateTypesArray\\(\\) has parameter \\$type with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/JsonSchema/Constraints/TypeConstraint.php
+
+		-
+			message: "#^Method JsonSchema\\\\Constraints\\\\TypeConstraint\\:\\:validateTypesArray\\(\\) has parameter \\$validTypesWording with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/JsonSchema/Constraints/TypeConstraint.php
+
+		-
+			message: "#^Negated boolean expression is always true\\.$#"
+			count: 2
+			path: src/JsonSchema/Constraints/TypeConstraint.php
+
+		-
+			message: "#^Parameter \\#3 \\$listEnd of method JsonSchema\\\\Constraints\\\\TypeConstraint\\:\\:implodeWith\\(\\) expects bool, string given\\.$#"
+			count: 1
+			path: src/JsonSchema/Constraints/TypeConstraint.php
+
+		-
+			message: "#^Static property JsonSchema\\\\Constraints\\\\TypeConstraint\\:\\:\\$wording \\(array\\<string\\>\\) does not accept default value of type array\\<int\\|string, string\\|null\\>\\.$#"
+			count: 1
+			path: src/JsonSchema/Constraints/TypeConstraint.php
+
+		-
+			message: "#^Method JsonSchema\\\\Constraints\\\\UndefinedConstraint\\:\\:applyDefaultValues\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/JsonSchema/Constraints/UndefinedConstraint.php
+
+		-
+			message: "#^Method JsonSchema\\\\Constraints\\\\UndefinedConstraint\\:\\:check\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/JsonSchema/Constraints/UndefinedConstraint.php
+
+		-
+			message: "#^Method JsonSchema\\\\Constraints\\\\UndefinedConstraint\\:\\:check\\(\\) has parameter \\$fromDefault with no type specified\\.$#"
+			count: 1
+			path: src/JsonSchema/Constraints/UndefinedConstraint.php
+
+		-
+			message: "#^Method JsonSchema\\\\Constraints\\\\UndefinedConstraint\\:\\:shouldApplyDefaultValue\\(\\) has parameter \\$name with no type specified\\.$#"
+			count: 1
+			path: src/JsonSchema/Constraints/UndefinedConstraint.php
+
+		-
+			message: "#^Method JsonSchema\\\\Constraints\\\\UndefinedConstraint\\:\\:validateCommonProperties\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/JsonSchema/Constraints/UndefinedConstraint.php
+
+		-
+			message: "#^Method JsonSchema\\\\Constraints\\\\UndefinedConstraint\\:\\:validateDependencies\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/JsonSchema/Constraints/UndefinedConstraint.php
+
+		-
+			message: "#^Method JsonSchema\\\\Constraints\\\\UndefinedConstraint\\:\\:validateOfProperties\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/JsonSchema/Constraints/UndefinedConstraint.php
+
+		-
+			message: "#^Method JsonSchema\\\\Constraints\\\\UndefinedConstraint\\:\\:validateTypes\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/JsonSchema/Constraints/UndefinedConstraint.php
+
+		-
+			message: "#^Method JsonSchema\\\\Constraints\\\\UndefinedConstraint\\:\\:validateUri\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/JsonSchema/Constraints/UndefinedConstraint.php
+
+		-
+			message: "#^Method JsonSchema\\\\Constraints\\\\UndefinedConstraint\\:\\:validateUri\\(\\) has parameter \\$schema with no type specified\\.$#"
+			count: 1
+			path: src/JsonSchema/Constraints/UndefinedConstraint.php
+
+		-
+			message: "#^Method JsonSchema\\\\Constraints\\\\UndefinedConstraint\\:\\:validateUri\\(\\) has parameter \\$schemaUri with no type specified\\.$#"
+			count: 1
+			path: src/JsonSchema/Constraints/UndefinedConstraint.php
+
+		-
+			message: "#^Parameter \\#1 \\$requiredOnly of method JsonSchema\\\\Constraints\\\\UndefinedConstraint\\:\\:shouldApplyDefaultValue\\(\\) expects bool, int given\\.$#"
+			count: 3
+			path: src/JsonSchema/Constraints/UndefinedConstraint.php
+
+		-
+			message: "#^Property JsonSchema\\\\Constraints\\\\UndefinedConstraint\\:\\:\\$appliedDefaults type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/JsonSchema/Constraints/UndefinedConstraint.php
+
+		-
+			message: "#^Method JsonSchema\\\\Entity\\\\JsonPointer\\:\\:encodePropertyPaths\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/JsonSchema/Entity/JsonPointer.php
+
+		-
+			message: "#^Method JsonSchema\\\\Entity\\\\JsonPointer\\:\\:setFromDefault\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/JsonSchema/Entity/JsonPointer.php
+
+		-
+			message: "#^Method JsonSchema\\\\Entity\\\\JsonPointer\\:\\:withPropertyPaths\\(\\) has parameter \\$propertyPaths with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/JsonSchema/Entity/JsonPointer.php
+
+		-
+			message: "#^Method JsonSchema\\\\Exception\\\\JsonDecodingException\\:\\:__construct\\(\\) has parameter \\$code with no type specified\\.$#"
+			count: 1
+			path: src/JsonSchema/Exception/JsonDecodingException.php
+
+		-
+			message: "#^Class JsonSchema\\\\Iterator\\\\ObjectIterator implements generic interface Iterator but does not specify its types\\: TKey, TValue$#"
+			count: 1
+			path: src/JsonSchema/Iterator/ObjectIterator.php
+
+		-
+			message: "#^Method JsonSchema\\\\Iterator\\\\ObjectIterator\\:\\:buildDataFromObject\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/JsonSchema/Iterator/ObjectIterator.php
+
+		-
+			message: "#^Method JsonSchema\\\\Iterator\\\\ObjectIterator\\:\\:getDataFromItem\\(\\) has parameter \\$item with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/JsonSchema/Iterator/ObjectIterator.php
+
+		-
+			message: "#^Method JsonSchema\\\\Iterator\\\\ObjectIterator\\:\\:getDataFromItem\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/JsonSchema/Iterator/ObjectIterator.php
+
+		-
+			message: "#^Method JsonSchema\\\\Iterator\\\\ObjectIterator\\:\\:initialize\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/JsonSchema/Iterator/ObjectIterator.php
+
+		-
+			message: "#^Property JsonSchema\\\\Iterator\\\\ObjectIterator\\:\\:\\$data type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/JsonSchema/Iterator/ObjectIterator.php
+
+		-
+			message: "#^Result of && is always false\\.$#"
+			count: 1
+			path: src/JsonSchema/Iterator/ObjectIterator.php
+
+		-
+			message: "#^Offset 4 does not exist on array\\{0\\: string, 1\\: non\\-falsy\\-string, 2\\: string, 3\\: non\\-falsy\\-string, 4\\?\\: string, 5\\?\\: non\\-falsy\\-string&numeric\\-string\\}\\.$#"
+			count: 1
+			path: src/JsonSchema/Rfc3339.php
+
+		-
+			message: "#^Offset 5 does not exist on array\\{0\\: string, 1\\: non\\-falsy\\-string, 2\\: string, 3\\: non\\-falsy\\-string, 4\\?\\: string, 5\\?\\: non\\-falsy\\-string&numeric\\-string\\}\\.$#"
+			count: 1
+			path: src/JsonSchema/Rfc3339.php
+
+		-
 			message: "#^Access to an undefined property object\\:\\:\\$properties\\.$#"
 			count: 3
 			path: src/JsonSchema/SchemaStorage.php
+
+		-
+			message: "#^Argument of an invalid type object supplied for foreach, only iterables are supported\\.$#"
+			count: 1
+			path: src/JsonSchema/SchemaStorage.php
+
+		-
+			message: "#^Call to function is_array\\(\\) with object will always evaluate to false\\.$#"
+			count: 1
+			path: src/JsonSchema/SchemaStorage.php
+
+		-
+			message: "#^Method JsonSchema\\\\SchemaStorage\\:\\:addSchema\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/JsonSchema/SchemaStorage.php
+
+		-
+			message: "#^Method JsonSchema\\\\SchemaStorage\\:\\:expandRefs\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/JsonSchema/SchemaStorage.php
+
+		-
+			message: "#^Method JsonSchema\\\\SchemaStorage\\:\\:resolveRef\\(\\) has parameter \\$resolveStack with no type specified\\.$#"
+			count: 1
+			path: src/JsonSchema/SchemaStorage.php
+
+		-
+			message: "#^Method JsonSchema\\\\SchemaStorage\\:\\:resolveRefSchema\\(\\) has parameter \\$resolveStack with no type specified\\.$#"
+			count: 1
+			path: src/JsonSchema/SchemaStorage.php
+
+		-
+			message: "#^Property JsonSchema\\\\SchemaStorage\\:\\:\\$schemas has no type specified\\.$#"
+			count: 1
+			path: src/JsonSchema/SchemaStorage.php
+
+		-
+			message: "#^Property JsonSchema\\\\SchemaStorage\\:\\:\\$uriResolver has no type specified\\.$#"
+			count: 1
+			path: src/JsonSchema/SchemaStorage.php
+
+		-
+			message: "#^Property JsonSchema\\\\SchemaStorage\\:\\:\\$uriRetriever has no type specified\\.$#"
+			count: 1
+			path: src/JsonSchema/SchemaStorage.php
+
+		-
+			message: "#^Result of && is always false\\.$#"
+			count: 1
+			path: src/JsonSchema/SchemaStorage.php
+
+		-
+			message: "#^Method JsonSchema\\\\SchemaStorageInterface\\:\\:addSchema\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/JsonSchema/SchemaStorageInterface.php
+
+		-
+			message: "#^Method JsonSchema\\\\Uri\\\\Retrievers\\\\Curl\\:\\:fetchMessageBody\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/JsonSchema/Uri/Retrievers/Curl.php
+
+		-
+			message: "#^Offset 1 does not exist on array\\{0\\?\\: string, 1\\?\\: string\\}\\.$#"
+			count: 2
+			path: src/JsonSchema/Uri/Retrievers/Curl.php
+
+		-
+			message: "#^Parameter \\#1 \\$response of method JsonSchema\\\\Uri\\\\Retrievers\\\\Curl\\:\\:fetchContentType\\(\\) expects string, string\\|true given\\.$#"
+			count: 1
+			path: src/JsonSchema/Uri/Retrievers/Curl.php
+
+		-
+			message: "#^Parameter \\#1 \\$response of method JsonSchema\\\\Uri\\\\Retrievers\\\\Curl\\:\\:fetchMessageBody\\(\\) expects string, string\\|true given\\.$#"
+			count: 1
+			path: src/JsonSchema/Uri/Retrievers/Curl.php
+
+		-
+			message: "#^Property JsonSchema\\\\Uri\\\\Retrievers\\\\Curl\\:\\:\\$messageBody has no type specified\\.$#"
+			count: 1
+			path: src/JsonSchema/Uri/Retrievers/Curl.php
+
+		-
+			message: "#^Method JsonSchema\\\\Uri\\\\Retrievers\\\\FileGetContents\\:\\:fetchContentType\\(\\) has parameter \\$headers with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/JsonSchema/Uri/Retrievers/FileGetContents.php
+
+		-
+			message: "#^Offset 1 does not exist on array\\{0\\?\\: string, 1\\?\\: string\\}\\.$#"
+			count: 1
+			path: src/JsonSchema/Uri/Retrievers/FileGetContents.php
+
+		-
+			message: "#^Parameter \\#1 \\$callback of function set_error_handler expects \\(callable\\(int, string, string, int, array\\)\\: bool\\)\\|null, Closure\\(mixed, mixed\\)\\: void given\\.$#"
+			count: 1
+			path: src/JsonSchema/Uri/Retrievers/FileGetContents.php
+
+		-
+			message: "#^Property JsonSchema\\\\Uri\\\\Retrievers\\\\AbstractRetriever\\:\\:\\$contentType \\(string\\) does not accept null\\.$#"
+			count: 1
+			path: src/JsonSchema/Uri/Retrievers/FileGetContents.php
+
+		-
+			message: "#^Property JsonSchema\\\\Uri\\\\Retrievers\\\\AbstractRetriever\\:\\:\\$contentType \\(string\\) does not accept string\\|null\\.$#"
+			count: 1
+			path: src/JsonSchema/Uri/Retrievers/FileGetContents.php
+
+		-
+			message: "#^Property JsonSchema\\\\Uri\\\\Retrievers\\\\FileGetContents\\:\\:\\$messageBody has no type specified\\.$#"
+			count: 1
+			path: src/JsonSchema/Uri/Retrievers/FileGetContents.php
+
+		-
+			message: "#^Method JsonSchema\\\\Uri\\\\Retrievers\\\\PredefinedArray\\:\\:__construct\\(\\) has parameter \\$schemas with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/JsonSchema/Uri/Retrievers/PredefinedArray.php
+
+		-
+			message: "#^Property JsonSchema\\\\Uri\\\\Retrievers\\\\PredefinedArray\\:\\:\\$schemas type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/JsonSchema/Uri/Retrievers/PredefinedArray.php
+
+		-
+			message: "#^Method JsonSchema\\\\Uri\\\\UriResolver\\:\\:generate\\(\\) has parameter \\$components with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/JsonSchema/Uri/UriResolver.php
+
+		-
+			message: "#^Method JsonSchema\\\\Uri\\\\UriResolver\\:\\:normalizePath\\(\\) should return string but returns string\\|null\\.$#"
+			count: 1
+			path: src/JsonSchema/Uri/UriResolver.php
+
+		-
+			message: "#^Method JsonSchema\\\\Uri\\\\UriResolver\\:\\:parse\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/JsonSchema/Uri/UriResolver.php
+
+		-
+			message: "#^Method JsonSchema\\\\Uri\\\\UriResolver\\:\\:resolve\\(\\) should return string but returns string\\|null\\.$#"
+			count: 1
+			path: src/JsonSchema/Uri/UriResolver.php
+
+		-
+			message: "#^Offset 0 does not exist on array\\{0\\?\\: string, 1\\?\\: non\\-falsy\\-string\\}\\.$#"
+			count: 1
+			path: src/JsonSchema/Uri/UriResolver.php
+
+		-
+			message: "#^Parameter \\#1 \\$uri of method JsonSchema\\\\Uri\\\\UriResolver\\:\\:parse\\(\\) expects string, string\\|null given\\.$#"
+			count: 1
+			path: src/JsonSchema/Uri/UriResolver.php
+
+		-
+			message: "#^Parameter \\#3 \\$length of function array_slice expects int\\|null, float\\|int\\<1, max\\> given\\.$#"
+			count: 1
+			path: src/JsonSchema/Uri/UriResolver.php
+
+		-
+			message: "#^Parameter \\#3 \\$subject of function preg_replace expects array\\|string, string\\|null given\\.$#"
+			count: 1
+			path: src/JsonSchema/Uri/UriResolver.php
+
+		-
+			message: "#^Call to function is_null\\(\\) with string will always evaluate to false\\.$#"
+			count: 2
+			path: src/JsonSchema/Uri/UriRetriever.php
+
+		-
+			message: "#^Cannot call method retrieve\\(\\) on JsonSchema\\\\Uri\\\\Retrievers\\\\UriRetrieverInterface\\|null\\.$#"
+			count: 1
+			path: src/JsonSchema/Uri/UriRetriever.php
+
+		-
+			message: "#^Method JsonSchema\\\\Uri\\\\UriRetriever\\:\\:addInvalidContentTypeEndpoint\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/JsonSchema/Uri/UriRetriever.php
+
+		-
+			message: "#^Method JsonSchema\\\\Uri\\\\UriRetriever\\:\\:generate\\(\\) has parameter \\$components with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/JsonSchema/Uri/UriRetriever.php
+
+		-
+			message: "#^Method JsonSchema\\\\Uri\\\\UriRetriever\\:\\:getUriRetriever\\(\\) should return JsonSchema\\\\Uri\\\\Retrievers\\\\UriRetrieverInterface but returns JsonSchema\\\\Uri\\\\Retrievers\\\\UriRetrieverInterface\\|null\\.$#"
+			count: 1
+			path: src/JsonSchema/Uri/UriRetriever.php
+
+		-
+			message: "#^Method JsonSchema\\\\Uri\\\\UriRetriever\\:\\:parse\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/JsonSchema/Uri/UriRetriever.php
+
+		-
+			message: "#^Method JsonSchema\\\\Uri\\\\UriRetriever\\:\\:retrieve\\(\\) has parameter \\$translate with no type specified\\.$#"
+			count: 1
+			path: src/JsonSchema/Uri/UriRetriever.php
+
+		-
+			message: "#^Method JsonSchema\\\\Uri\\\\UriRetriever\\:\\:setTranslation\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/JsonSchema/Uri/UriRetriever.php
+
+		-
+			message: "#^Method JsonSchema\\\\Uri\\\\UriRetriever\\:\\:setTranslation\\(\\) has parameter \\$from with no type specified\\.$#"
+			count: 1
+			path: src/JsonSchema/Uri/UriRetriever.php
+
+		-
+			message: "#^Method JsonSchema\\\\Uri\\\\UriRetriever\\:\\:setTranslation\\(\\) has parameter \\$to with no type specified\\.$#"
+			count: 1
+			path: src/JsonSchema/Uri/UriRetriever.php
+
+		-
+			message: "#^Method JsonSchema\\\\Uri\\\\UriRetriever\\:\\:translate\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/JsonSchema/Uri/UriRetriever.php
+
+		-
+			message: "#^Method JsonSchema\\\\Uri\\\\UriRetriever\\:\\:translate\\(\\) has parameter \\$uri with no type specified\\.$#"
+			count: 1
+			path: src/JsonSchema/Uri/UriRetriever.php
+
+		-
+			message: "#^Parameter \\#1 \\$uri of method JsonSchema\\\\Uri\\\\UriRetriever\\:\\:parse\\(\\) expects string, string\\|null given\\.$#"
+			count: 1
+			path: src/JsonSchema/Uri/UriRetriever.php
+
+		-
+			message: "#^Property JsonSchema\\\\Uri\\\\UriRetriever\\:\\:\\$allowedInvalidContentTypeEndpoints type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/JsonSchema/Uri/UriRetriever.php
+
+		-
+			message: "#^Property JsonSchema\\\\Uri\\\\UriRetriever\\:\\:\\$translationMap type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/JsonSchema/Uri/UriRetriever.php
+
+		-
+			message: "#^Method JsonSchema\\\\Validator\\:\\:check\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/JsonSchema/Validator.php
+
+		-
+			message: "#^Method JsonSchema\\\\Validator\\:\\:check\\(\\) has parameter \\$schema with no type specified\\.$#"
+			count: 1
+			path: src/JsonSchema/Validator.php
+
+		-
+			message: "#^Method JsonSchema\\\\Validator\\:\\:check\\(\\) has parameter \\$value with no type specified\\.$#"
+			count: 1
+			path: src/JsonSchema/Validator.php
+
+		-
+			message: "#^Method JsonSchema\\\\Validator\\:\\:coerce\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/JsonSchema/Validator.php
+
+		-
+			message: "#^Method JsonSchema\\\\Validator\\:\\:coerce\\(\\) has parameter \\$schema with no type specified\\.$#"
+			count: 1
+			path: src/JsonSchema/Validator.php
+
+		-
+			message: "#^Method JsonSchema\\\\Validator\\:\\:coerce\\(\\) has parameter \\$value with no type specified\\.$#"
+			count: 1
+			path: src/JsonSchema/Validator.php
 

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,5 +1,5 @@
 parameters:
-    level: 2
+    level: 8
     paths:
         - ./src/
     ignoreErrors: []

--- a/src/JsonSchema/ConstraintError.php
+++ b/src/JsonSchema/ConstraintError.php
@@ -52,6 +52,9 @@ class ConstraintError extends Enum
     const TYPE = 'type';
     const UNIQUE_ITEMS = 'uniqueItems';
 
+    /**
+     * @return string
+     */
     public function getMessage()
     {
         $name = $this->getValue();

--- a/src/JsonSchema/Validator.php
+++ b/src/JsonSchema/Validator.php
@@ -35,6 +35,14 @@ class Validator extends BaseConstraint
      * The validation works as defined by the schema proposal in http://json-schema.org.
      *
      * Note that the first argument is passed by reference, so you must pass in a variable.
+     *
+     * @param mixed $value
+     * @param mixed $schema
+     * @param int   $checkMode
+     *
+     * @return int
+     *
+     * @phpstan-param Constraint::CHECK_MODE_* $checkMode
      */
     public function validate(&$value, $schema = null, $checkMode = null)
     {


### PR DESCRIPTION
Closes #661 - this implements it in a different way, instead of a sub-directory with the phpstan binary we just require phpstan in the CI, so it runs there, but can't easily be run locally (well you have to `composer require phpstan/phpstan marc-mabe/php-enum-phpstan --dev && git checkout composer.json` then you can call `vendor/bin/phpstan` in your dev env).

It's a compromise situation until legacy php versions are dropped, which probably would be reasonable to do for 6.0 IMO, but another discussion for another day.