### PR TITLE
Fix ObjectIterator for PHP8

### DIFF
--- a/src/JsonSchema/Iterator/ObjectIterator.php
+++ b/src/JsonSchema/Iterator/ObjectIterator.php
@@ -39,6 +39,7 @@ class ObjectIterator implements \Iterator, \Countable
     /**
      * {@inheritdoc}
      */
+    #[\ReturnTypeWillChange]
     public function current()
     {
         $this->initialize();
@@ -49,7 +50,7 @@ class ObjectIterator implements \Iterator, \Countable
     /**
      * {@inheritdoc}
      */
-    public function next()
+    public function next(): void
     {
         $this->initialize();
         $this->position++;
@@ -58,7 +59,7 @@ class ObjectIterator implements \Iterator, \Countable
     /**
      * {@inheritdoc}
      */
-    public function key()
+    public function key(): int
     {
         $this->initialize();
 
@@ -68,7 +69,7 @@ class ObjectIterator implements \Iterator, \Countable
     /**
      * {@inheritdoc}
      */
-    public function valid()
+    public function valid(): bool
     {
         $this->initialize();
 
@@ -78,7 +79,7 @@ class ObjectIterator implements \Iterator, \Countable
     /**
      * {@inheritdoc}
      */
-    public function rewind()
+    public function rewind(): void
     {
         $this->initialize();
         $this->position = 0;
@@ -87,7 +88,7 @@ class ObjectIterator implements \Iterator, \Countable
     /**
      * {@inheritdoc}
      */
-    public function count()
+    public function count(): int
     {
         $this->initialize();
 


### PR DESCRIPTION
Hi, with PHP8.1 the iterator methods of ObjectIterator must be covariant with the PHP core interfaces.

I didn't know if theres a specific return type for `::current`, so I went with the suppress annotation here. Happy to change this to a return type, if there is one?

```
Deprecated:  Return type of JsonSchema\Iterator\ObjectIterator::current() should either be compatible with Iterator::current(): mixed, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in [...]/vendor/justinrainbow/json-schema/src/JsonSchema/Iterator/ObjectIterator.php on line 42

Deprecated:  Return type of JsonSchema\Iterator\ObjectIterator::next() should either be compatible with Iterator::next(): void, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in [...]/vendor/justinrainbow/json-schema/src/JsonSchema/Iterator/ObjectIterator.php on line 52

Deprecated:  Return type of JsonSchema\Iterator\ObjectIterator::key() should either be compatible with Iterator::key(): mixed, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in [...]/vendor/justinrainbow/json-schema/src/JsonSchema/Iterator/ObjectIterator.php on line 61

Deprecated:  Return type of JsonSchema\Iterator\ObjectIterator::valid() should either be compatible with Iterator::valid(): bool, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in [...]/vendor/justinrainbow/json-schema/src/JsonSchema/Iterator/ObjectIterator.php on line 71

Deprecated:  Return type of JsonSchema\Iterator\ObjectIterator::rewind() should either be compatible with Iterator::rewind(): void, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in [...]/vendor/justinrainbow/json-schema/src/JsonSchema/Iterator/ObjectIterator.php on line 81

Deprecated: Return type of JsonSchema\Iterator\ObjectIterator::count() should either be compatible with Countable::count(): int, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in [...]/vendor/justinrainbow/json-schema/src/JsonSchema/Iterator/ObjectIterator.php on line 90
```