### PR TITLE
Raise to PHP 7.2 minimum and add support for PHP 8.0 and 8.1

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -17,34 +17,35 @@ jobs:
     strategy:
       matrix:
         php-version:
-          - "5.3"
-          - "5.4"
-          - "5.5"
-          - "5.6"
-          - "7.0"
-          - "7.1"
+          # - "5.3"
+          # - "5.4"
+          # - "5.5"
+          # - "5.6"
+          # - "7.0"
+          # - "7.1"
           - "7.2"
           - "7.3"
           - "7.4"
-#          - "8.0"
+          - "8.0"
+          - "8.1"
         dependencies: [highest]
         experimental: [false]
         include:
-          - php-version: "5.3"
-            dependencies: highest
-            experimental: false
-          - php-version: "5.3"
-            dependencies: lowest
-            experimental: false
-#          - php-version: "8.0"
-#            dependencies: highest
-#            experimental: false
-#          - php-version: "8.1"
-#            dependencies: lowest-ignore
-#            experimental: true
-#          - php-version: "8.1"
-#            dependencies: highest-ignore
-#            experimental: true
+          # - php-version: "5.3"
+          #   dependencies: highest
+          #   experimental: false
+          # - php-version: "5.3"
+          #   dependencies: lowest
+          #   experimental: false
+         - php-version: "8.0"
+           dependencies: highest
+           experimental: false
+         - php-version: "8.1"
+           dependencies: lowest-ignore
+           experimental: true
+         - php-version: "8.1"
+           dependencies: highest-ignore
+           experimental: true
 
     steps:
       - name: "Checkout"

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       matrix:
         php-version:
-          - "5.3"
+          - "7.2"
           - "latest"
 
     steps:

--- a/composer.json
+++ b/composer.json
@@ -27,14 +27,14 @@
         }
     ],
     "require": {
-        "php": ">=5.3.3",
+        "php": ">=7.2",
         "marc-mabe/php-enum":"^2.0 || ^3.0 || ^4.0",
-        "icecave/parity": "1.0.0"
+        "icecave/parity": "^3.0"
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "~2.2.20 || ~2.19.0",
         "json-schema/json-schema-test-suite": "1.2.0",
-        "phpunit/phpunit": "^4.8.35"
+        "phpunit/phpunit": "^8.5.26"
     },
     "extra": {
         "branch-alias": {

--- a/src/JsonSchema/Iterator/ObjectIterator.php
+++ b/src/JsonSchema/Iterator/ObjectIterator.php
@@ -39,6 +39,7 @@ class ObjectIterator implements \Iterator, \Countable
     /**
      * {@inheritdoc}
      */
+    #[\ReturnTypeWillChange]
     public function current()
     {
         $this->initialize();
@@ -49,7 +50,7 @@ class ObjectIterator implements \Iterator, \Countable
     /**
      * {@inheritdoc}
      */
-    public function next()
+    public function next(): void
     {
         $this->initialize();
         $this->position++;
@@ -58,6 +59,7 @@ class ObjectIterator implements \Iterator, \Countable
     /**
      * {@inheritdoc}
      */
+    #[\ReturnTypeWillChange]
     public function key()
     {
         $this->initialize();
@@ -68,7 +70,7 @@ class ObjectIterator implements \Iterator, \Countable
     /**
      * {@inheritdoc}
      */
-    public function valid()
+    public function valid(): bool
     {
         $this->initialize();
 
@@ -78,7 +80,7 @@ class ObjectIterator implements \Iterator, \Countable
     /**
      * {@inheritdoc}
      */
-    public function rewind()
+    public function rewind(): void
     {
         $this->initialize();
         $this->position = 0;
@@ -87,7 +89,7 @@ class ObjectIterator implements \Iterator, \Countable
     /**
      * {@inheritdoc}
      */
-    public function count()
+    public function count(): int
     {
         $this->initialize();
 

--- a/src/JsonSchema/Uri/UriResolver.php
+++ b/src/JsonSchema/Uri/UriResolver.php
@@ -28,6 +28,10 @@ class UriResolver implements UriResolverInterface
      */
     public function parse($uri)
     {
+        if (null === $uri || '' === $uri) {
+            return [];
+        }
+
         preg_match('|^(([^:/?#]+):)?(//([^/?#]*))?([^?#]*)(\?([^#]*))?(#(.*))?|', $uri, $match);
 
         $components = array();
@@ -102,7 +106,7 @@ class UriResolver implements UriResolverInterface
             return $uri;
         }
         $baseComponents = $this->parse($baseUri);
-        $basePath = $baseComponents['path'];
+        $basePath = $baseComponents['path'] ?? '';
 
         $baseComponents['path'] = self::combineRelativePathWithBasePath($path, $basePath);
         if (isset($components['fragment'])) {

--- a/src/JsonSchema/Uri/UriResolver.php
+++ b/src/JsonSchema/Uri/UriResolver.php
@@ -29,7 +29,7 @@ class UriResolver implements UriResolverInterface
     public function parse($uri)
     {
         if (null === $uri || '' === $uri) {
-            return [];
+            return array();
         }
 
         preg_match('|^(([^:/?#]+):)?(//([^/?#]*))?([^?#]*)(\?([^#]*))?(#(.*))?|', $uri, $match);

--- a/src/JsonSchema/Uri/UriRetriever.php
+++ b/src/JsonSchema/Uri/UriRetriever.php
@@ -83,9 +83,11 @@ class UriRetriever implements BaseUriRetrieverInterface
             return;
         }
 
-        foreach ($this->allowedInvalidContentTypeEndpoints as $endpoint) {
-            if (strpos($uri, $endpoint) === 0) {
-                return true;
+        if (null !== $uri) {
+            foreach ($this->allowedInvalidContentTypeEndpoints as $endpoint) {
+                if (strpos($uri, $endpoint) === 0) {
+                    return true;
+                }
             }
         }
 

--- a/tests/ConstraintErrorTest.php
+++ b/tests/ConstraintErrorTest.php
@@ -24,10 +24,9 @@ class ConstraintErrorTest extends TestCase
     {
         $e = ConstraintError::MISSING_ERROR();
 
-        $this->setExpectedException(
-            '\JsonSchema\Exception\InvalidArgumentException',
-            'Missing error message for missingError'
-        );
+        $this->expectException(\JsonSchema\Exception\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Missing error message for missingError');
+
         $e->getMessage();
     }
 }

--- a/tests/Constraints/CoerciveTest.php
+++ b/tests/Constraints/CoerciveTest.php
@@ -18,7 +18,7 @@ class CoerciveTest extends VeryBaseTestCase
 {
     protected $factory = null;
 
-    public function setUp():void
+    public function setUp(): void
     {
         $this->factory = new Factory();
         $this->factory->setConfig(Constraint::CHECK_MODE_TYPE_CAST | Constraint::CHECK_MODE_COERCE_TYPES);

--- a/tests/Constraints/CoerciveTest.php
+++ b/tests/Constraints/CoerciveTest.php
@@ -18,7 +18,7 @@ class CoerciveTest extends VeryBaseTestCase
 {
     protected $factory = null;
 
-    public function setUp()
+    public function setUp():void
     {
         $this->factory = new Factory();
         $this->factory->setConfig(Constraint::CHECK_MODE_TYPE_CAST | Constraint::CHECK_MODE_COERCE_TYPES);

--- a/tests/Constraints/FactoryTest.php
+++ b/tests/Constraints/FactoryTest.php
@@ -42,7 +42,7 @@ class FactoryTest extends TestCase
      */
     protected $factory;
 
-    protected function setUp()
+    protected function setUp():void
     {
         $this->factory = new Factory();
     }
@@ -85,7 +85,7 @@ class FactoryTest extends TestCase
      */
     public function testExceptionWhenCreateInstanceForInvalidConstraintName($constraintName)
     {
-        $this->setExpectedException('JsonSchema\Exception\InvalidArgumentException');
+        $this->expectException('JsonSchema\Exception\InvalidArgumentException');
         $this->factory->createInstanceFor($constraintName);
     }
 

--- a/tests/Constraints/FactoryTest.php
+++ b/tests/Constraints/FactoryTest.php
@@ -42,7 +42,7 @@ class FactoryTest extends TestCase
      */
     protected $factory;
 
-    protected function setUp():void
+    protected function setUp(): void
     {
         $this->factory = new Factory();
     }

--- a/tests/Constraints/FormatTest.php
+++ b/tests/Constraints/FormatTest.php
@@ -17,7 +17,7 @@ class FormatTest extends BaseTestCase
 {
     protected $validateSchema = true;
 
-    public function setUp():void
+    public function setUp(): void
     {
         date_default_timezone_set('UTC');
     }

--- a/tests/Constraints/FormatTest.php
+++ b/tests/Constraints/FormatTest.php
@@ -17,7 +17,7 @@ class FormatTest extends BaseTestCase
 {
     protected $validateSchema = true;
 
-    public function setUp()
+    public function setUp():void
     {
         date_default_timezone_set('UTC');
     }

--- a/tests/Constraints/MinLengthMaxLengthMultiByteTest.php
+++ b/tests/Constraints/MinLengthMaxLengthMultiByteTest.php
@@ -13,7 +13,7 @@ class MinLengthMaxLengthMultiByteTest extends BaseTestCase
 {
     protected $validateSchema = true;
 
-    protected function setUp()
+    protected function setUp():void
     {
         if (!extension_loaded('mbstring')) {
             $this->markTestSkipped('mbstring extension is not available');

--- a/tests/Constraints/MinLengthMaxLengthMultiByteTest.php
+++ b/tests/Constraints/MinLengthMaxLengthMultiByteTest.php
@@ -13,7 +13,7 @@ class MinLengthMaxLengthMultiByteTest extends BaseTestCase
 {
     protected $validateSchema = true;
 
-    protected function setUp():void
+    protected function setUp(): void
     {
         if (!extension_loaded('mbstring')) {
             $this->markTestSkipped('mbstring extension is not available');

--- a/tests/Constraints/SchemaValidationTest.php
+++ b/tests/Constraints/SchemaValidationTest.php
@@ -102,19 +102,15 @@ class SchemaValidationTest extends TestCase
 
     public function testNonObjectSchema()
     {
-        $this->setExpectedException(
-            '\JsonSchema\Exception\RuntimeException',
-            'Cannot validate the schema of a non-object'
-        );
+        $this->expectException('\JsonSchema\Exception\RuntimeException');
+        $this->expectExceptionMessage('Cannot validate the schema of a non-object');
         $this->testValidCases('"notAnObject"');
     }
 
     public function testInvalidSchemaException()
     {
-        $this->setExpectedException(
-            '\JsonSchema\Exception\InvalidSchemaException',
-            'Schema did not pass validation'
-        );
+        $this->expectException('\JsonSchema\Exception\InvalidSchemaException');
+        $this->expectExceptionMessage('Schema did not pass validation');
 
         $input = json_decode('{}');
         $schema = json_decode('{"properties":{"propertyOne":{"type":"string","required":true}}}');

--- a/tests/Constraints/SelfDefinedSchemaTest.php
+++ b/tests/Constraints/SelfDefinedSchemaTest.php
@@ -74,7 +74,7 @@ class SelfDefinedSchemaTest extends BaseTestCase
 
         $v = new Validator();
 
-        $this->setExpectedException('\JsonSchema\Exception\InvalidArgumentException');
+        $this->expectException('\JsonSchema\Exception\InvalidArgumentException');
 
         $v->validate($value, $schema);
     }

--- a/tests/Constraints/TypeTest.php
+++ b/tests/Constraints/TypeTest.php
@@ -125,10 +125,8 @@ class TypeTest extends TestCase
         $m = $r->getMethod('validateTypeNameWording');
         $m->setAccessible(true);
 
-        $this->setExpectedException(
-            '\UnexpectedValueException',
-            "No wording for 'notAValidTypeName' available, expected wordings are: [an integer, a number, a boolean, an object, an array, a string, a null]"
-        );
+        $this->expectException('\UnexpectedValueException');
+        $this->expectExceptionMessage("No wording for 'notAValidTypeName' available, expected wordings are: [an integer, a number, a boolean, an object, an array, a string, a null]");
         $m->invoke($t, 'notAValidTypeName');
     }
 
@@ -138,10 +136,8 @@ class TypeTest extends TestCase
         $data = new \stdClass();
         $schema = json_decode('{"type": "notAValidTypeName"}');
 
-        $this->setExpectedException(
-            'JsonSchema\Exception\InvalidArgumentException',
-            'object is an invalid type for notAValidTypeName'
-        );
+        $this->expectException('JsonSchema\Exception\InvalidArgumentException');
+        $this->expectExceptionMessage('object is an invalid type for notAValidTypeName');
         $t->check($data, $schema);
     }
 }

--- a/tests/Constraints/ValidationExceptionTest.php
+++ b/tests/Constraints/ValidationExceptionTest.php
@@ -45,7 +45,7 @@ class ValidationExceptionTest extends TestCase
             $exception->getMessage()
         );
 
-        $this->setExpectedException('JsonSchema\Exception\ValidationException');
+        $this->expectException('JsonSchema\Exception\ValidationException');
         throw $exception;
     }
 }

--- a/tests/Entity/JsonPointerTest.php
+++ b/tests/Entity/JsonPointerTest.php
@@ -113,10 +113,8 @@ class JsonPointerTest extends TestCase
 
     public function testCreateWithInvalidValue()
     {
-        $this->setExpectedException(
-            '\JsonSchema\Exception\InvalidArgumentException',
-            'Ref value must be a string'
-        );
+        $this->expectException('\JsonSchema\Exception\InvalidArgumentException');
+        $this->expectExceptionMessage('Ref value must be a string');
         new JsonPointer(null);
     }
 }

--- a/tests/Iterators/ObjectIteratorTest.php
+++ b/tests/Iterators/ObjectIteratorTest.php
@@ -16,7 +16,7 @@ class ObjectIteratorTest extends TestCase
 {
     protected $testObject;
 
-    public function setUp()
+    public function setUp():void
     {
         $this->testObject = (object) array(
             'subOne' => (object) array(

--- a/tests/Iterators/ObjectIteratorTest.php
+++ b/tests/Iterators/ObjectIteratorTest.php
@@ -16,7 +16,7 @@ class ObjectIteratorTest extends TestCase
 {
     protected $testObject;
 
-    public function setUp():void
+    public function setUp(): void
     {
         $this->testObject = (object) array(
             'subOne' => (object) array(

--- a/tests/RefTest.php
+++ b/tests/RefTest.php
@@ -69,7 +69,7 @@ class RefTest extends TestCase
 
         $v = new Validator();
         if ($exception) {
-            $this->setExpectedException($exception);
+            $this->expectException($exception);
         }
 
         $v->validate($document, $schema);

--- a/tests/SchemaStorageTest.php
+++ b/tests/SchemaStorageTest.php
@@ -102,10 +102,8 @@ class SchemaStorageTest extends TestCase
 
     public function testUnresolvableJsonPointExceptionShouldBeThrown()
     {
-        $this->setExpectedException(
-            'JsonSchema\Exception\UnresolvableJsonPointerException',
-            'File: http://www.example.com/schema.json is found, but could not resolve fragment: #/definitions/car'
-        );
+        $this->expectException('JsonSchema\Exception\UnresolvableJsonPointerException');
+        $this->expectExceptionMessage('File: http://www.example.com/schema.json is found, but could not resolve fragment: #/definitions/car');
 
         $mainSchema = $this->getInvalidSchema();
         $mainSchemaPath = 'http://www.example.com/schema.json';
@@ -121,10 +119,8 @@ class SchemaStorageTest extends TestCase
 
     public function testResolveRefWithNoAssociatedFileName()
     {
-        $this->setExpectedException(
-            'JsonSchema\Exception\UnresolvableJsonPointerException',
-            "Could not resolve fragment '#': no file is defined"
-        );
+        $this->expectException('JsonSchema\Exception\UnresolvableJsonPointerException');
+        $this->expectExceptionMessage("Could not resolve fragment '#': no file is defined");
 
         $schemaStorage = new SchemaStorage();
         $schemaStorage->resolveRef('#');

--- a/tests/Uri/Retrievers/CurlTest.php
+++ b/tests/Uri/Retrievers/CurlTest.php
@@ -17,10 +17,8 @@ namespace JsonSchema\Tests\Uri\Retrievers
         {
             $c = new Curl();
 
-            $this->setExpectedException(
-                '\JsonSchema\Exception\ResourceNotFoundException',
-                'JSON schema not found'
-            );
+            $this->expectException('\JsonSchema\Exception\ResourceNotFoundException');
+            $this->expectExceptionMessage('JSON schema not found');
             $c->retrieve(__DIR__ . '/notARealFile');
         }
 

--- a/tests/Uri/Retrievers/FileGetContentsTest.php
+++ b/tests/Uri/Retrievers/FileGetContentsTest.php
@@ -30,10 +30,8 @@ namespace JsonSchema\Tests\Uri\Retrievers
         {
             $res = new FileGetContents();
 
-            $this->setExpectedException(
-                '\JsonSchema\Exception\ResourceNotFoundException',
-                'JSON schema not found at http://example.com/false'
-            );
+            $this->expectException('\JsonSchema\Exception\ResourceNotFoundException');
+            $this->expectExceptionMessage('JSON schema not found at http://example.com/false');
             $res->retrieve('http://example.com/false');
         }
 
@@ -41,10 +39,8 @@ namespace JsonSchema\Tests\Uri\Retrievers
         {
             $res = new FileGetContents();
 
-            $this->setExpectedException(
-                '\JsonSchema\Exception\ResourceNotFoundException',
-                'JSON schema not found at file:///this/is/a/directory/'
-            );
+            $this->expectException('\JsonSchema\Exception\ResourceNotFoundException');
+            $this->expectExceptionMessage('JSON schema not found at file:///this/is/a/directory/');
             $res->retrieve('file:///this/is/a/directory/');
         }
 

--- a/tests/Uri/Retrievers/PredefinedArrayTest.php
+++ b/tests/Uri/Retrievers/PredefinedArrayTest.php
@@ -12,7 +12,7 @@ class PredefinedArrayTest extends TestCase
 {
     private $retriever;
 
-    public function setUp():void
+    public function setUp(): void
     {
         $this->retriever = new PredefinedArray(
             array(

--- a/tests/Uri/Retrievers/PredefinedArrayTest.php
+++ b/tests/Uri/Retrievers/PredefinedArrayTest.php
@@ -12,7 +12,7 @@ class PredefinedArrayTest extends TestCase
 {
     private $retriever;
 
-    public function setUp()
+    public function setUp():void
     {
         $this->retriever = new PredefinedArray(
             array(

--- a/tests/Uri/UriResolverTest.php
+++ b/tests/Uri/UriResolverTest.php
@@ -7,7 +7,7 @@ use PHPUnit\Framework\TestCase;
 
 class UriResolverTest extends TestCase
 {
-    public function setUp()
+    public function setUp():void
     {
         $this->resolver = new UriResolver();
     }

--- a/tests/Uri/UriResolverTest.php
+++ b/tests/Uri/UriResolverTest.php
@@ -7,7 +7,7 @@ use PHPUnit\Framework\TestCase;
 
 class UriResolverTest extends TestCase
 {
-    public function setUp():void
+    public function setUp(): void
     {
         $this->resolver = new UriResolver();
     }

--- a/tests/Uri/UriRetrieverTest.php
+++ b/tests/Uri/UriRetrieverTest.php
@@ -21,7 +21,7 @@ class UriRetrieverTest extends TestCase
 {
     protected $validator;
 
-    protected function setUp()
+    protected function setUp():void
     {
         $this->validator = new Validator();
     }
@@ -34,7 +34,7 @@ class UriRetrieverTest extends TestCase
             throw new JsonDecodingException($error);
         }
 
-        $retriever = $this->getMock('JsonSchema\Uri\UriRetriever', array('retrieve'));
+        $retriever = $this->createMock('JsonSchema\Uri\UriRetriever');
 
         $retriever->expects($this->at(0))
                   ->method('retrieve')
@@ -235,24 +235,26 @@ EOF;
 
     public function testConfirmMediaTypeAcceptsJsonSchemaType()
     {
-        $retriever = $this->getMock('JsonSchema\Uri\UriRetriever', array('getContentType'));
+        $retrieverUri = $this->createMock(\JsonSchema\Uri\Retrievers\UriRetrieverInterface::class);
+        $retrieverUri->expects($this->at(0))
+            ->method('getContentType')
+            ->will($this->returnValue('application/schema+json'));
 
-        $retriever->expects($this->at(0))
-                ->method('getContentType')
-                ->will($this->returnValue('application/schema+json'));
+        $retriever = new \JsonSchema\Uri\UriRetriever();
 
-        $this->assertEquals(null, $retriever->confirmMediaType($retriever, null));
+        $this->assertEquals(null, $retriever->confirmMediaType($retrieverUri, null));
     }
 
     public function testConfirmMediaTypeAcceptsJsonType()
     {
-        $retriever = $this->getMock('JsonSchema\Uri\UriRetriever', array('getContentType'));
+        $retrieverUri = $this->createMock(\JsonSchema\Uri\Retrievers\UriRetrieverInterface::class);
+        $retrieverUri->expects($this->at(0))
+            ->method('getContentType')
+            ->will($this->returnValue('application/json'));
 
-        $retriever->expects($this->at(0))
-                ->method('getContentType')
-                ->will($this->returnValue('application/json'));
+        $retriever = new \JsonSchema\Uri\UriRetriever();
 
-        $this->assertEquals(null, $retriever->confirmMediaType($retriever, null));
+        $this->assertEquals(null, $retriever->confirmMediaType($retrieverUri, null));
     }
 
     /**
@@ -260,13 +262,14 @@ EOF;
      */
     public function testConfirmMediaTypeThrowsExceptionForUnsupportedTypes()
     {
-        $retriever = $this->getMock('JsonSchema\Uri\UriRetriever', array('getContentType'));
+        $retrieverUri = $this->createMock(\JsonSchema\Uri\Retrievers\UriRetrieverInterface::class);
+        $retrieverUri->expects($this->at(0))
+            ->method('getContentType')
+            ->will($this->returnValue('text/html'));
 
-        $retriever->expects($this->at(0))
-                ->method('getContentType')
-                ->will($this->returnValue('text/html'));
+        $retriever = new \JsonSchema\Uri\UriRetriever();
 
-        $this->assertEquals(null, $retriever->confirmMediaType($retriever, null));
+        $this->assertEquals(null, $retriever->confirmMediaType($retrieverUri, null));
     }
 
     private function mockRetriever($schema)
@@ -332,7 +335,7 @@ EOF;
 
     public function testInvalidContentTypeEndpointsDefault()
     {
-        $mock = $this->getMock('JsonSchema\Uri\UriRetriever', array('getContentType'));
+        $mock = $this->createMock(\JsonSchema\Uri\Retrievers\UriRetrieverInterface::class);
         $mock->method('getContentType')->willReturn('Application/X-Fake-Type');
         $retriever = new UriRetriever();
 
@@ -345,7 +348,7 @@ EOF;
      */
     public function testInvalidContentTypeEndpointsUnknown()
     {
-        $mock = $this->getMock('JsonSchema\Uri\UriRetriever', array('getContentType'));
+        $mock = $this->createMock(\JsonSchema\Uri\Retrievers\UriRetrieverInterface::class);
         $mock->method('getContentType')->willReturn('Application/X-Fake-Type');
         $retriever = new UriRetriever();
 
@@ -354,7 +357,7 @@ EOF;
 
     public function testInvalidContentTypeEndpointsAdded()
     {
-        $mock = $this->getMock('JsonSchema\Uri\UriRetriever', array('getContentType'));
+        $mock = $this->createMock(\JsonSchema\Uri\Retrievers\UriRetrieverInterface::class);
         $mock->method('getContentType')->willReturn('Application/X-Fake-Type');
         $retriever = new UriRetriever();
         $retriever->addInvalidContentTypeEndpoint('http://example.com');
@@ -385,10 +388,8 @@ EOF;
     {
         $retriever = new UriRetriever();
 
-        $this->setExpectedException(
-            'JsonSchema\Exception\JsonDecodingException',
-            'JSON syntax is malformed'
-        );
+        $this->expectException('JsonSchema\Exception\JsonDecodingException');
+        $this->expectExceptionMessage('JSON syntax is malformed');
         $schema = $retriever->retrieve('package://tests/fixtures/bad-syntax.json');
     }
 

--- a/tests/Uri/UriRetrieverTest.php
+++ b/tests/Uri/UriRetrieverTest.php
@@ -21,7 +21,7 @@ class UriRetrieverTest extends TestCase
 {
     protected $validator;
 
-    protected function setUp():void
+    protected function setUp(): void
     {
         $this->validator = new Validator();
     }

--- a/tests/ValidatorTest.php
+++ b/tests/ValidatorTest.php
@@ -31,7 +31,7 @@ class ValidatorTest extends TestCase
 
         $validator = new Validator();
 
-        $this->setExpectedException('\JsonSchema\Exception\InvalidArgumentException');
+        $this->expectException('\JsonSchema\Exception\InvalidArgumentException');
         $validator->validate($data, $schema);
     }
 


### PR DESCRIPTION
* PHP support since version 7.2;
* Support for php 8.0;
* Support for php 8.1.

what do u think about this? isn't it time to abandon the old versions of php? why do we need php 5? for whom?