### PR TITLE
feat: Add support for Draft 6 in NumberConstraint

### DIFF
--- a/src/JsonSchema/Constraints/NumberConstraint.php
+++ b/src/JsonSchema/Constraints/NumberConstraint.php
@@ -26,7 +26,8 @@ class NumberConstraint extends Constraint
     public function check(&$element, $schema = null, JsonPointer $path = null, $i = null)
     {
         // Verify minimum
-        if (isset($schema->exclusiveMinimum)) {
+        if (isset($schema->exclusiveMinimum) && filter_var($schema->exclusiveMinimum, FILTER_VALIDATE_BOOLEAN)) {
+            // Draft 4 schema
             if (isset($schema->minimum)) {
                 if ($schema->exclusiveMinimum && $element <= $schema->minimum) {
                     $this->addError(ConstraintError::EXCLUSIVE_MINIMUM(), $path, array('minimum' => $schema->minimum));
@@ -36,12 +37,18 @@ class NumberConstraint extends Constraint
             } else {
                 $this->addError(ConstraintError::MISSING_MINIMUM(), $path);
             }
+        } elseif (isset($schema->exclusiveMinimum) && filter_var($schema->exclusiveMinimum, FILTER_VALIDATE_INT)) {
+            // Draft 6 schema
+            if ($element <= $schema->exclusiveMinimum) {
+                $this->addError(ConstraintError::EXCLUSIVE_MINIMUM(), $path, array('exclusiveMinimum' => $schema->exclusiveMinimum));
+            }
         } elseif (isset($schema->minimum) && $element < $schema->minimum) {
             $this->addError(ConstraintError::MINIMUM(), $path, array('minimum' => $schema->minimum));
         }
 
         // Verify maximum
-        if (isset($schema->exclusiveMaximum)) {
+        if (isset($schema->exclusiveMaximum) && filter_var($schema->exclusiveMaximum, FILTER_VALIDATE_INT)) {
+            // Draft 4 schema
             if (isset($schema->maximum)) {
                 if ($schema->exclusiveMaximum && $element >= $schema->maximum) {
                     $this->addError(ConstraintError::EXCLUSIVE_MAXIMUM(), $path, array('maximum' => $schema->maximum));
@@ -50,6 +57,11 @@ class NumberConstraint extends Constraint
                 }
             } else {
                 $this->addError(ConstraintError::MISSING_MAXIMUM(), $path);
+            }
+        } elseif (isset($schema->exclusiveMaximum) && filter_var($schema->exclusiveMaximum, FILTER_VALIDATE_INT)) {
+            // Draft 6 schema
+            if ($element >= $schema->exclusiveMaximum) {
+                $this->addError(ConstraintError::EXCLUSIVE_MAXIMUM(), $path, array('exclusiveMaximum' => $schema->exclusiveMaximum));
             }
         } elseif (isset($schema->maximum) && $element > $schema->maximum) {
             $this->addError(ConstraintError::MAXIMUM(), $path, array('maximum' => $schema->maximum));

--- a/tests/Constraints/MinimumMaximumTest.php
+++ b/tests/Constraints/MinimumMaximumTest.php
@@ -28,12 +28,25 @@ class MinimumMaximumTest extends BaseTestCase
                 }'
             ),
             array(
-                '{"value": 3}',
                 '{
-                    "type": "object",
-                    "properties": {
-                        "value": {"type": "integer", "minimum": 3, "exclusiveMinimum": true}
-                    }
+                  "value":16
+                }',
+                '{
+                  "type":"object",
+                  "properties":{
+                    "value":{"type":"integer","maximum":8}
+                  }
+                }'
+            ),
+            array(
+                '{
+                  "value":2
+                }',
+                '{
+                  "type":"object",
+                  "properties":{
+                    "value":{"type":"integer","exclusiveMinimum":2}
+                  }
                 }'
             ),
             array(
@@ -43,8 +56,17 @@ class MinimumMaximumTest extends BaseTestCase
                 '{
                   "type":"object",
                   "properties":{
-                    "value":{"type":"integer","maximum":8}
+                    "value":{"type":"integer","exclusiveMaximum":16}
                   }
+                }'
+            ),
+            array(
+                '{"value": 3}',
+                '{
+                    "type": "object",
+                    "properties": {
+                        "value": {"type": "integer", "minimum": 3, "exclusiveMinimum": true}
+                    }
                 }'
             ),
             array(


### PR DESCRIPTION
I am opening this PR because I first encountered it as reported in https://github.com/api-platform/core/issues/6041. I have read and seen either via commit history or issues (such as #699) that this repository has very limited _people_ capabilities.

I tried to keep this as _short_ as possible to offer a Draft 4 and Draft 6 compliance for Numbers->Range case without changing too much. Ref: [Draft 6 Backward-incompatible changes](https://json-schema.org/draft-06/json-schema-release-notes#backwards-incompatible-changes). 

I don't know if an `is_bool` is fine vs `filter_var`, I am more than happy to apply changes as per your feedback. 