### PR TITLE
Addresses Content-Type mismatch on HTTP 301 Moved Permanently with FileGetContents

### DIFF
--- a/src/JsonSchema/Uri/Retrievers/FileGetContents.php
+++ b/src/JsonSchema/Uri/Retrievers/FileGetContents.php
@@ -68,7 +68,7 @@ class FileGetContents extends AbstractRetriever
      */
     private function fetchContentType(array $headers)
     {
-        foreach ($headers as $header) {
+        foreach (array_reverse($headers) as $header) {
             if ($this->contentType = self::getContentTypeMatchInHeader($header)) {
                 return true;
             }

--- a/tests/Uri/Retrievers/FileGetContentsTest.php
+++ b/tests/Uri/Retrievers/FileGetContentsTest.php
@@ -59,6 +59,15 @@ namespace JsonSchema\Tests\Uri\Retrievers
             $this->assertTrue($fetchContentType->invoke($res, array('Content-Type: application/json')));
             $this->assertFalse($fetchContentType->invoke($res, array('X-Some-Header: whateverValue')));
         }
+
+        public function testCanHandleHttp301PermanentRedirect()
+        {
+            $res = new FileGetContents();
+
+            $res->retrieve('http://asyncapi.com/definitions/2.0.0/asyncapi.json');
+
+            $this->assertSame('application/schema+json', $res->getContentType());
+        }
     }
 }
 

--- a/tests/Uri/Retrievers/FileGetContentsTest.php
+++ b/tests/Uri/Retrievers/FileGetContentsTest.php
@@ -1,50 +1,49 @@
 <?php
 
-namespace JsonSchema\Tests\Uri\Retrievers
+namespace JsonSchema\Tests\Uri\Retrievers;
+
+use JsonSchema\Uri\Retrievers\FileGetContents;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @group FileGetContents
+ */
+class FileGetContentsTest extends TestCase
 {
-    use JsonSchema\Uri\Retrievers\FileGetContents;
-    use PHPUnit\Framework\TestCase;
-
     /**
-     * @group FileGetContents
+     * @expectedException \JsonSchema\Exception\ResourceNotFoundException
      */
-    class FileGetContentsTest extends TestCase
+    public function testFetchMissingFile()
     {
-        /**
-         * @expectedException \JsonSchema\Exception\ResourceNotFoundException
-         */
-        public function testFetchMissingFile()
-        {
-            $res = new FileGetContents();
-            $res->retrieve(__DIR__ . '/Fixture/missing.json');
-        }
+        $res = new FileGetContents();
+        $res->retrieve(__DIR__ . '/Fixture/missing.json');
+    }
 
-        public function testFetchFile()
-        {
-            $res = new FileGetContents();
-            $result = $res->retrieve(__DIR__ . '/../Fixture/child.json');
-            $this->assertNotEmpty($result);
-        }
+    public function testFetchFile()
+    {
+        $res = new FileGetContents();
+        $result = $res->retrieve(__DIR__ . '/../Fixture/child.json');
+        $this->assertNotEmpty($result);
+    }
 
-        public function testContentType()
-        {
-            $res = new FileGetContents();
+    public function testContentType()
+    {
+        $res = new FileGetContents();
 
-            $reflector = new \ReflectionObject($res);
-            $fetchContentType = $reflector->getMethod('fetchContentType');
-            $fetchContentType->setAccessible(true);
+        $reflector = new \ReflectionObject($res);
+        $fetchContentType = $reflector->getMethod('fetchContentType');
+        $fetchContentType->setAccessible(true);
 
-            $this->assertTrue($fetchContentType->invoke($res, array('Content-Type: application/json')));
-            $this->assertFalse($fetchContentType->invoke($res, array('X-Some-Header: whateverValue')));
-        }
+        $this->assertTrue($fetchContentType->invoke($res, array('Content-Type: application/json')));
+        $this->assertFalse($fetchContentType->invoke($res, array('X-Some-Header: whateverValue')));
+    }
 
-        public function testCanHandleHttp301PermanentRedirect()
-        {
-            $res = new FileGetContents();
+    public function testCanHandleHttp301PermanentRedirect()
+    {
+        $res = new FileGetContents();
 
-            $res->retrieve('http://asyncapi.com/definitions/2.0.0/asyncapi.json');
+        $res->retrieve('http://asyncapi.com/definitions/2.0.0/asyncapi.json');
 
-            $this->assertSame('application/schema+json', $res->getContentType());
-        }
+        $this->assertSame('application/schema+json', $res->getContentType());
     }
 }

--- a/tests/Uri/Retrievers/FileGetContentsTest.php
+++ b/tests/Uri/Retrievers/FileGetContentsTest.php
@@ -26,28 +26,6 @@ namespace JsonSchema\Tests\Uri\Retrievers
             $this->assertNotEmpty($result);
         }
 
-        public function testFalseReturn()
-        {
-            $res = new FileGetContents();
-
-            $this->setExpectedException(
-                '\JsonSchema\Exception\ResourceNotFoundException',
-                'JSON schema not found at http://example.com/false'
-            );
-            $res->retrieve('http://example.com/false');
-        }
-
-        public function testFetchDirectory()
-        {
-            $res = new FileGetContents();
-
-            $this->setExpectedException(
-                '\JsonSchema\Exception\ResourceNotFoundException',
-                'JSON schema not found at file:///this/is/a/directory/'
-            );
-            $res->retrieve('file:///this/is/a/directory/');
-        }
-
         public function testContentType()
         {
             $res = new FileGetContents();
@@ -67,18 +45,6 @@ namespace JsonSchema\Tests\Uri\Retrievers
             $res->retrieve('http://asyncapi.com/definitions/2.0.0/asyncapi.json');
 
             $this->assertSame('application/schema+json', $res->getContentType());
-        }
-    }
-}
-
-namespace JsonSchema\Uri\Retrievers
-{
-    function file_get_contents($uri)
-    {
-        switch ($uri) {
-            case 'http://example.com/false': return false;
-            case 'file:///this/is/a/directory/': return '';
-            default: return \file_get_contents($uri);
         }
     }
 }


### PR DESCRIPTION
This PR attempts to resolve issue #694, in order to do so three commits where added
- The first adds a failing test showing the issue
- The second refactors the usage of `$http_response_header` [[link]](https://www.php.net/manual/en/reserved.variables.httpresponseheader.php) with `get_headers()` [[link]](https://www.php.net/manual/en/function.get-headers.php)
- The third commit reverse the headers before parsing to match on the latest `Content-Type` header.