### PR TITLE
refactor: Remove dead block of code

### DIFF
--- a/src/JsonSchema/Constraints/FormatConstraint.php
+++ b/src/JsonSchema/Constraints/FormatConstraint.php
@@ -184,14 +184,6 @@ class FormatConstraint extends Constraint
             return true;
         }
 
-        // handles the case where a non-6 digit microsecond datetime is passed
-        // which will fail the above string comparison because the passed
-        // $datetime may be '2000-05-01T12:12:12.123Z' but format() will return
-        // '2000-05-01T12:12:12.123000Z'
-        if ((strpos('u', $format) !== -1) && (preg_match('/\.\d+Z$/', $datetime))) {
-            return true;
-        }
-
         return false;
     }
 


### PR DESCRIPTION
Based on the original PR (#641) from Markus Staab it was found the incorrect order of arguments to be in a dead piece of code. The `strpos`-call was added in ffc856db on 18/02/2016 whereas in 6474265b on 03/03/2016 the calling code of the `validateDateTime` with an `format` argument containing an `u` was removed making this check void. So removing the code block would be best, hence this PR.