### PR TITLE
Update references to jsonrainbow

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # JSON Schema for PHP
 
-[![Build Status](https://github.com/justinrainbow/json-schema/actions/workflows/continuous-integration.yml/badge.svg)](https://github.com/justinrainbow/json-schema/actions)
+[![Build Status](https://github.com/jsonrainbow/json-schema/actions/workflows/continuous-integration.yml/badge.svg)](https://github.com/jsonrainbow/json-schema/actions)
 [![Latest Stable Version](https://poser.pugx.org/justinrainbow/json-schema/v/stable.png)](https://packagist.org/packages/justinrainbow/json-schema)
 [![Total Downloads](https://poser.pugx.org/justinrainbow/json-schema/downloads.png)](https://packagist.org/packages/justinrainbow/json-schema)
 
@@ -13,7 +13,7 @@ See [json-schema](http://json-schema.org/) for more details.
 ### Library
 
 ```bash
-git clone https://github.com/justinrainbow/json-schema.git
+git clone https://github.com/jsonrainbow/json-schema.git
 ```
 
 ### Composer

--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
         "json",
         "schema"
     ],
-    "homepage": "https://github.com/justinrainbow/json-schema",
+    "homepage": "https://github.com/jsonrainbow/json-schema",
     "license": "MIT",
     "authors": [
         {

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -17,7 +17,7 @@ Installation
 
 .. code-block:: console
 
-   git clone https://github.com/justinrainbow/json-schema.git
+   git clone https://github.com/jsonrainbow/json-schema.git
 
 Composer method
 ^^^^^^^^^^^^^^^


### PR DESCRIPTION
Replaces #723 

>I was notified by one of my securityscanners that the project URL has been moved (this is indeed correct, as I read in https://github.com/jsonrainbow/json-schema/issues/658).
>
>I took the liberty to update the homepage in the composer.json to point to the new URL.