### PR TITLE
php 8.4 support for 5.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -34,11 +34,6 @@
         "json-schema/json-schema-test-suite": "1.2.0",
         "phpunit/phpunit": "^4.8.35"
     },
-    "extra": {
-        "branch-alias": {
-            "dev-master": "5.0.x-dev"
-        }
-    },
     "autoload": {
         "psr-4": {
             "JsonSchema\\": "src/JsonSchema/"

--- a/composer.json
+++ b/composer.json
@@ -62,10 +62,10 @@
         "bin/validate-json"
     ],
     "scripts": {
-        "coverage": "phpunit --coverage-text",
-        "style-check": "php-cs-fixer fix --dry-run --verbose --diff",
-        "style-fix": "php-cs-fixer fix --verbose",
-        "test": "phpunit",
-        "testOnly": "phpunit --colors --filter"
+        "coverage": "@php phpunit --coverage-text",
+        "style-check": "@php php-cs-fixer fix --dry-run --verbose --diff",
+        "style-fix": "@php php-cs-fixer fix --verbose",
+        "test": "@php phpunit",
+        "testOnly": "@php phpunit --colors --filter"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
         }
     ],
     "require": {
-        "php": ">=5.3.3"
+        "php": ">=7.1"
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "~2.2.20||~2.15.1",

--- a/src/JsonSchema/Constraints/BaseConstraint.php
+++ b/src/JsonSchema/Constraints/BaseConstraint.php
@@ -38,12 +38,12 @@ class BaseConstraint
     /**
      * @param Factory $factory
      */
-    public function __construct(Factory $factory = null)
+    public function __construct(?Factory $factory = null)
     {
         $this->factory = $factory ?: new Factory();
     }
 
-    public function addError(JsonPointer $path = null, $message, $constraint = '', array $more = null)
+    public function addError(?JsonPointer $path = null, $message, $constraint = '', array $more = null)
     {
         $error = array(
             'property' => $this->convertJsonPointerIntoPropertyPath($path ?: new JsonPointer('')),

--- a/src/JsonSchema/Constraints/CollectionConstraint.php
+++ b/src/JsonSchema/Constraints/CollectionConstraint.php
@@ -22,7 +22,7 @@ class CollectionConstraint extends Constraint
     /**
      * {@inheritdoc}
      */
-    public function check(&$value, $schema = null, JsonPointer $path = null, $i = null)
+    public function check(&$value, $schema = null, ?JsonPointer $path = null, $i = null)
     {
         // Verify minItems
         if (isset($schema->minItems) && count($value) < $schema->minItems) {
@@ -61,7 +61,7 @@ class CollectionConstraint extends Constraint
      * @param JsonPointer|null $path
      * @param string           $i
      */
-    protected function validateItems(&$value, $schema = null, JsonPointer $path = null, $i = null)
+    protected function validateItems(&$value, $schema = null, ?JsonPointer $path = null, $i = null)
     {
         if (is_object($schema->items)) {
             // just one type definition for the whole array

--- a/src/JsonSchema/Constraints/Constraint.php
+++ b/src/JsonSchema/Constraints/Constraint.php
@@ -39,7 +39,7 @@ abstract class Constraint extends BaseConstraint implements ConstraintInterface
      *
      * @return JsonPointer;
      */
-    protected function incrementPath(JsonPointer $path = null, $i)
+    protected function incrementPath(?JsonPointer $path = null, $i)
     {
         $path = $path ?: new JsonPointer('');
 
@@ -65,7 +65,7 @@ abstract class Constraint extends BaseConstraint implements ConstraintInterface
      * @param JsonPointer|null $path
      * @param mixed            $i
      */
-    protected function checkArray(&$value, $schema = null, JsonPointer $path = null, $i = null)
+    protected function checkArray(&$value, $schema = null, ?JsonPointer $path = null, $i = null)
     {
         $validator = $this->factory->createInstanceFor('collection');
         $validator->check($value, $schema, $path, $i);
@@ -83,7 +83,7 @@ abstract class Constraint extends BaseConstraint implements ConstraintInterface
      * @param mixed            $additionalProperties
      * @param mixed            $patternProperties
      */
-    protected function checkObject(&$value, $schema = null, JsonPointer $path = null, $properties = null,
+    protected function checkObject(&$value, $schema = null, ?JsonPointer $path = null, $properties = null,
         $additionalProperties = null, $patternProperties = null, $appliedDefaults = array())
     {
         $validator = $this->factory->createInstanceFor('object');
@@ -100,7 +100,7 @@ abstract class Constraint extends BaseConstraint implements ConstraintInterface
      * @param JsonPointer|null $path
      * @param mixed            $i
      */
-    protected function checkType(&$value, $schema = null, JsonPointer $path = null, $i = null)
+    protected function checkType(&$value, $schema = null, ?JsonPointer $path = null, $i = null)
     {
         $validator = $this->factory->createInstanceFor('type');
         $validator->check($value, $schema, $path, $i);
@@ -116,7 +116,7 @@ abstract class Constraint extends BaseConstraint implements ConstraintInterface
      * @param JsonPointer|null $path
      * @param mixed            $i
      */
-    protected function checkUndefined(&$value, $schema = null, JsonPointer $path = null, $i = null, $fromDefault = false)
+    protected function checkUndefined(&$value, $schema = null, ?JsonPointer $path = null, $i = null, $fromDefault = false)
     {
         $validator = $this->factory->createInstanceFor('undefined');
 
@@ -133,7 +133,7 @@ abstract class Constraint extends BaseConstraint implements ConstraintInterface
      * @param JsonPointer|null $path
      * @param mixed            $i
      */
-    protected function checkString($value, $schema = null, JsonPointer $path = null, $i = null)
+    protected function checkString($value, $schema = null, ?JsonPointer $path = null, $i = null)
     {
         $validator = $this->factory->createInstanceFor('string');
         $validator->check($value, $schema, $path, $i);
@@ -149,7 +149,7 @@ abstract class Constraint extends BaseConstraint implements ConstraintInterface
      * @param JsonPointer $path
      * @param mixed       $i
      */
-    protected function checkNumber($value, $schema = null, JsonPointer $path = null, $i = null)
+    protected function checkNumber($value, $schema = null, ?JsonPointer $path = null, $i = null)
     {
         $validator = $this->factory->createInstanceFor('number');
         $validator->check($value, $schema, $path, $i);
@@ -165,7 +165,7 @@ abstract class Constraint extends BaseConstraint implements ConstraintInterface
      * @param JsonPointer|null $path
      * @param mixed            $i
      */
-    protected function checkEnum($value, $schema = null, JsonPointer $path = null, $i = null)
+    protected function checkEnum($value, $schema = null, ?JsonPointer $path = null, $i = null)
     {
         $validator = $this->factory->createInstanceFor('enum');
         $validator->check($value, $schema, $path, $i);
@@ -181,7 +181,7 @@ abstract class Constraint extends BaseConstraint implements ConstraintInterface
      * @param JsonPointer|null $path
      * @param mixed            $i
      */
-    protected function checkFormat($value, $schema = null, JsonPointer $path = null, $i = null)
+    protected function checkFormat($value, $schema = null, ?JsonPointer $path = null, $i = null)
     {
         $validator = $this->factory->createInstanceFor('format');
         $validator->check($value, $schema, $path, $i);

--- a/src/JsonSchema/Constraints/ConstraintInterface.php
+++ b/src/JsonSchema/Constraints/ConstraintInterface.php
@@ -40,7 +40,7 @@ interface ConstraintInterface
      * @param string           $constraint the constraint/rule that is broken, e.g.: 'minLength'
      * @param array            $more       more array elements to add to the error
      */
-    public function addError(JsonPointer $path = null, $message, $constraint='', array $more = null);
+    public function addError(?JsonPointer $path = null, $message, $constraint='', array $more = null);
 
     /**
      * checks if the validator has not raised errors
@@ -61,5 +61,5 @@ interface ConstraintInterface
      *
      * @throws \JsonSchema\Exception\ExceptionInterface
      */
-    public function check(&$value, $schema = null, JsonPointer $path = null, $i = null);
+    public function check(&$value, $schema = null, ?JsonPointer $path = null, $i = null);
 }

--- a/src/JsonSchema/Constraints/EnumConstraint.php
+++ b/src/JsonSchema/Constraints/EnumConstraint.php
@@ -22,7 +22,7 @@ class EnumConstraint extends Constraint
     /**
      * {@inheritdoc}
      */
-    public function check(&$element, $schema = null, JsonPointer $path = null, $i = null)
+    public function check(&$element, $schema = null, ?JsonPointer $path = null, $i = null)
     {
         // Only validate enum if the attribute exists
         if ($element instanceof UndefinedConstraint && (!isset($schema->required) || !$schema->required)) {

--- a/src/JsonSchema/Constraints/Factory.php
+++ b/src/JsonSchema/Constraints/Factory.php
@@ -74,8 +74,8 @@ class Factory
      * @param int                   $checkMode
      */
     public function __construct(
-        SchemaStorageInterface $schemaStorage = null,
-        UriRetrieverInterface $uriRetriever = null,
+        ?SchemaStorageInterface $schemaStorage = null,
+        ?UriRetrieverInterface $uriRetriever = null,
         $checkMode = Constraint::CHECK_MODE_NORMAL
     ) {
         // set provided config options

--- a/src/JsonSchema/Constraints/FormatConstraint.php
+++ b/src/JsonSchema/Constraints/FormatConstraint.php
@@ -24,7 +24,7 @@ class FormatConstraint extends Constraint
     /**
      * {@inheritdoc}
      */
-    public function check(&$element, $schema = null, JsonPointer $path = null, $i = null)
+    public function check(&$element, $schema = null, ?JsonPointer $path = null, $i = null)
     {
         if (!isset($schema->format) || $this->factory->getConfig(self::CHECK_MODE_DISABLE_FORMAT)) {
             return;

--- a/src/JsonSchema/Constraints/NumberConstraint.php
+++ b/src/JsonSchema/Constraints/NumberConstraint.php
@@ -22,7 +22,7 @@ class NumberConstraint extends Constraint
     /**
      * {@inheritdoc}
      */
-    public function check(&$element, $schema = null, JsonPointer $path = null, $i = null)
+    public function check(&$element, $schema = null, ?JsonPointer $path = null, $i = null)
     {
         // Verify minimum
         if (isset($schema->exclusiveMinimum)) {

--- a/src/JsonSchema/Constraints/ObjectConstraint.php
+++ b/src/JsonSchema/Constraints/ObjectConstraint.php
@@ -27,7 +27,7 @@ class ObjectConstraint extends Constraint
     /**
      * {@inheritdoc}
      */
-    public function check(&$element, $schema = null, JsonPointer $path = null, $properties = null,
+    public function check(&$element, $schema = null, ?JsonPointer $path = null, $properties = null,
         $additionalProp = null, $patternProperties = null, $appliedDefaults = array())
     {
         if ($element instanceof UndefinedConstraint) {
@@ -51,7 +51,7 @@ class ObjectConstraint extends Constraint
         $this->validateElement($element, $matches, $schema, $path, $properties, $additionalProp);
     }
 
-    public function validatePatternProperties($element, JsonPointer $path = null, $patternProperties)
+    public function validatePatternProperties($element, ?JsonPointer $path = null, $patternProperties)
     {
         $try = array('/', '#', '+', '~', '%');
         $matches = array();
@@ -90,7 +90,7 @@ class ObjectConstraint extends Constraint
      * @param \StdClass        $properties     Properties
      * @param mixed            $additionalProp Additional properties
      */
-    public function validateElement($element, $matches, $schema = null, JsonPointer $path = null,
+    public function validateElement($element, $matches, $schema = null, ?JsonPointer $path = null,
         $properties = null, $additionalProp = null)
     {
         $this->validateMinMaxConstraint($element, $schema, $path);
@@ -132,7 +132,7 @@ class ObjectConstraint extends Constraint
      * @param \stdClass        $properties Property definitions
      * @param JsonPointer|null $path       Path?
      */
-    public function validateProperties(&$element, $properties = null, JsonPointer $path = null)
+    public function validateProperties(&$element, $properties = null, ?JsonPointer $path = null)
     {
         $undefinedConstraint = $this->factory->createInstanceFor('undefined');
 
@@ -174,7 +174,7 @@ class ObjectConstraint extends Constraint
      * @param \stdClass        $objectDefinition ObjectConstraint definition
      * @param JsonPointer|null $path             Path to test?
      */
-    protected function validateMinMaxConstraint($element, $objectDefinition, JsonPointer $path = null)
+    protected function validateMinMaxConstraint($element, $objectDefinition, ?JsonPointer $path = null)
     {
         // Verify minimum number of properties
         if (isset($objectDefinition->minProperties) && !is_object($objectDefinition->minProperties)) {

--- a/src/JsonSchema/Constraints/SchemaConstraint.php
+++ b/src/JsonSchema/Constraints/SchemaConstraint.php
@@ -28,7 +28,7 @@ class SchemaConstraint extends Constraint
     /**
      * {@inheritdoc}
      */
-    public function check(&$element, $schema = null, JsonPointer $path = null, $i = null)
+    public function check(&$element, $schema = null, ?JsonPointer $path = null, $i = null)
     {
         if ($schema !== null) {
             // passed schema

--- a/src/JsonSchema/Constraints/StringConstraint.php
+++ b/src/JsonSchema/Constraints/StringConstraint.php
@@ -22,7 +22,7 @@ class StringConstraint extends Constraint
     /**
      * {@inheritdoc}
      */
-    public function check(&$element, $schema = null, JsonPointer $path = null, $i = null)
+    public function check(&$element, $schema = null, ?JsonPointer $path = null, $i = null)
     {
         // Verify maxLength
         if (isset($schema->maxLength) && $this->strlen($element) > $schema->maxLength) {

--- a/src/JsonSchema/Constraints/TypeConstraint.php
+++ b/src/JsonSchema/Constraints/TypeConstraint.php
@@ -39,7 +39,7 @@ class TypeConstraint extends Constraint
     /**
      * {@inheritdoc}
      */
-    public function check(&$value = null, $schema = null, JsonPointer $path = null, $i = null)
+    public function check(&$value = null, $schema = null, ?JsonPointer $path = null, $i = null)
     {
         $type = isset($schema->type) ? $schema->type : null;
         $isValid = false;

--- a/src/JsonSchema/Constraints/UndefinedConstraint.php
+++ b/src/JsonSchema/Constraints/UndefinedConstraint.php
@@ -31,7 +31,7 @@ class UndefinedConstraint extends Constraint
     /**
      * {@inheritdoc}
      */
-    public function check(&$value, $schema = null, JsonPointer $path = null, $i = null, $fromDefault = false)
+    public function check(&$value, $schema = null, ?JsonPointer $path = null, $i = null, $fromDefault = false)
     {
         if (is_null($schema) || !is_object($schema)) {
             return;

--- a/src/JsonSchema/Exception/JsonDecodingException.php
+++ b/src/JsonSchema/Exception/JsonDecodingException.php
@@ -14,7 +14,7 @@ namespace JsonSchema\Exception;
  */
 class JsonDecodingException extends RuntimeException
 {
-    public function __construct($code = JSON_ERROR_NONE, \Exception $previous = null)
+    public function __construct($code = JSON_ERROR_NONE, ?\Exception $previous = null)
     {
         switch ($code) {
             case JSON_ERROR_DEPTH:

--- a/src/JsonSchema/SchemaStorage.php
+++ b/src/JsonSchema/SchemaStorage.php
@@ -17,8 +17,8 @@ class SchemaStorage implements SchemaStorageInterface
     protected $schemas = array();
 
     public function __construct(
-        UriRetrieverInterface $uriRetriever = null,
-        UriResolverInterface $uriResolver = null
+        ?UriRetrieverInterface $uriRetriever = null,
+        ?UriResolverInterface $uriResolver = null
     ) {
         $this->uriRetriever = $uriRetriever ?: new UriRetriever();
         $this->uriResolver = $uriResolver ?: new UriResolver();

--- a/tests/Constraints/FactoryTest.php
+++ b/tests/Constraints/FactoryTest.php
@@ -30,7 +30,7 @@ class MyBadConstraint
  */
 class MyStringConstraint extends Constraint
 {
-    public function check(&$value, $schema = null, JsonPointer $path = null, $i = null)
+    public function check(&$value, $schema = null, ?JsonPointer $path = null, $i = null)
     {
     }
 }


### PR DESCRIPTION
To be released as 5.3.0

Backports #717 for 5.x.x and bumps minimum php req to 7.1.0 as discussed in https://github.com/jsonrainbow/json-schema/discussions/726#discussioncomment-9857798