### PR TITLE
Correct misconfigured mocks in JsonSchema\Tests\Uri\UriRetrieverTest 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Correct misconfigured mocks in JsonSchema\Tests\Uri\UriRetrieverTest ([#741](https://github.com/jsonrainbow/json-schema/pull/741))
 
 ## [6.0.0] - 2024-07-30
 ### Added

--- a/tests/Uri/UriRetrieverTest.php
+++ b/tests/Uri/UriRetrieverTest.php
@@ -235,24 +235,26 @@ EOF;
 
     public function testConfirmMediaTypeAcceptsJsonSchemaType()
     {
-        $retriever = $this->getMock('JsonSchema\Uri\UriRetriever', array('getContentType'));
+        $uriRetriever = $this->getMock('JsonSchema\Uri\Retrievers\UriRetrieverInterface', array('getContentType'));
+        $retriever = new UriRetriever();
 
-        $retriever->expects($this->at(0))
+        $uriRetriever->expects($this->at(0))
                 ->method('getContentType')
-                ->will($this->returnValue('application/schema+json'));
+                ->willReturn('application/schema+json');
 
-        $this->assertEquals(null, $retriever->confirmMediaType($retriever, null));
+        $this->assertEquals(null, $retriever->confirmMediaType($uriRetriever, null));
     }
 
     public function testConfirmMediaTypeAcceptsJsonType()
     {
-        $retriever = $this->getMock('JsonSchema\Uri\UriRetriever', array('getContentType'));
+        $uriRetriever = $this->getMock('JsonSchema\Uri\Retrievers\UriRetrieverInterface', array('getContentType'));
+        $retriever = new UriRetriever();
 
-        $retriever->expects($this->at(0))
+        $uriRetriever->expects($this->at(0))
                 ->method('getContentType')
-                ->will($this->returnValue('application/json'));
+                ->willReturn('application/json');
 
-        $this->assertEquals(null, $retriever->confirmMediaType($retriever, null));
+        $this->assertEquals(null, $retriever->confirmMediaType($uriRetriever, null));
     }
 
     /**
@@ -260,13 +262,14 @@ EOF;
      */
     public function testConfirmMediaTypeThrowsExceptionForUnsupportedTypes()
     {
-        $retriever = $this->getMock('JsonSchema\Uri\UriRetriever', array('getContentType'));
+        $uriRetriever = $this->getMock('JsonSchema\Uri\Retrievers\UriRetrieverInterface', array('getContentType'));
+        $retriever = new UriRetriever();
 
-        $retriever->expects($this->at(0))
+        $uriRetriever->expects($this->at(0))
                 ->method('getContentType')
-                ->will($this->returnValue('text/html'));
+                ->willReturn('text/html');
 
-        $this->assertEquals(null, $retriever->confirmMediaType($retriever, null));
+        $this->assertEquals(null, $retriever->confirmMediaType($uriRetriever, null));
     }
 
     private function mockRetriever($schema)
@@ -332,7 +335,7 @@ EOF;
 
     public function testInvalidContentTypeEndpointsDefault()
     {
-        $mock = $this->getMock('JsonSchema\Uri\UriRetriever', array('getContentType'));
+        $mock = $this->getMock('JsonSchema\Uri\Retrievers\UriRetrieverInterface', array('getContentType'));
         $mock->method('getContentType')->willReturn('Application/X-Fake-Type');
         $retriever = new UriRetriever();
 
@@ -345,7 +348,7 @@ EOF;
      */
     public function testInvalidContentTypeEndpointsUnknown()
     {
-        $mock = $this->getMock('JsonSchema\Uri\UriRetriever', array('getContentType'));
+        $mock = $this->getMock('JsonSchema\Uri\Retrievers\UriRetrieverInterface', array('getContentType'));
         $mock->method('getContentType')->willReturn('Application/X-Fake-Type');
         $retriever = new UriRetriever();
 
@@ -354,7 +357,7 @@ EOF;
 
     public function testInvalidContentTypeEndpointsAdded()
     {
-        $mock = $this->getMock('JsonSchema\Uri\UriRetriever', array('getContentType'));
+        $mock = $this->getMock('JsonSchema\Uri\Retrievers\UriRetrieverInterface', array('getContentType'));
         $mock->method('getContentType')->willReturn('Application/X-Fake-Type');
         $retriever = new UriRetriever();
         $retriever->addInvalidContentTypeEndpoint('http://example.com');

--- a/tests/Uri/UriRetrieverTest.php
+++ b/tests/Uri/UriRetrieverTest.php
@@ -153,7 +153,7 @@ EOF;
             'title' => 'schema'
         );
 
-        $retriever = new \JsonSchema\Uri\UriRetriever();
+        $retriever = new UriRetriever();
         $this->assertEquals(
             $schema,
             $retriever->resolvePointer(
@@ -173,7 +173,7 @@ EOF;
             'title' => 'schema'
         );
 
-        $retriever = new \JsonSchema\Uri\UriRetriever();
+        $retriever = new UriRetriever();
         $this->assertEquals(
             $schema->definitions->foo,
             $retriever->resolvePointer(
@@ -196,7 +196,7 @@ EOF;
             'title' => 'schema'
         );
 
-        $retriever = new \JsonSchema\Uri\UriRetriever();
+        $retriever = new UriRetriever();
         $retriever->resolvePointer(
             $schema, 'http://example.org/schema.json#/definitions/bar'
         );
@@ -216,7 +216,7 @@ EOF;
             'title' => 'schema'
         );
 
-        $retriever = new \JsonSchema\Uri\UriRetriever();
+        $retriever = new UriRetriever();
         $retriever->resolvePointer(
             $schema, 'http://example.org/schema.json#/definitions/foo'
         );
@@ -227,7 +227,7 @@ EOF;
      */
     public function testResolveExcessLevelUp()
     {
-        $retriever = new \JsonSchema\Uri\UriRetriever();
+        $retriever = new UriRetriever();
         $retriever->resolve(
             '../schema.json#', 'http://example.org/schema.json#'
         );

--- a/tests/Uri/UriRetrieverTest.php
+++ b/tests/Uri/UriRetrieverTest.php
@@ -39,7 +39,7 @@ class UriRetrieverTest extends TestCase
         $retriever->expects($this->at(0))
                   ->method('retrieve')
                   ->with($this->equalTo(null), $this->equalTo('http://some.host.at/somewhere/parent'))
-                  ->will($this->returnValue($jsonSchema));
+                  ->willReturn($jsonSchema);
 
         return $retriever;
     }

--- a/tests/Uri/UriRetrieverTest.php
+++ b/tests/Uri/UriRetrieverTest.php
@@ -392,7 +392,7 @@ EOF;
             'JsonSchema\Exception\JsonDecodingException',
             'JSON syntax is malformed'
         );
-        $schema = $retriever->retrieve('package://tests/fixtures/bad-syntax.json');
+        $retriever->retrieve('package://tests/fixtures/bad-syntax.json');
     }
 
     public function testGenerateURI()

--- a/tests/Uri/UriRetrieverTest.php
+++ b/tests/Uri/UriRetrieverTest.php
@@ -235,7 +235,7 @@ EOF;
 
     public function testConfirmMediaTypeAcceptsJsonSchemaType()
     {
-        $uriRetriever = $this->getMock('JsonSchema\Uri\Retrievers\UriRetrieverInterface', array('getContentType'));
+        $uriRetriever = $this->getMock('JsonSchema\Uri\Retrievers\UriRetrieverInterface');
         $retriever = new UriRetriever();
 
         $uriRetriever->expects($this->at(0))
@@ -247,7 +247,7 @@ EOF;
 
     public function testConfirmMediaTypeAcceptsJsonType()
     {
-        $uriRetriever = $this->getMock('JsonSchema\Uri\Retrievers\UriRetrieverInterface', array('getContentType'));
+        $uriRetriever = $this->getMock('JsonSchema\Uri\Retrievers\UriRetrieverInterface');
         $retriever = new UriRetriever();
 
         $uriRetriever->expects($this->at(0))
@@ -262,7 +262,7 @@ EOF;
      */
     public function testConfirmMediaTypeThrowsExceptionForUnsupportedTypes()
     {
-        $uriRetriever = $this->getMock('JsonSchema\Uri\Retrievers\UriRetrieverInterface', array('getContentType'));
+        $uriRetriever = $this->getMock('JsonSchema\Uri\Retrievers\UriRetrieverInterface');
         $retriever = new UriRetriever();
 
         $uriRetriever->expects($this->at(0))
@@ -335,7 +335,7 @@ EOF;
 
     public function testInvalidContentTypeEndpointsDefault()
     {
-        $mock = $this->getMock('JsonSchema\Uri\Retrievers\UriRetrieverInterface', array('getContentType'));
+        $mock = $this->getMock('JsonSchema\Uri\Retrievers\UriRetrieverInterface');
         $mock->method('getContentType')->willReturn('Application/X-Fake-Type');
         $retriever = new UriRetriever();
 
@@ -348,7 +348,7 @@ EOF;
      */
     public function testInvalidContentTypeEndpointsUnknown()
     {
-        $mock = $this->getMock('JsonSchema\Uri\Retrievers\UriRetrieverInterface', array('getContentType'));
+        $mock = $this->getMock('JsonSchema\Uri\Retrievers\UriRetrieverInterface');
         $mock->method('getContentType')->willReturn('Application/X-Fake-Type');
         $retriever = new UriRetriever();
 
@@ -357,7 +357,7 @@ EOF;
 
     public function testInvalidContentTypeEndpointsAdded()
     {
-        $mock = $this->getMock('JsonSchema\Uri\Retrievers\UriRetrieverInterface', array('getContentType'));
+        $mock = $this->getMock('JsonSchema\Uri\Retrievers\UriRetrieverInterface');
         $mock->method('getContentType')->willReturn('Application/X-Fake-Type');
         $retriever = new UriRetriever();
         $retriever->addInvalidContentTypeEndpoint('http://example.com');


### PR DESCRIPTION
During the upgrade path to raise the minimum level of PHP it was found that the 'JsonSchema\Tests\Uri\UriRetrieverTest` had incorrectly configured mocks. 
The `UriRetrieverTest::confirmMediaType()` requires a `JsonSchema\Uri\Retrievers\UriRetrieverInterface` and not an instance of itself.
This test corrects them.