### PR TITLE
Add missing property in uri resolver test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Correct misconfigured mocks in JsonSchema\Tests\Uri\UriRetrieverTest ([#741](https://github.com/jsonrainbow/json-schema/pull/741))
 - Fix pugx badges in README ([#742](https://github.com/jsonrainbow/json-schema/pull/742))
+- Add missing property in UriResolverTest ([#743](https://github.com/jsonrainbow/json-schema/pull/743))
 
 ## [6.0.0] - 2024-07-30
 ### Added

--- a/tests/Uri/UriResolverTest.php
+++ b/tests/Uri/UriResolverTest.php
@@ -7,6 +7,8 @@ use PHPUnit\Framework\TestCase;
 
 class UriResolverTest extends TestCase
 {
+    private $resolver;
+
     public function setUp()
     {
         $this->resolver = new UriResolver();


### PR DESCRIPTION
This PR adds a missing property definition in the UriResolverTest. This missing definition was found while trying to add PHP 8.0 and greater to the GHA workflows.