### PR TITLE
Extend pipeline for newer versions php

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -26,7 +26,10 @@ jobs:
           - "7.2"
           - "7.3"
           - "7.4"
-#          - "8.0"
+          - "8.0"
+          - "8.1"
+          - "8.2"
+          - "8.3"
         dependencies: [highest]
         experimental: [false]
         include:

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -17,12 +17,6 @@ jobs:
     strategy:
       matrix:
         php-version:
-          - "5.3"
-          - "5.4"
-          - "5.5"
-          - "5.6"
-          - "7.0"
-          - "7.1"
           - "7.2"
           - "7.3"
           - "7.4"
@@ -33,10 +27,10 @@ jobs:
         dependencies: [highest]
         experimental: [false]
         include:
-          - php-version: "5.3"
+          - php-version: "7.2"
             dependencies: highest
             experimental: false
-          - php-version: "5.3"
+          - php-version: "7.2"
             dependencies: lowest
             experimental: false
 #          - php-version: "8.0"

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       matrix:
         php-version:
-          - "5.3"
+          - "7.2"
           - "latest"
 
     steps:

--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
     "require": {
         "php": "^7.2 || ^8.0",
         "marc-mabe/php-enum":"^2.0 || ^3.0 || ^4.0",
-        "icecave/parity": "1.0.0"
+        "icecave/parity": "^3.0"
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "~2.2.20 || ~2.19.0",

--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,8 @@
     "require-dev": {
         "friendsofphp/php-cs-fixer": "~2.2.20 || ~2.19.0",
         "json-schema/json-schema-test-suite": "1.2.0",
-        "phpunit/phpunit": "^8.5"
+        "phpunit/phpunit": "^8.5",
+        "phpspec/prophecy": "^1.19"
     },
     "extra": {
         "branch-alias": {

--- a/composer.json
+++ b/composer.json
@@ -73,7 +73,7 @@
         "coverage": "phpunit --coverage-text",
         "style-check": "php-cs-fixer fix --dry-run --verbose --diff",
         "style-fix": "php-cs-fixer fix --verbose",
-        "test": "phpunit",
+        "test": "phpunit --verbose",
         "testOnly": "phpunit --colors --filter"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,7 @@
     "require-dev": {
         "friendsofphp/php-cs-fixer": "~2.2.20 || ~2.19.0",
         "json-schema/json-schema-test-suite": "1.2.0",
-        "phpunit/phpunit": "^4.8.35"
+        "phpunit/phpunit": "^8.5"
     },
     "extra": {
         "branch-alias": {

--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
         }
     ],
     "require": {
-        "php": ">=5.3.3",
+        "php": "^7.2 || ^8.0",
         "marc-mabe/php-enum":"^2.0 || ^3.0 || ^4.0",
         "icecave/parity": "1.0.0"
     },

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<phpunit backupGlobals="false"
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
+         backupGlobals="false"
          backupStaticAttributes="false"
          colors="true"
          convertErrorsToExceptions="true"
@@ -8,7 +10,6 @@
          convertWarningsToExceptions="true"
          processIsolation="false"
          stopOnFailure="false"
-         syntaxCheck="false"
          bootstrap="vendor/autoload.php"
          verbose="true"
 >

--- a/src/JsonSchema/Iterator/ObjectIterator.php
+++ b/src/JsonSchema/Iterator/ObjectIterator.php
@@ -39,6 +39,7 @@ class ObjectIterator implements \Iterator, \Countable
     /**
      * {@inheritdoc}
      */
+    #[\ReturnTypeWillChange]
     public function current()
     {
         $this->initialize();
@@ -49,7 +50,7 @@ class ObjectIterator implements \Iterator, \Countable
     /**
      * {@inheritdoc}
      */
-    public function next()
+    public function next(): void
     {
         $this->initialize();
         $this->position++;
@@ -58,7 +59,7 @@ class ObjectIterator implements \Iterator, \Countable
     /**
      * {@inheritdoc}
      */
-    public function key()
+    public function key(): int
     {
         $this->initialize();
 
@@ -68,7 +69,7 @@ class ObjectIterator implements \Iterator, \Countable
     /**
      * {@inheritdoc}
      */
-    public function valid()
+    public function valid(): bool
     {
         $this->initialize();
 
@@ -78,7 +79,7 @@ class ObjectIterator implements \Iterator, \Countable
     /**
      * {@inheritdoc}
      */
-    public function rewind()
+    public function rewind(): void
     {
         $this->initialize();
         $this->position = 0;
@@ -87,7 +88,7 @@ class ObjectIterator implements \Iterator, \Countable
     /**
      * {@inheritdoc}
      */
-    public function count()
+    public function count(): int
     {
         $this->initialize();
 

--- a/src/JsonSchema/Uri/UriResolver.php
+++ b/src/JsonSchema/Uri/UriResolver.php
@@ -28,7 +28,7 @@ class UriResolver implements UriResolverInterface
      */
     public function parse($uri)
     {
-        preg_match('|^(([^:/?#]+):)?(//([^/?#]*))?([^?#]*)(\?([^#]*))?(#(.*))?|', $uri, $match);
+        preg_match('|^(([^:/?#]+):)?(//([^/?#]*))?([^?#]*)(\?([^#]*))?(#(.*))?|', $uri ?: '', $match);
 
         $components = array();
         if (5 < count($match)) {

--- a/src/JsonSchema/Uri/UriRetriever.php
+++ b/src/JsonSchema/Uri/UriRetriever.php
@@ -84,7 +84,7 @@ class UriRetriever implements BaseUriRetrieverInterface
         }
 
         foreach ($this->allowedInvalidContentTypeEndpoints as $endpoint) {
-            if (strpos($uri, $endpoint) === 0) {
+            if (!\is_null($uri) && strpos($uri, $endpoint) === 0) {
                 return true;
             }
         }

--- a/tests/ConstraintErrorTest.php
+++ b/tests/ConstraintErrorTest.php
@@ -24,10 +24,9 @@ class ConstraintErrorTest extends TestCase
     {
         $e = ConstraintError::MISSING_ERROR();
 
-        $this->setExpectedException(
-            '\JsonSchema\Exception\InvalidArgumentException',
-            'Missing error message for missingError'
-        );
+        $this->expectException('\JsonSchema\Exception\InvalidArgumentException');
+        $this->expectExceptionMessage('Missing error message for missingError');
+
         $e->getMessage();
     }
 }

--- a/tests/Constraints/CoerciveTest.php
+++ b/tests/Constraints/CoerciveTest.php
@@ -18,7 +18,7 @@ class CoerciveTest extends VeryBaseTestCase
 {
     protected $factory = null;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->factory = new Factory();
         $this->factory->setConfig(Constraint::CHECK_MODE_TYPE_CAST | Constraint::CHECK_MODE_COERCE_TYPES);

--- a/tests/Constraints/FactoryTest.php
+++ b/tests/Constraints/FactoryTest.php
@@ -42,7 +42,7 @@ class FactoryTest extends TestCase
      */
     protected $factory;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->factory = new Factory();
     }

--- a/tests/Constraints/FactoryTest.php
+++ b/tests/Constraints/FactoryTest.php
@@ -85,7 +85,7 @@ class FactoryTest extends TestCase
      */
     public function testExceptionWhenCreateInstanceForInvalidConstraintName($constraintName)
     {
-        $this->setExpectedException('JsonSchema\Exception\InvalidArgumentException');
+        $this->expectException('JsonSchema\Exception\InvalidArgumentException');
         $this->factory->createInstanceFor($constraintName);
     }
 

--- a/tests/Constraints/FactoryTest.php
+++ b/tests/Constraints/FactoryTest.php
@@ -96,19 +96,17 @@ class FactoryTest extends TestCase
         );
     }
 
-    /**
-     * @expectedException \JsonSchema\Exception\InvalidArgumentException
-     */
     public function testSetConstraintClassExistsCondition()
     {
+        $this->expectException(\JsonSchema\Exception\InvalidArgumentException::class);
+
         $this->factory->setConstraintClass('string', 'SomeConstraint');
     }
 
-    /**
-     * @expectedException \JsonSchema\Exception\InvalidArgumentException
-     */
     public function testSetConstraintClassImplementsCondition()
     {
+        $this->expectException(\JsonSchema\Exception\InvalidArgumentException::class);
+
         $this->factory->setConstraintClass('string', 'JsonSchema\Tests\Constraints\MyBadConstraint');
     }
 

--- a/tests/Constraints/FormatTest.php
+++ b/tests/Constraints/FormatTest.php
@@ -17,7 +17,7 @@ class FormatTest extends BaseTestCase
 {
     protected $validateSchema = true;
 
-    public function setUp()
+    public function setUp(): void
     {
         date_default_timezone_set('UTC');
     }

--- a/tests/Constraints/MinLengthMaxLengthMultiByteTest.php
+++ b/tests/Constraints/MinLengthMaxLengthMultiByteTest.php
@@ -13,7 +13,7 @@ class MinLengthMaxLengthMultiByteTest extends BaseTestCase
 {
     protected $validateSchema = true;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         if (!extension_loaded('mbstring')) {
             $this->markTestSkipped('mbstring extension is not available');

--- a/tests/Constraints/SchemaValidationTest.php
+++ b/tests/Constraints/SchemaValidationTest.php
@@ -102,19 +102,16 @@ class SchemaValidationTest extends TestCase
 
     public function testNonObjectSchema()
     {
-        $this->setExpectedException(
-            '\JsonSchema\Exception\RuntimeException',
-            'Cannot validate the schema of a non-object'
-        );
+        $this->expectException('\JsonSchema\Exception\RuntimeException');
+        $this->expectExceptionMessage('Cannot validate the schema of a non-object');
+
         $this->testValidCases('"notAnObject"');
     }
 
     public function testInvalidSchemaException()
     {
-        $this->setExpectedException(
-            '\JsonSchema\Exception\InvalidSchemaException',
-            'Schema did not pass validation'
-        );
+        $this->expectException('\JsonSchema\Exception\InvalidSchemaException');
+        $this->expectExceptionMessage('Schema did not pass validation');
 
         $input = json_decode('{}');
         $schema = json_decode('{"properties":{"propertyOne":{"type":"string","required":true}}}');

--- a/tests/Constraints/SelfDefinedSchemaTest.php
+++ b/tests/Constraints/SelfDefinedSchemaTest.php
@@ -74,7 +74,7 @@ class SelfDefinedSchemaTest extends BaseTestCase
 
         $v = new Validator();
 
-        $this->setExpectedException('\JsonSchema\Exception\InvalidArgumentException');
+        $this->expectException('\JsonSchema\Exception\InvalidArgumentException');
 
         $v->validate($value, $schema);
     }

--- a/tests/Constraints/TypeTest.php
+++ b/tests/Constraints/TypeTest.php
@@ -80,7 +80,7 @@ class TypeTest extends TestCase
 
         $actualError = $actualErrors[0];
 
-        $this->assertInternalType('array', $actualError, sprintf('Failed to assert that Type error is an array, %s given', gettype($actualError)));
+        $this->assertIsArray($actualError, sprintf('Failed to assert that Type error is an array, %s given', gettype($actualError)));
 
         $messageKey = 'message';
         $this->assertArrayHasKey(

--- a/tests/Constraints/TypeTest.php
+++ b/tests/Constraints/TypeTest.php
@@ -116,6 +116,7 @@ class TypeTest extends TestCase
         $m->setAccessible(true);
 
         $m->invoke($t, $nameWording);
+        $this->expectNotToPerformAssertions();
     }
 
     public function testInvalidateTypeNameWording()

--- a/tests/Constraints/TypeTest.php
+++ b/tests/Constraints/TypeTest.php
@@ -125,10 +125,9 @@ class TypeTest extends TestCase
         $m = $r->getMethod('validateTypeNameWording');
         $m->setAccessible(true);
 
-        $this->setExpectedException(
-            '\UnexpectedValueException',
-            "No wording for 'notAValidTypeName' available, expected wordings are: [an integer, a number, a boolean, an object, an array, a string, a null]"
-        );
+        $this->expectException('\UnexpectedValueException');
+        $this->expectExceptionMessage("No wording for 'notAValidTypeName' available, expected wordings are: [an integer, a number, a boolean, an object, an array, a string, a null]");
+
         $m->invoke($t, 'notAValidTypeName');
     }
 
@@ -138,10 +137,9 @@ class TypeTest extends TestCase
         $data = new \stdClass();
         $schema = json_decode('{"type": "notAValidTypeName"}');
 
-        $this->setExpectedException(
-            'JsonSchema\Exception\InvalidArgumentException',
-            'object is an invalid type for notAValidTypeName'
-        );
+        $this->expectException('JsonSchema\Exception\InvalidArgumentException');
+        $this->expectExceptionMessage('object is an invalid type for notAValidTypeName');
+
         $t->check($data, $schema);
     }
 }

--- a/tests/Constraints/ValidationExceptionTest.php
+++ b/tests/Constraints/ValidationExceptionTest.php
@@ -45,7 +45,7 @@ class ValidationExceptionTest extends TestCase
             $exception->getMessage()
         );
 
-        $this->setExpectedException('JsonSchema\Exception\ValidationException');
+        $this->expectException('JsonSchema\Exception\ValidationException');
         throw $exception;
     }
 }

--- a/tests/Constraints/VeryBaseTestCase.php
+++ b/tests/Constraints/VeryBaseTestCase.php
@@ -30,7 +30,7 @@ abstract class VeryBaseTestCase extends TestCase
      */
     protected function getUriRetrieverMock($schema)
     {
-        $relativeTestsRoot = realpath(__DIR__ . '/../../vendor/json-schema/JSON-Schema-Test-Suite/remotes');
+        $relativeTestsRoot = realpath(__DIR__ . '/../../vendor/json-schema/json-schema-test-suite/remotes');
 
         $jsonSchemaDraft03 = $this->getJsonSchemaDraft03();
         $jsonSchemaDraft04 = $this->getJsonSchemaDraft04();

--- a/tests/Drafts/BaseDraftTestCase.php
+++ b/tests/Drafts/BaseDraftTestCase.php
@@ -10,7 +10,7 @@ use JsonSchema\Tests\Constraints\BaseTestCase;
 abstract class BaseDraftTestCase extends BaseTestCase
 {
     /** @var string */
-    protected $relativeTestsRoot = '/../../vendor/json-schema/JSON-Schema-Test-Suite/tests';
+    protected $relativeTestsRoot = '/../../vendor/json-schema/json-schema-test-suite/tests';
 
     private function setUpTests($isValid)
     {

--- a/tests/Entity/JsonPointerTest.php
+++ b/tests/Entity/JsonPointerTest.php
@@ -113,10 +113,9 @@ class JsonPointerTest extends TestCase
 
     public function testCreateWithInvalidValue()
     {
-        $this->setExpectedException(
-            '\JsonSchema\Exception\InvalidArgumentException',
-            'Ref value must be a string'
-        );
+        $this->expectException('\JsonSchema\Exception\InvalidArgumentException');
+        $this->expectExceptionMessage('Ref value must be a string');
+
         new JsonPointer(null);
     }
 }

--- a/tests/Iterators/ObjectIteratorTest.php
+++ b/tests/Iterators/ObjectIteratorTest.php
@@ -16,7 +16,7 @@ class ObjectIteratorTest extends TestCase
 {
     protected $testObject;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->testObject = (object) array(
             'subOne' => (object) array(

--- a/tests/RefTest.php
+++ b/tests/RefTest.php
@@ -69,7 +69,7 @@ class RefTest extends TestCase
 
         $v = new Validator();
         if ($exception) {
-            $this->setExpectedException($exception);
+            $this->expectException($exception);
         }
 
         $v->validate($document, $schema);

--- a/tests/SchemaStorageTest.php
+++ b/tests/SchemaStorageTest.php
@@ -102,10 +102,8 @@ class SchemaStorageTest extends TestCase
 
     public function testUnresolvableJsonPointExceptionShouldBeThrown()
     {
-        $this->setExpectedException(
-            'JsonSchema\Exception\UnresolvableJsonPointerException',
-            'File: http://www.example.com/schema.json is found, but could not resolve fragment: #/definitions/car'
-        );
+        $this->expectException('JsonSchema\Exception\UnresolvableJsonPointerException');
+        $this->expectExceptionMessage('File: http://www.example.com/schema.json is found, but could not resolve fragment: #/definitions/car');
 
         $mainSchema = $this->getInvalidSchema();
         $mainSchemaPath = 'http://www.example.com/schema.json';
@@ -121,10 +119,8 @@ class SchemaStorageTest extends TestCase
 
     public function testResolveRefWithNoAssociatedFileName()
     {
-        $this->setExpectedException(
-            'JsonSchema\Exception\UnresolvableJsonPointerException',
-            "Could not resolve fragment '#': no file is defined"
-        );
+        $this->expectException('JsonSchema\Exception\UnresolvableJsonPointerException');
+        $this->expectExceptionMessage("Could not resolve fragment '#': no file is defined");
 
         $schemaStorage = new SchemaStorage();
         $schemaStorage->resolveRef('#');

--- a/tests/Uri/Retrievers/CurlTest.php
+++ b/tests/Uri/Retrievers/CurlTest.php
@@ -17,10 +17,9 @@ namespace JsonSchema\Tests\Uri\Retrievers
         {
             $c = new Curl();
 
-            $this->setExpectedException(
-                '\JsonSchema\Exception\ResourceNotFoundException',
-                'JSON schema not found'
-            );
+            $this->expectException('\JsonSchema\Exception\ResourceNotFoundException');
+            $this->expectExceptionMessage('JSON schema not found');
+
             $c->retrieve(__DIR__ . '/notARealFile');
         }
 

--- a/tests/Uri/Retrievers/CurlTest.php
+++ b/tests/Uri/Retrievers/CurlTest.php
@@ -10,7 +10,9 @@ namespace JsonSchema\Tests\Uri\Retrievers
         public function testRetrieveFile()
         {
             $c = new Curl();
-            $c->retrieve(realpath(__DIR__ . '/../../fixtures/foobar.json'));
+            $result = $c->retrieve(realpath(__DIR__ . '/../../fixtures/foobar.json'));
+
+            self::assertStringEqualsFileCanonicalizing(realpath(__DIR__ . '/../../fixtures/foobar.json'), $result);
         }
 
         public function testRetrieveNonexistantFile()
@@ -26,7 +28,9 @@ namespace JsonSchema\Tests\Uri\Retrievers
         public function testNoContentType()
         {
             $c = new Curl();
-            $c->retrieve(realpath(__DIR__ . '/../../fixtures') . '/foobar-noheader.json');
+            $result = $c->retrieve(realpath(__DIR__ . '/../../fixtures') . '/foobar-noheader.json');
+
+            self::assertStringEqualsFileCanonicalizing(realpath(__DIR__ . '/../../fixtures/foobar.json'), $result);
         }
     }
 }

--- a/tests/Uri/Retrievers/FileGetContentsTest.php
+++ b/tests/Uri/Retrievers/FileGetContentsTest.php
@@ -10,12 +10,12 @@ use PHPUnit\Framework\TestCase;
  */
 class FileGetContentsTest extends TestCase
 {
-    /**
-     * @expectedException \JsonSchema\Exception\ResourceNotFoundException
-     */
     public function testFetchMissingFile()
     {
         $res = new FileGetContents();
+
+        $this->expectException(\JsonSchema\Exception\ResourceNotFoundException::class);
+
         $res->retrieve(__DIR__ . '/Fixture/missing.json');
     }
 

--- a/tests/Uri/Retrievers/PredefinedArrayTest.php
+++ b/tests/Uri/Retrievers/PredefinedArrayTest.php
@@ -12,7 +12,7 @@ class PredefinedArrayTest extends TestCase
 {
     private $retriever;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->retriever = new PredefinedArray(
             array(

--- a/tests/Uri/Retrievers/PredefinedArrayTest.php
+++ b/tests/Uri/Retrievers/PredefinedArrayTest.php
@@ -29,11 +29,9 @@ class PredefinedArrayTest extends TestCase
         $this->assertEquals('THE_ADDRESS_SCHEMA', $this->retriever->retrieve('http://acme.com/schemas/address#'));
     }
 
-    /**
-     * @expectedException \JsonSchema\Exception\ResourceNotFoundException
-     */
     public function testRetrieveNonExistsingSchema()
     {
+        $this->expectException(\JsonSchema\Exception\ResourceNotFoundException::class);
         $this->retriever->retrieve('http://acme.com/schemas/plop#');
     }
 

--- a/tests/Uri/UriResolverTest.php
+++ b/tests/Uri/UriResolverTest.php
@@ -96,7 +96,6 @@ class UriResolverTest extends TestCase
         );
     }
 
-
     public function testResolveRelativeUriNoBase()
     {
         $this->expectException(\JsonSchema\Exception\UriResolverException::class);

--- a/tests/Uri/UriResolverTest.php
+++ b/tests/Uri/UriResolverTest.php
@@ -9,7 +9,7 @@ class UriResolverTest extends TestCase
 {
     private $resolver;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->resolver = new UriResolver();
     }

--- a/tests/Uri/UriResolverTest.php
+++ b/tests/Uri/UriResolverTest.php
@@ -96,18 +96,11 @@ class UriResolverTest extends TestCase
         );
     }
 
-    /**
-     * @expectedException \JsonSchema\Exception\UriResolverException
-     */
+
     public function testResolveRelativeUriNoBase()
     {
-        $this->assertEquals(
-            'http://example.org/foo/bar.json',
-            $this->resolver->resolve(
-                'bar.json',
-                null
-            )
-        );
+        $this->expectException(\JsonSchema\Exception\UriResolverException::class);
+        $this->resolver->resolve('bar.json', null);
     }
 
     public function testResolveRelativeUriBaseDir()

--- a/tests/Uri/UriRetrieverTest.php
+++ b/tests/Uri/UriRetrieverTest.php
@@ -358,7 +358,9 @@ EOF;
         $retriever = new UriRetriever();
         $retriever->addInvalidContentTypeEndpoint('http://example.com');
 
-        $retriever->confirmMediaType($mock, 'http://example.com');
+        $result = $retriever->confirmMediaType($mock, 'http://example.com');
+
+        self::assertTrue($result);
     }
 
     public function testSchemaCache()

--- a/tests/Uri/UriRetrieverTest.php
+++ b/tests/Uri/UriRetrieverTest.php
@@ -9,7 +9,10 @@
 
 namespace JsonSchema\Tests\Uri;
 
+use JsonSchema\Exception\InvalidSchemaMediaTypeException;
 use JsonSchema\Exception\JsonDecodingException;
+use JsonSchema\Exception\ResourceNotFoundException;
+use JsonSchema\Exception\UriResolverException;
 use JsonSchema\Uri\UriRetriever;
 use JsonSchema\Validator;
 use PHPUnit\Framework\TestCase;
@@ -34,7 +37,7 @@ class UriRetrieverTest extends TestCase
             throw new JsonDecodingException($error);
         }
 
-        $retriever = $this->getMock('JsonSchema\Uri\UriRetriever', array('retrieve'));
+        $retriever = $this->createMock('JsonSchema\Uri\UriRetriever');
 
         $retriever->expects($this->at(0))
                   ->method('retrieve')
@@ -232,7 +235,7 @@ EOF;
 
     public function testConfirmMediaTypeAcceptsJsonSchemaType()
     {
-        $uriRetriever = $this->getMock('JsonSchema\Uri\Retrievers\UriRetrieverInterface');
+        $uriRetriever = $this->createMock('JsonSchema\Uri\Retrievers\UriRetrieverInterface');
         $retriever = new UriRetriever();
 
         $uriRetriever->expects($this->at(0))
@@ -244,7 +247,7 @@ EOF;
 
     public function testConfirmMediaTypeAcceptsJsonType()
     {
-        $uriRetriever = $this->getMock('JsonSchema\Uri\Retrievers\UriRetrieverInterface');
+        $uriRetriever = $this->createMock('JsonSchema\Uri\Retrievers\UriRetrieverInterface');
         $retriever = new UriRetriever();
 
         $uriRetriever->expects($this->at(0))
@@ -256,9 +259,8 @@ EOF;
 
     public function testConfirmMediaTypeThrowsExceptionForUnsupportedTypes()
     {
-        $uriRetriever = $this->getMock('JsonSchema\Uri\Retrievers\UriRetrieverInterface');
+        $uriRetriever = $this->createMock('JsonSchema\Uri\Retrievers\UriRetrieverInterface');
         $retriever = new UriRetriever();
-
         $uriRetriever->expects($this->at(0))
                 ->method('getContentType')
                 ->willReturn('text/html');
@@ -331,7 +333,7 @@ EOF;
 
     public function testInvalidContentTypeEndpointsDefault()
     {
-        $mock = $this->getMock('JsonSchema\Uri\Retrievers\UriRetrieverInterface');
+        $mock = $this->createMock('JsonSchema\Uri\Retrievers\UriRetrieverInterface');
         $mock->method('getContentType')->willReturn('Application/X-Fake-Type');
         $retriever = new UriRetriever();
 
@@ -341,7 +343,7 @@ EOF;
 
     public function testInvalidContentTypeEndpointsUnknown()
     {
-        $mock = $this->getMock('JsonSchema\Uri\Retrievers\UriRetrieverInterface');
+        $mock = $this->createMock('JsonSchema\Uri\Retrievers\UriRetrieverInterface');
         $mock->method('getContentType')->willReturn('Application/X-Fake-Type');
         $retriever = new UriRetriever();
 
@@ -351,7 +353,7 @@ EOF;
 
     public function testInvalidContentTypeEndpointsAdded()
     {
-        $mock = $this->getMock('JsonSchema\Uri\Retrievers\UriRetrieverInterface');
+        $mock = $this->createMock('JsonSchema\Uri\Retrievers\UriRetrieverInterface');
         $mock->method('getContentType')->willReturn('Application/X-Fake-Type');
         $retriever = new UriRetriever();
         $retriever->addInvalidContentTypeEndpoint('http://example.com');

--- a/tests/Uri/UriRetrieverTest.php
+++ b/tests/Uri/UriRetrieverTest.php
@@ -388,10 +388,9 @@ EOF;
     {
         $retriever = new UriRetriever();
 
-        $this->setExpectedException(
-            'JsonSchema\Exception\JsonDecodingException',
-            'JSON syntax is malformed'
-        );
+        $this->expectException('JsonSchema\Exception\JsonDecodingException');
+        $this->expectExceptionMessage('JSON syntax is malformed');
+
         $retriever->retrieve('package://tests/fixtures/bad-syntax.json');
     }
 

--- a/tests/Uri/UriRetrieverTest.php
+++ b/tests/Uri/UriRetrieverTest.php
@@ -300,7 +300,7 @@ EOF;
         $root = sprintf('file://%s/', realpath(__DIR__ . '/../..'));
 
         $uri = $retriever->translate('package://foo/bar.json');
-        $this->assertEquals("${root}foo/bar.json", $uri);
+        $this->assertEquals("{$root}foo/bar.json", $uri);
     }
 
     public function testDefaultDistTranslations()

--- a/tests/Uri/UriRetrieverTest.php
+++ b/tests/Uri/UriRetrieverTest.php
@@ -21,7 +21,7 @@ class UriRetrieverTest extends TestCase
 {
     protected $validator;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->validator = new Validator();
     }

--- a/tests/Uri/UriRetrieverTest.php
+++ b/tests/Uri/UriRetrieverTest.php
@@ -182,9 +182,6 @@ EOF;
         );
     }
 
-    /**
-     * @expectedException \JsonSchema\Exception\ResourceNotFoundException
-     */
     public function testResolvePointerFragmentNotFound()
     {
         $schema = (object) array(
@@ -197,14 +194,13 @@ EOF;
         );
 
         $retriever = new UriRetriever();
+
+        $this->expectException(ResourceNotFoundException::class);
         $retriever->resolvePointer(
             $schema, 'http://example.org/schema.json#/definitions/bar'
         );
     }
 
-    /**
-     * @expectedException \JsonSchema\Exception\ResourceNotFoundException
-     */
     public function testResolvePointerFragmentNoArray()
     {
         $schema = (object) array(
@@ -217,17 +213,18 @@ EOF;
         );
 
         $retriever = new UriRetriever();
+
+        $this->expectException(ResourceNotFoundException::class);
         $retriever->resolvePointer(
             $schema, 'http://example.org/schema.json#/definitions/foo'
         );
     }
 
-    /**
-     * @expectedException \JsonSchema\Exception\UriResolverException
-     */
     public function testResolveExcessLevelUp()
     {
         $retriever = new UriRetriever();
+
+        $this->expectException(UriResolverException::class);
         $retriever->resolve(
             '../schema.json#', 'http://example.org/schema.json#'
         );
@@ -257,9 +254,6 @@ EOF;
         $this->assertEquals(null, $retriever->confirmMediaType($uriRetriever, null));
     }
 
-    /**
-     * @expectedException \JsonSchema\Exception\InvalidSchemaMediaTypeException
-     */
     public function testConfirmMediaTypeThrowsExceptionForUnsupportedTypes()
     {
         $uriRetriever = $this->getMock('JsonSchema\Uri\Retrievers\UriRetrieverInterface');
@@ -269,7 +263,9 @@ EOF;
                 ->method('getContentType')
                 ->willReturn('text/html');
 
-        $this->assertEquals(null, $retriever->confirmMediaType($uriRetriever, null));
+        $this->expectException(InvalidSchemaMediaTypeException::class);
+
+        $retriever->confirmMediaType($uriRetriever, null);
     }
 
     private function mockRetriever($schema)
@@ -343,15 +339,13 @@ EOF;
         $this->assertTrue($retriever->confirmMediaType($mock, 'https://json-schema.org/'));
     }
 
-    /**
-     * @expectedException \JsonSchema\Exception\InvalidSchemaMediaTypeException
-     */
     public function testInvalidContentTypeEndpointsUnknown()
     {
         $mock = $this->getMock('JsonSchema\Uri\Retrievers\UriRetrieverInterface');
         $mock->method('getContentType')->willReturn('Application/X-Fake-Type');
         $retriever = new UriRetriever();
 
+        $this->expectException(InvalidSchemaMediaTypeException::class);
         $retriever->confirmMediaType($mock, 'http://example.com');
     }
 

--- a/tests/ValidatorTest.php
+++ b/tests/ValidatorTest.php
@@ -31,7 +31,7 @@ class ValidatorTest extends TestCase
 
         $validator = new Validator();
 
-        $this->setExpectedException('\JsonSchema\Exception\InvalidArgumentException');
+        $this->expectException('\JsonSchema\Exception\InvalidArgumentException');
         $validator->validate($data, $schema);
     }
 


### PR DESCRIPTION
This PR updates the pipeline to include PHP >= 8.0 and no longer include PHP <= 7.1. In addition the PR contains the following changes to have green results.
- Update to PHPUnit 8.5 to resolve invocations of deprecated/removed method `each()`, see https://www.php.net/manual/en/function.each.php. Which resulted in:
  - Add `void` return types to `::setup()` methods
  - Explicitly include `phpspec/prophecy`
  - Replace `::setExpectedException()` and `@ExpectedException` for `::expectException`
  - Replace `::assertInternalType()` with `assertIs*()`  methods
  - Replace `::getMock()` with `::createMock()`
- Improve test assertions in case of warning or error during test run.
- Port #682 to fix deprecations from `ObjectIterator`
- Update `icecave/parity` to `^3,0` to resolve invocations of deprecated/removed method `each()`
- Correct styles reported by GHA [workflow](https://github.com/jsonrainbow/json-schema/blob/master/.github/workflows/style-check.yml)