### PR TITLE
test: Correct casing of paths used in tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Correct misconfigured mocks in JsonSchema\Tests\Uri\UriRetrieverTest ([#741](https://github.com/jsonrainbow/json-schema/pull/741))
 - Fix pugx badges in README ([#742](https://github.com/jsonrainbow/json-schema/pull/742))
 - Add missing property in UriResolverTest ([#743](https://github.com/jsonrainbow/json-schema/pull/743))
+- Correct casing of paths used in tests ([#745](https://github.com/jsonrainbow/json-schema/pull/745))
 
 ## [6.0.0] - 2024-07-30
 ### Added

--- a/tests/Constraints/VeryBaseTestCase.php
+++ b/tests/Constraints/VeryBaseTestCase.php
@@ -30,7 +30,7 @@ abstract class VeryBaseTestCase extends TestCase
      */
     protected function getUriRetrieverMock($schema)
     {
-        $relativeTestsRoot = realpath(__DIR__ . '/../../vendor/json-schema/JSON-Schema-Test-Suite/remotes');
+        $relativeTestsRoot = realpath(__DIR__ . '/../../vendor/json-schema/json-schema-test-suite/remotes');
 
         $jsonSchemaDraft03 = $this->getJsonSchemaDraft03();
         $jsonSchemaDraft04 = $this->getJsonSchemaDraft04();

--- a/tests/Drafts/BaseDraftTestCase.php
+++ b/tests/Drafts/BaseDraftTestCase.php
@@ -10,7 +10,7 @@ use JsonSchema\Tests\Constraints\BaseTestCase;
 abstract class BaseDraftTestCase extends BaseTestCase
 {
     /** @var string */
-    protected $relativeTestsRoot = '/../../vendor/json-schema/JSON-Schema-Test-Suite/tests';
+    protected $relativeTestsRoot = '/../../vendor/json-schema/json-schema-test-suite/tests';
 
     private function setUpTests($isValid)
     {


### PR DESCRIPTION
During development I noticed the number of test differed between my local runs (on a Mac Book with case insensitive volume) and the runs in the CI/CD (1969 vs. 961).

The root cause was to be in the paths mentioned in the tests to not be correct in terms of casing. This PR addresses this difference.