### PR TITLE
refactor: Replace traditional syntax array with short syntax array

### DIFF
--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -6,14 +6,14 @@ $finder->in(__DIR__);
 
 /* Based on ^2.1 of php-cs-fixer */
 $config
-    ->setRules(array(
+    ->setRules([
         // default
         '@PSR2' => true,
         '@Symfony' => true,
         // additionally
-        'array_syntax' => array('syntax' => 'long'),
+        'array_syntax' => ['syntax' => 'short'],
         'binary_operator_spaces' => false,
-        'concat_space' => array('spacing' => 'one'),
+        'concat_space' => ['spacing' => 'one'],
         'increment_style' => false,
         'no_superfluous_phpdoc_tags' => false,
         'no_useless_else' => true,
@@ -22,12 +22,12 @@ $config
         'phpdoc_no_package' => false,
         'phpdoc_order' => true,
         'phpdoc_summary' => false,
-        'phpdoc_types_order' => array('null_adjustment' => 'none', 'sort_algorithm' => 'none'),
+        'phpdoc_types_order' => ['null_adjustment' => 'none', 'sort_algorithm' => 'none'],
         'simplified_null_return' => false,
         'single_line_throw' => false,
         'trailing_comma_in_multiline' => false,
         'yoda_style' => false,
-    ))
+    ])
     ->setFinder($finder)
 ;
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add missing property in UriResolverTest ([#743](https://github.com/jsonrainbow/json-schema/pull/743))
 - Correct casing of paths used in tests ([#745](https://github.com/jsonrainbow/json-schema/pull/745))
 
+### Changed
+- Bump to minimum PHP 7.2 ([#746](https://github.com/jsonrainbow/json-schema/pull/746))
+- Replace traditional syntax array with short syntax array ([#747](https://github.com/jsonrainbow/json-schema/pull/747))
+
 ## [6.0.0] - 2024-07-30
 ### Added
 - Add URI translation, package:// URI scheme & bundle spec schemas ([#362](https://github.com/jsonrainbow/json-schema/pull/362))

--- a/bin/validate-json
+++ b/bin/validate-json
@@ -20,8 +20,8 @@ if (!$composerAutoload) {
 }
 require($composerAutoload);
 
-$arOptions = array();
-$arArgs = array();
+$arOptions = [];
+$arArgs = [];
 array_shift($argv);//script itself
 foreach ($argv as $arg) {
     if ($arg[0] == '-') {
@@ -66,7 +66,7 @@ if (count($arArgs) == 1) {
 function showJsonError()
 {
     $constants = get_defined_constants(true);
-    $json_errors = array();
+    $json_errors = [];
     foreach ($constants['json'] as $name => $value) {
         if (!strncmp($name, 'JSON_ERROR_', 11)) {
             $json_errors[$value] = $name;
@@ -101,11 +101,11 @@ function getUrlFromPath($path)
 function parseHeaderValue($headerValue)
 {
     if (strpos($headerValue, ';') === false) {
-        return array('_value' => $headerValue);
+        return ['_value' => $headerValue];
     }
 
     $parts = explode(';', $headerValue);
-    $arData = array('_value' => array_shift($parts));
+    $arData = ['_value' => array_shift($parts)];
     foreach ($parts as $part) {
         list($name, $value) = explode('=', $part);
         $arData[$name] = trim($value, ' "\'');
@@ -128,15 +128,15 @@ function output($str) {
 $urlData = getUrlFromPath($pathData);
 
 $context = stream_context_create(
-    array(
-        'http' => array(
-            'header'        => array(
+    [
+        'http' => [
+            'header'        => [
                 'Accept: */*',
                 'Connection: Close'
-            ),
+            ],
             'max_redirects' => 5
-        )
-    )
+        ]
+    ]
 );
 $dataString = file_get_contents($pathData, false, $context);
 if ($dataString == '') {

--- a/demo/demo.php
+++ b/demo/demo.php
@@ -6,7 +6,7 @@ $data = json_decode(file_get_contents('data.json'));
 
 // Validate
 $validator = new JsonSchema\Validator();
-$validator->validate($data, (object) array('$ref' => 'file://' . realpath('schema.json')));
+$validator->validate($data, (object) ['$ref' => 'file://' . realpath('schema.json')]);
 
 if ($validator->isValid()) {
     echo "The supplied JSON validates against the schema.\n";

--- a/src/JsonSchema/ConstraintError.php
+++ b/src/JsonSchema/ConstraintError.php
@@ -55,7 +55,7 @@ class ConstraintError extends Enum
     public function getMessage()
     {
         $name = $this->getValue();
-        static $messages = array(
+        static $messages = [
             self::ADDITIONAL_ITEMS => 'The item %s[%s] is not defined and the definition does not allow additional items',
             self::ADDITIONAL_PROPERTIES => 'The property %s is not defined and the definition does not allow additional properties',
             self::ALL_OF => 'Failed to match all schemas',
@@ -101,7 +101,7 @@ class ConstraintError extends Enum
             self::PROPERTIES_MAX => 'Must contain no more than %d properties',
             self::TYPE => '%s value found, but %s is required',
             self::UNIQUE_ITEMS => 'There are no duplicates allowed in the array'
-        );
+        ];
 
         if (!isset($messages[$name])) {
             throw new InvalidArgumentException('Missing error message for ' . $name);

--- a/src/JsonSchema/Constraints/BaseConstraint.php
+++ b/src/JsonSchema/Constraints/BaseConstraint.php
@@ -24,7 +24,7 @@ class BaseConstraint
     /**
      * @var array Errors
      */
-    protected $errors = array();
+    protected $errors = [];
 
     /**
      * @var int All error types which have occurred
@@ -44,11 +44,11 @@ class BaseConstraint
         $this->factory = $factory ?: new Factory();
     }
 
-    public function addError(ConstraintError $constraint, ?JsonPointer $path = null, array $more = array())
+    public function addError(ConstraintError $constraint, ?JsonPointer $path = null, array $more = [])
     {
         $message = $constraint ? $constraint->getMessage() : '';
         $name = $constraint ? $constraint->getValue() : '';
-        $error = array(
+        $error = [
             'property' => $this->convertJsonPointerIntoPropertyPath($path ?: new JsonPointer('')),
             'pointer' => ltrim(strval($path ?: new JsonPointer('')), '#'),
             'message' => ucfirst(vsprintf($message, array_map(function ($val) {
@@ -58,12 +58,12 @@ class BaseConstraint
 
                 return json_encode($val);
             }, array_values($more)))),
-            'constraint' => array(
+            'constraint' => [
                 'name' => $name,
                 'params' => $more
-            ),
+            ],
             'context' => $this->factory->getErrorContext(),
-        );
+        ];
 
         if ($this->factory->getConfig(Constraint::CHECK_MODE_EXCEPTIONS)) {
             throw new ValidationException(sprintf('Error validating %s: %s', $error['pointer'], $error['message']));
@@ -119,7 +119,7 @@ class BaseConstraint
      */
     public function reset()
     {
-        $this->errors = array();
+        $this->errors = [];
         $this->errorMask = Validator::ERROR_NONE;
     }
 

--- a/src/JsonSchema/Constraints/CollectionConstraint.php
+++ b/src/JsonSchema/Constraints/CollectionConstraint.php
@@ -27,12 +27,12 @@ class CollectionConstraint extends Constraint
     {
         // Verify minItems
         if (isset($schema->minItems) && count($value) < $schema->minItems) {
-            $this->addError(ConstraintError::MIN_ITEMS(), $path, array('minItems' => $schema->minItems));
+            $this->addError(ConstraintError::MIN_ITEMS(), $path, ['minItems' => $schema->minItems]);
         }
 
         // Verify maxItems
         if (isset($schema->maxItems) && count($value) > $schema->maxItems) {
-            $this->addError(ConstraintError::MAX_ITEMS(), $path, array('maxItems' => $schema->maxItems));
+            $this->addError(ConstraintError::MAX_ITEMS(), $path, ['maxItems' => $schema->maxItems]);
         }
 
         // Verify uniqueItems
@@ -101,11 +101,11 @@ class CollectionConstraint extends Constraint
                             $this->addError(
                                 ConstraintError::ADDITIONAL_ITEMS(),
                                 $path,
-                                array(
+                                [
                                     'item' => $i,
                                     'property' => $k,
                                     'additionalItems' => $schema->additionalItems
-                                )
+                                ]
                             );
                         }
                     } else {

--- a/src/JsonSchema/Constraints/ConstConstraint.php
+++ b/src/JsonSchema/Constraints/ConstConstraint.php
@@ -44,6 +44,6 @@ class ConstConstraint extends Constraint
             return;
         }
 
-        $this->addError(ConstraintError::CONSTANT(), $path, array('const' => $schema->const));
+        $this->addError(ConstraintError::CONSTANT(), $path, ['const' => $schema->const]);
     }
 }

--- a/src/JsonSchema/Constraints/Constraint.php
+++ b/src/JsonSchema/Constraints/Constraint.php
@@ -51,7 +51,7 @@ abstract class Constraint extends BaseConstraint implements ConstraintInterface
         $path = $path->withPropertyPaths(
             array_merge(
                 $path->getPropertyPaths(),
-                array($i)
+                [$i]
             )
         );
 
@@ -85,7 +85,7 @@ abstract class Constraint extends BaseConstraint implements ConstraintInterface
      * @param mixed            $patternProperties
      */
     protected function checkObject(&$value, $schema = null, ?JsonPointer $path = null, $properties = null,
-        $additionalProperties = null, $patternProperties = null, $appliedDefaults = array())
+        $additionalProperties = null, $patternProperties = null, $appliedDefaults = [])
     {
         /** @var ObjectConstraint $validator */
         $validator = $this->factory->createInstanceFor('object');

--- a/src/JsonSchema/Constraints/ConstraintInterface.php
+++ b/src/JsonSchema/Constraints/ConstraintInterface.php
@@ -40,7 +40,7 @@ interface ConstraintInterface
      * @param JsonPointer|null $path
      * @param array            $more       more array elements to add to the error
      */
-    public function addError(ConstraintError $constraint, ?JsonPointer $path = null, array $more = array());
+    public function addError(ConstraintError $constraint, ?JsonPointer $path = null, array $more = []);
 
     /**
      * checks if the validator has not raised errors

--- a/src/JsonSchema/Constraints/EnumConstraint.php
+++ b/src/JsonSchema/Constraints/EnumConstraint.php
@@ -47,6 +47,6 @@ class EnumConstraint extends Constraint
             }
         }
 
-        $this->addError(ConstraintError::ENUM(), $path, array('enum' => $schema->enum));
+        $this->addError(ConstraintError::ENUM(), $path, ['enum' => $schema->enum]);
     }
 }

--- a/src/JsonSchema/Constraints/Factory.php
+++ b/src/JsonSchema/Constraints/Factory.php
@@ -39,7 +39,7 @@ class Factory
     /**
      * @var TypeCheck\TypeCheckInterface[]
      */
-    private $typeCheck = array();
+    private $typeCheck = [];
 
     /**
      * @var int Validation context
@@ -49,7 +49,7 @@ class Factory
     /**
      * @var array
      */
-    protected $constraintMap = array(
+    protected $constraintMap = [
         'array' => 'JsonSchema\Constraints\CollectionConstraint',
         'collection' => 'JsonSchema\Constraints\CollectionConstraint',
         'object' => 'JsonSchema\Constraints\ObjectConstraint',
@@ -62,12 +62,12 @@ class Factory
         'format' => 'JsonSchema\Constraints\FormatConstraint',
         'schema' => 'JsonSchema\Constraints\SchemaConstraint',
         'validator' => 'JsonSchema\Validator'
-    );
+    ];
 
     /**
      * @var array<ConstraintInterface>
      */
-    private $instanceCache = array();
+    private $instanceCache = [];
 
     /**
      * @param ?SchemaStorage         $schemaStorage

--- a/src/JsonSchema/Constraints/FormatConstraint.php
+++ b/src/JsonSchema/Constraints/FormatConstraint.php
@@ -34,73 +34,73 @@ class FormatConstraint extends Constraint
         switch ($schema->format) {
             case 'date':
                 if (!$date = $this->validateDateTime($element, 'Y-m-d')) {
-                    $this->addError(ConstraintError::FORMAT_DATE(), $path, array(
+                    $this->addError(ConstraintError::FORMAT_DATE(), $path, [
                             'date' => $element,
                             'format' => $schema->format
-                        )
+                        ]
                     );
                 }
                 break;
 
             case 'time':
                 if (!$this->validateDateTime($element, 'H:i:s')) {
-                    $this->addError(ConstraintError::FORMAT_TIME(), $path, array(
+                    $this->addError(ConstraintError::FORMAT_TIME(), $path, [
                             'time' => json_encode($element),
                             'format' => $schema->format,
-                        )
+                        ]
                     );
                 }
                 break;
 
             case 'date-time':
                 if (null === Rfc3339::createFromString($element)) {
-                    $this->addError(ConstraintError::FORMAT_DATE_TIME(), $path, array(
+                    $this->addError(ConstraintError::FORMAT_DATE_TIME(), $path, [
                             'dateTime' => json_encode($element),
                             'format' => $schema->format
-                        )
+                        ]
                     );
                 }
                 break;
 
             case 'utc-millisec':
                 if (!$this->validateDateTime($element, 'U')) {
-                    $this->addError(ConstraintError::FORMAT_DATE_UTC(), $path, array(
+                    $this->addError(ConstraintError::FORMAT_DATE_UTC(), $path, [
                         'value' => $element,
-                        'format' => $schema->format));
+                        'format' => $schema->format]);
                 }
                 break;
 
             case 'regex':
                 if (!$this->validateRegex($element)) {
-                    $this->addError(ConstraintError::FORMAT_REGEX(), $path, array(
+                    $this->addError(ConstraintError::FORMAT_REGEX(), $path, [
                             'value' => $element,
                             'format' => $schema->format
-                        )
+                        ]
                     );
                 }
                 break;
 
             case 'color':
                 if (!$this->validateColor($element)) {
-                    $this->addError(ConstraintError::FORMAT_COLOR(), $path, array('format' => $schema->format));
+                    $this->addError(ConstraintError::FORMAT_COLOR(), $path, ['format' => $schema->format]);
                 }
                 break;
 
             case 'style':
                 if (!$this->validateStyle($element)) {
-                    $this->addError(ConstraintError::FORMAT_STYLE(), $path, array('format' => $schema->format));
+                    $this->addError(ConstraintError::FORMAT_STYLE(), $path, ['format' => $schema->format]);
                 }
                 break;
 
             case 'phone':
                 if (!$this->validatePhone($element)) {
-                    $this->addError(ConstraintError::FORMAT_PHONE(), $path, array('format' => $schema->format));
+                    $this->addError(ConstraintError::FORMAT_PHONE(), $path, ['format' => $schema->format]);
                 }
                 break;
 
             case 'uri':
                 if (null === filter_var($element, FILTER_VALIDATE_URL, FILTER_NULL_ON_FAILURE)) {
-                    $this->addError(ConstraintError::FORMAT_URL(), $path, array('format' => $schema->format));
+                    $this->addError(ConstraintError::FORMAT_URL(), $path, ['format' => $schema->format]);
                 }
                 break;
 
@@ -125,7 +125,7 @@ class FormatConstraint extends Constraint
                         $validURL = null;
                     }
                     if ($validURL === null) {
-                        $this->addError(ConstraintError::FORMAT_URL_REF(), $path, array('format' => $schema->format));
+                        $this->addError(ConstraintError::FORMAT_URL_REF(), $path, ['format' => $schema->format]);
                     }
                 }
                 break;
@@ -137,27 +137,27 @@ class FormatConstraint extends Constraint
                     $filterFlags |= constant('FILTER_FLAG_EMAIL_UNICODE'); // @codeCoverageIgnore
                 }
                 if (null === filter_var($element, FILTER_VALIDATE_EMAIL, $filterFlags)) {
-                    $this->addError(ConstraintError::FORMAT_EMAIL(), $path, array('format' => $schema->format));
+                    $this->addError(ConstraintError::FORMAT_EMAIL(), $path, ['format' => $schema->format]);
                 }
                 break;
 
             case 'ip-address':
             case 'ipv4':
                 if (null === filter_var($element, FILTER_VALIDATE_IP, FILTER_NULL_ON_FAILURE | FILTER_FLAG_IPV4)) {
-                    $this->addError(ConstraintError::FORMAT_IP(), $path, array('format' => $schema->format));
+                    $this->addError(ConstraintError::FORMAT_IP(), $path, ['format' => $schema->format]);
                 }
                 break;
 
             case 'ipv6':
                 if (null === filter_var($element, FILTER_VALIDATE_IP, FILTER_NULL_ON_FAILURE | FILTER_FLAG_IPV6)) {
-                    $this->addError(ConstraintError::FORMAT_IP(), $path, array('format' => $schema->format));
+                    $this->addError(ConstraintError::FORMAT_IP(), $path, ['format' => $schema->format]);
                 }
                 break;
 
             case 'host-name':
             case 'hostname':
                 if (!$this->validateHostname($element)) {
-                    $this->addError(ConstraintError::FORMAT_HOSTNAME(), $path, array('format' => $schema->format));
+                    $this->addError(ConstraintError::FORMAT_HOSTNAME(), $path, ['format' => $schema->format]);
                 }
                 break;
 
@@ -194,9 +194,9 @@ class FormatConstraint extends Constraint
 
     protected function validateColor($color)
     {
-        if (in_array(strtolower($color), array('aqua', 'black', 'blue', 'fuchsia',
+        if (in_array(strtolower($color), ['aqua', 'black', 'blue', 'fuchsia',
             'gray', 'green', 'lime', 'maroon', 'navy', 'olive', 'orange', 'purple',
-            'red', 'silver', 'teal', 'white', 'yellow'))) {
+            'red', 'silver', 'teal', 'white', 'yellow'])) {
             return true;
         }
 

--- a/src/JsonSchema/Constraints/NumberConstraint.php
+++ b/src/JsonSchema/Constraints/NumberConstraint.php
@@ -29,40 +29,40 @@ class NumberConstraint extends Constraint
         if (isset($schema->exclusiveMinimum)) {
             if (isset($schema->minimum)) {
                 if ($schema->exclusiveMinimum && $element <= $schema->minimum) {
-                    $this->addError(ConstraintError::EXCLUSIVE_MINIMUM(), $path, array('minimum' => $schema->minimum));
+                    $this->addError(ConstraintError::EXCLUSIVE_MINIMUM(), $path, ['minimum' => $schema->minimum]);
                 } elseif ($element < $schema->minimum) {
-                    $this->addError(ConstraintError::MINIMUM(), $path, array('minimum' => $schema->minimum));
+                    $this->addError(ConstraintError::MINIMUM(), $path, ['minimum' => $schema->minimum]);
                 }
             } else {
                 $this->addError(ConstraintError::MISSING_MINIMUM(), $path);
             }
         } elseif (isset($schema->minimum) && $element < $schema->minimum) {
-            $this->addError(ConstraintError::MINIMUM(), $path, array('minimum' => $schema->minimum));
+            $this->addError(ConstraintError::MINIMUM(), $path, ['minimum' => $schema->minimum]);
         }
 
         // Verify maximum
         if (isset($schema->exclusiveMaximum)) {
             if (isset($schema->maximum)) {
                 if ($schema->exclusiveMaximum && $element >= $schema->maximum) {
-                    $this->addError(ConstraintError::EXCLUSIVE_MAXIMUM(), $path, array('maximum' => $schema->maximum));
+                    $this->addError(ConstraintError::EXCLUSIVE_MAXIMUM(), $path, ['maximum' => $schema->maximum]);
                 } elseif ($element > $schema->maximum) {
-                    $this->addError(ConstraintError::MAXIMUM(), $path, array('maximum' => $schema->maximum));
+                    $this->addError(ConstraintError::MAXIMUM(), $path, ['maximum' => $schema->maximum]);
                 }
             } else {
                 $this->addError(ConstraintError::MISSING_MAXIMUM(), $path);
             }
         } elseif (isset($schema->maximum) && $element > $schema->maximum) {
-            $this->addError(ConstraintError::MAXIMUM(), $path, array('maximum' => $schema->maximum));
+            $this->addError(ConstraintError::MAXIMUM(), $path, ['maximum' => $schema->maximum]);
         }
 
         // Verify divisibleBy - Draft v3
         if (isset($schema->divisibleBy) && $this->fmod($element, $schema->divisibleBy) != 0) {
-            $this->addError(ConstraintError::DIVISIBLE_BY(), $path, array('divisibleBy' => $schema->divisibleBy));
+            $this->addError(ConstraintError::DIVISIBLE_BY(), $path, ['divisibleBy' => $schema->divisibleBy]);
         }
 
         // Verify multipleOf - Draft v4
         if (isset($schema->multipleOf) && $this->fmod($element, $schema->multipleOf) != 0) {
-            $this->addError(ConstraintError::MULTIPLE_OF(), $path, array('multipleOf' => $schema->multipleOf));
+            $this->addError(ConstraintError::MULTIPLE_OF(), $path, ['multipleOf' => $schema->multipleOf]);
         }
 
         $this->checkFormat($element, $schema, $path, $i);

--- a/src/JsonSchema/Constraints/ObjectConstraint.php
+++ b/src/JsonSchema/Constraints/ObjectConstraint.php
@@ -23,13 +23,13 @@ class ObjectConstraint extends Constraint
     /**
      * @var array List of properties to which a default value has been applied
      */
-    protected $appliedDefaults = array();
+    protected $appliedDefaults = [];
 
     /**
      * {@inheritdoc}
      */
     public function check(&$element, $schema = null, ?JsonPointer $path = null, $properties = null,
-        $additionalProp = null, $patternProperties = null, $appliedDefaults = array())
+        $additionalProp = null, $patternProperties = null, $appliedDefaults = [])
     {
         if ($element instanceof UndefinedConstraint) {
             return;
@@ -37,7 +37,7 @@ class ObjectConstraint extends Constraint
 
         $this->appliedDefaults = $appliedDefaults;
 
-        $matches = array();
+        $matches = [];
         if ($patternProperties) {
             // validate the element pattern properties
             $matches = $this->validatePatternProperties($element, $path, $patternProperties);
@@ -54,13 +54,13 @@ class ObjectConstraint extends Constraint
 
     public function validatePatternProperties($element, ?JsonPointer $path = null, $patternProperties)
     {
-        $matches = array();
+        $matches = [];
         foreach ($patternProperties as $pregex => $schema) {
             $fullRegex = self::jsonPatternToPhpRegex($pregex);
 
             // Validate the pattern before using it to test for matches
             if (@preg_match($fullRegex, '') === false) {
-                $this->addError(ConstraintError::PREGEX_INVALID(), $path, array('pregex' => $pregex));
+                $this->addError(ConstraintError::PREGEX_INVALID(), $path, ['pregex' => $pregex]);
                 continue;
             }
             foreach ($element as $i => $value) {
@@ -94,7 +94,7 @@ class ObjectConstraint extends Constraint
 
             // no additional properties allowed
             if (!in_array($i, $matches) && $additionalProp === false && $this->inlineSchemaProperty !== $i && !$definition) {
-                $this->addError(ConstraintError::ADDITIONAL_PROPERTIES(), $path, array('property' => $i));
+                $this->addError(ConstraintError::ADDITIONAL_PROPERTIES(), $path, ['property' => $i]);
             }
 
             // additional properties defined
@@ -109,10 +109,10 @@ class ObjectConstraint extends Constraint
             // property requires presence of another
             $require = $this->getProperty($definition, 'requires');
             if ($require && !$this->getProperty($element, $require)) {
-                $this->addError(ConstraintError::REQUIRES(), $path, array(
+                $this->addError(ConstraintError::REQUIRES(), $path, [
                     'property' => $i,
                     'requiredProperty' => $require
-                ));
+                ]);
             }
 
             $property = $this->getProperty($element, $i, $this->factory->createInstanceFor('undefined'));
@@ -176,13 +176,13 @@ class ObjectConstraint extends Constraint
         // Verify minimum number of properties
         if (isset($objectDefinition->minProperties) && !is_object($objectDefinition->minProperties)) {
             if ($this->getTypeCheck()->propertyCount($element) < $objectDefinition->minProperties) {
-                $this->addError(ConstraintError::PROPERTIES_MIN(), $path, array('minProperties' => $objectDefinition->minProperties));
+                $this->addError(ConstraintError::PROPERTIES_MIN(), $path, ['minProperties' => $objectDefinition->minProperties]);
             }
         }
         // Verify maximum number of properties
         if (isset($objectDefinition->maxProperties) && !is_object($objectDefinition->maxProperties)) {
             if ($this->getTypeCheck()->propertyCount($element) > $objectDefinition->maxProperties) {
-                $this->addError(ConstraintError::PROPERTIES_MAX(), $path, array('maxProperties' => $objectDefinition->maxProperties));
+                $this->addError(ConstraintError::PROPERTIES_MAX(), $path, ['maxProperties' => $objectDefinition->maxProperties]);
             }
         }
     }

--- a/src/JsonSchema/Constraints/StringConstraint.php
+++ b/src/JsonSchema/Constraints/StringConstraint.php
@@ -27,23 +27,23 @@ class StringConstraint extends Constraint
     {
         // Verify maxLength
         if (isset($schema->maxLength) && $this->strlen($element) > $schema->maxLength) {
-            $this->addError(ConstraintError::LENGTH_MAX(), $path, array(
+            $this->addError(ConstraintError::LENGTH_MAX(), $path, [
                 'maxLength' => $schema->maxLength,
-            ));
+            ]);
         }
 
         //verify minLength
         if (isset($schema->minLength) && $this->strlen($element) < $schema->minLength) {
-            $this->addError(ConstraintError::LENGTH_MIN(), $path, array(
+            $this->addError(ConstraintError::LENGTH_MIN(), $path, [
                 'minLength' => $schema->minLength,
-            ));
+            ]);
         }
 
         // Verify a regex pattern
         if (isset($schema->pattern) && !preg_match(self::jsonPatternToPhpRegex($schema->pattern), $element)) {
-            $this->addError(ConstraintError::PATTERN(), $path, array(
+            $this->addError(ConstraintError::PATTERN(), $path, [
                 'pattern' => $schema->pattern,
-            ));
+            ]);
         }
 
         $this->checkFormat($element, $schema, $path, $i);

--- a/src/JsonSchema/Constraints/TypeConstraint.php
+++ b/src/JsonSchema/Constraints/TypeConstraint.php
@@ -25,7 +25,7 @@ class TypeConstraint extends Constraint
     /**
      * @var array|string[] type wordings for validation error messages
      */
-    public static $wording = array(
+    public static $wording = [
         'integer' => 'an integer',
         'number'  => 'a number',
         'boolean' => 'a boolean',
@@ -35,7 +35,7 @@ class TypeConstraint extends Constraint
         'null'    => 'a null',
         'any'     => null, // validation of 'any' is always true so is not needed in message wording
         0         => null, // validation of a false-y value is always true, so not needed as well
-    );
+    ];
 
     /**
      * {@inheritdoc}
@@ -46,7 +46,7 @@ class TypeConstraint extends Constraint
         $isValid = false;
         $coerce = $this->factory->getConfig(self::CHECK_MODE_COERCE_TYPES);
         $earlyCoerce = $this->factory->getConfig(self::CHECK_MODE_EARLY_COERCE);
-        $wording = array();
+        $wording = [];
 
         if (is_array($type)) {
             $this->validateTypesArray($value, $type, $wording, $isValid, $path, $coerce && $earlyCoerce);
@@ -69,10 +69,10 @@ class TypeConstraint extends Constraint
                 $this->validateTypeNameWording($type);
                 $wording[] = self::$wording[$type];
             }
-            $this->addError(ConstraintError::TYPE(), $path, array(
+            $this->addError(ConstraintError::TYPE(), $path, [
                     'found' => gettype($value),
                     'expected' => $this->implodeWith($wording, ', ', 'or')
-            ));
+            ]);
         }
     }
 
@@ -136,7 +136,7 @@ class TypeConstraint extends Constraint
         }
         $lastElement  = array_slice($elements, -1);
         $firsElements = join($delimiter, array_slice($elements, 0, -1));
-        $implodedElements = array_merge(array($firsElements), $lastElement);
+        $implodedElements = array_merge([$firsElements], $lastElement);
 
         return join(" $listEnd ", $implodedElements);
     }
@@ -308,7 +308,7 @@ class TypeConstraint extends Constraint
     protected function toArray($value)
     {
         if (is_scalar($value) || is_null($value)) {
-            return array($value);
+            return [$value];
         }
 
         return $value;

--- a/src/JsonSchema/Constraints/UndefinedConstraint.php
+++ b/src/JsonSchema/Constraints/UndefinedConstraint.php
@@ -27,7 +27,7 @@ class UndefinedConstraint extends Constraint
     /**
      * @var array List of properties to which a default value has been applied
      */
-    protected $appliedDefaults = array();
+    protected $appliedDefaults = [];
 
     /**
      * {@inheritdoc}
@@ -141,9 +141,9 @@ class UndefinedConstraint extends Constraint
                     if (!$this->getTypeCheck()->propertyExists($value, $required)) {
                         $this->addError(
                             ConstraintError::REQUIRED(),
-                            $this->incrementPath($path, $required), array(
+                            $this->incrementPath($path, $required), [
                                 'property' => $required
-                            )
+                            ]
                         );
                     }
                 }
@@ -152,7 +152,7 @@ class UndefinedConstraint extends Constraint
                 if ($schema->required && $value instanceof self) {
                     $propertyPaths = $path->getPropertyPaths();
                     $propertyName = end($propertyPaths);
-                    $this->addError(ConstraintError::REQUIRED(), $path, array('property' => $propertyName));
+                    $this->addError(ConstraintError::REQUIRED(), $path, ['property' => $propertyName]);
                 }
             } else {
                 // if the value is both undefined and not required, skip remaining checks
@@ -269,7 +269,7 @@ class UndefinedConstraint extends Constraint
                 }
             }
         } elseif (isset($schema->items) && LooseTypeCheck::isArray($value)) {
-            $items = array();
+            $items = [];
             if (LooseTypeCheck::isArray($schema->items)) {
                 $items = $schema->items;
             } elseif (isset($schema->minItems) && count($value) < $schema->minItems) {
@@ -349,12 +349,12 @@ class UndefinedConstraint extends Constraint
         }
 
         if (isset($schema->oneOf)) {
-            $allErrors = array();
+            $allErrors = [];
             $matchedSchemas = 0;
             $startErrors = $this->getErrors();
             foreach ($schema->oneOf as $oneOf) {
                 try {
-                    $this->errors = array();
+                    $this->errors = [];
                     $this->checkUndefined($value, $oneOf, $path, $i);
                     if (count($this->getErrors()) == 0) {
                         $matchedSchemas++;
@@ -389,19 +389,19 @@ class UndefinedConstraint extends Constraint
                 if (is_string($dependency)) {
                     // Draft 3 string is allowed - e.g. "dependencies": {"bar": "foo"}
                     if (!$this->getTypeCheck()->propertyExists($value, $dependency)) {
-                        $this->addError(ConstraintError::DEPENDENCIES(), $path, array(
+                        $this->addError(ConstraintError::DEPENDENCIES(), $path, [
                             'key' => $key,
                             'dependency' => $dependency
-                        ));
+                        ]);
                     }
                 } elseif (is_array($dependency)) {
                     // Draft 4 must be an array - e.g. "dependencies": {"bar": ["foo"]}
                     foreach ($dependency as $d) {
                         if (!$this->getTypeCheck()->propertyExists($value, $d)) {
-                            $this->addError(ConstraintError::DEPENDENCIES(), $path, array(
+                            $this->addError(ConstraintError::DEPENDENCIES(), $path, [
                                 'key' => $key,
                                 'dependency' => $dependency
-                            ));
+                            ]);
                         }
                     }
                 } elseif (is_object($dependency)) {

--- a/src/JsonSchema/Entity/JsonPointer.php
+++ b/src/JsonSchema/Entity/JsonPointer.php
@@ -22,7 +22,7 @@ class JsonPointer
     private $filename;
 
     /** @var string[] */
-    private $propertyPaths = array();
+    private $propertyPaths = [];
 
     /**
      * @var bool Whether the value at this path was set from a schema default
@@ -54,7 +54,7 @@ class JsonPointer
      */
     private function decodePropertyPaths($propertyPathString)
     {
-        $paths = array();
+        $paths = [];
         foreach (explode('/', trim($propertyPathString, '/')) as $path) {
             $path = $this->decodePath($path);
             if (is_string($path) && '' !== $path) {
@@ -71,7 +71,7 @@ class JsonPointer
     private function encodePropertyPaths()
     {
         return array_map(
-            array($this, 'encodePath'),
+            [$this, 'encodePath'],
             $this->getPropertyPaths()
         );
     }
@@ -83,7 +83,7 @@ class JsonPointer
      */
     private function decodePath($path)
     {
-        return strtr($path, array('~1' => '/', '~0' => '~', '%25' => '%'));
+        return strtr($path, ['~1' => '/', '~0' => '~', '%25' => '%']);
     }
 
     /**
@@ -93,7 +93,7 @@ class JsonPointer
      */
     private function encodePath($path)
     {
-        return strtr($path, array('/' => '~1', '~' => '~0', '%' => '%25'));
+        return strtr($path, ['/' => '~1', '~' => '~0', '%' => '%25']);
     }
 
     /**

--- a/src/JsonSchema/Iterator/ObjectIterator.php
+++ b/src/JsonSchema/Iterator/ObjectIterator.php
@@ -23,7 +23,7 @@ class ObjectIterator implements \Iterator, \Countable
     private $position = 0;
 
     /** @var array */
-    private $data = array();
+    private $data = [];
 
     /** @var bool */
     private $initialized = false;
@@ -113,7 +113,7 @@ class ObjectIterator implements \Iterator, \Countable
      */
     private function buildDataFromObject($object)
     {
-        $result = array();
+        $result = [];
 
         $stack = new \SplStack();
         $stack->push($object);
@@ -142,7 +142,7 @@ class ObjectIterator implements \Iterator, \Countable
     private function getDataFromItem($item)
     {
         if (!is_object($item) && !is_array($item)) {
-            return array();
+            return [];
         }
 
         return is_object($item) ? get_object_vars($item) : $item;

--- a/src/JsonSchema/SchemaStorage.php
+++ b/src/JsonSchema/SchemaStorage.php
@@ -14,7 +14,7 @@ class SchemaStorage implements SchemaStorageInterface
 
     protected $uriRetriever;
     protected $uriResolver;
-    protected $schemas = array();
+    protected $schemas = [];
 
     public function __construct(
         ?UriRetrieverInterface $uriRetriever = null,
@@ -121,7 +121,7 @@ class SchemaStorage implements SchemaStorageInterface
     /**
      * {@inheritdoc}
      */
-    public function resolveRef($ref, $resolveStack = array())
+    public function resolveRef($ref, $resolveStack = [])
     {
         $jsonPointer = new JsonPointer($ref);
 
@@ -156,7 +156,7 @@ class SchemaStorage implements SchemaStorageInterface
     /**
      * {@inheritdoc}
      */
-    public function resolveRefSchema($refSchema, $resolveStack = array())
+    public function resolveRefSchema($refSchema, $resolveStack = [])
     {
         if (is_object($refSchema) && property_exists($refSchema, '$ref') && is_string($refSchema->{'$ref'})) {
             if (in_array($refSchema, $resolveStack, true)) {

--- a/src/JsonSchema/Uri/Retrievers/Curl.php
+++ b/src/JsonSchema/Uri/Retrievers/Curl.php
@@ -41,7 +41,7 @@ class Curl extends AbstractRetriever
         curl_setopt($ch, CURLOPT_URL, $uri);
         curl_setopt($ch, CURLOPT_HEADER, true);
         curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
-        curl_setopt($ch, CURLOPT_HTTPHEADER, array('Accept: ' . Validator::SCHEMA_MEDIA_TYPE));
+        curl_setopt($ch, CURLOPT_HTTPHEADER, ['Accept: ' . Validator::SCHEMA_MEDIA_TYPE]);
 
         $response = curl_exec($ch);
         if (false === $response) {

--- a/src/JsonSchema/Uri/UriResolver.php
+++ b/src/JsonSchema/Uri/UriResolver.php
@@ -30,13 +30,13 @@ class UriResolver implements UriResolverInterface
     {
         preg_match('|^(([^:/?#]+):)?(//([^/?#]*))?([^?#]*)(\?([^#]*))?(#(.*))?|', (string) $uri, $match);
 
-        $components = array();
+        $components = [];
         if (5 < count($match)) {
-            $components =  array(
+            $components =  [
                 'scheme'    => $match[2],
                 'authority' => $match[4],
                 'path'      => $match[5]
-            );
+            ];
         }
         if (7 < count($match)) {
             $components['query'] = $match[7];

--- a/src/JsonSchema/Uri/UriRetriever.php
+++ b/src/JsonSchema/Uri/UriRetriever.php
@@ -27,18 +27,18 @@ class UriRetriever implements BaseUriRetrieverInterface
     /**
      * @var array Map of URL translations
      */
-    protected $translationMap = array(
+    protected $translationMap = [
         // use local copies of the spec schemas
         '|^https?://json-schema.org/draft-(0[34])/schema#?|' => 'package://dist/schema/json-schema-draft-$1.json'
-    );
+    ];
 
     /**
      * @var array A list of endpoints for media type check exclusion
      */
-    protected $allowedInvalidContentTypeEndpoints = array(
+    protected $allowedInvalidContentTypeEndpoints = [
         'http://json-schema.org/',
         'https://json-schema.org/'
-    );
+    ];
 
     /**
      * @var null|UriRetrieverInterface
@@ -50,7 +50,7 @@ class UriRetriever implements BaseUriRetrieverInterface
      *
      * @see loadSchema
      */
-    private $schemaCache = array();
+    private $schemaCache = [];
 
     /**
      * Adds an endpoint to the media type validation exclusion list
@@ -79,7 +79,7 @@ class UriRetriever implements BaseUriRetrieverInterface
             return;
         }
 
-        if (in_array($contentType, array(Validator::SCHEMA_MEDIA_TYPE, 'application/json'))) {
+        if (in_array($contentType, [Validator::SCHEMA_MEDIA_TYPE, 'application/json'])) {
             return;
         }
 
@@ -243,13 +243,13 @@ class UriRetriever implements BaseUriRetrieverInterface
     {
         preg_match('|^(([^:/?#]+):)?(//([^/?#]*))?([^?#]*)(\?([^#]*))?(#(.*))?|', $uri, $match);
 
-        $components = array();
+        $components = [];
         if (5 < count($match)) {
-            $components =  array(
+            $components =  [
                 'scheme'    => $match[2],
                 'authority' => $match[4],
                 'path'      => $match[5]
-            );
+            ];
         }
 
         if (7 < count($match)) {

--- a/tests/Constraints/AdditionalPropertiesTest.php
+++ b/tests/Constraints/AdditionalPropertiesTest.php
@@ -17,8 +17,8 @@ class AdditionalPropertiesTest extends BaseTestCase
 
     public function getInvalidTests()
     {
-        return array(
-            array(
+        return [
+            [
                 '{
                   "prop":"1",
                   "patternProp":"3",
@@ -35,22 +35,22 @@ class AdditionalPropertiesTest extends BaseTestCase
                   "additionalProperties": false
                 }',
                 null,
-                array(
-                    array(
+                [
+                    [
                         'property'   => '',
                         'pointer'    => '',
                         'message'    => 'The property additionalProp is not defined and the definition does not allow additional properties',
-                        'constraint' => array(
+                        'constraint' => [
                             'name' => 'additionalProp',
-                            'params' => array(
+                            'params' => [
                                 'property' => 'additionalProp'
-                            )
-                        ),
+                            ]
+                        ],
                         'context' => Validator::ERROR_DOCUMENT_VALIDATION
-                    )
-                )
-            ),
-            array(
+                    ]
+                ]
+            ],
+            [
                 '{
                   "prop":"1",
                   "additionalProp":"2"
@@ -62,8 +62,8 @@ class AdditionalPropertiesTest extends BaseTestCase
                   },
                   "additionalProperties": false
                 }'
-            ),
-            array(
+            ],
+            [
                 '{
                   "prop":"1",
                   "additionalProp":2
@@ -75,8 +75,8 @@ class AdditionalPropertiesTest extends BaseTestCase
                   },
                   "additionalProperties": {"type":"string"}
                 }'
-            ),
-            array(
+            ],
+            [
                 '{
                   "prop":"1",
                   "additionalProp":2
@@ -88,8 +88,8 @@ class AdditionalPropertiesTest extends BaseTestCase
                   },
                   "additionalProperties": {"type":"string"}
                 }'
-            ),
-            array(
+            ],
+            [
                 '{
                   "prop1": "a",
                   "prop2": "b"
@@ -100,8 +100,8 @@ class AdditionalPropertiesTest extends BaseTestCase
                     "type": "boolean"
                   }
                 }'
-            ),
-            array(
+            ],
+            [
                 '{
                   "prop1": "a",
                   "prop2": "b"
@@ -110,14 +110,14 @@ class AdditionalPropertiesTest extends BaseTestCase
                   "type": "object",
                   "additionalProperties": false
                 }'
-            ),
-        );
+            ],
+        ];
     }
 
     public function getValidTests()
     {
-        return array(
-            array(
+        return [
+            [
                 '{
                   "prop":"1",
                   "additionalProp":"2"
@@ -128,8 +128,8 @@ class AdditionalPropertiesTest extends BaseTestCase
                     "prop":{"type":"string"}
                   }
                 }'
-            ),
-            array(
+            ],
+            [
                 '{
                   "prop":"1",
                   "additionalProp":"2"
@@ -140,8 +140,8 @@ class AdditionalPropertiesTest extends BaseTestCase
                     "prop":{"type":"string"}
                   }
                 }'
-            ),
-            array(
+            ],
+            [
                 '{
                   "prop":"1",
                   "additionalProp":"2"
@@ -153,8 +153,8 @@ class AdditionalPropertiesTest extends BaseTestCase
                   },
                   "additionalProperties": {"type":"string"}
                 }'
-            ),
-            array(
+            ],
+            [
                 '{
                   "prop":"1",
                   "additionalProp":[]
@@ -166,8 +166,8 @@ class AdditionalPropertiesTest extends BaseTestCase
                   },
                   "additionalProperties": true
                 }'
-            ),
-            array(
+            ],
+            [
                 '{
                   "prop1": "a",
                   "prop2": "b"
@@ -178,8 +178,8 @@ class AdditionalPropertiesTest extends BaseTestCase
                     "type": "string"
                   }
                 }'
-            ),
-            array(
+            ],
+            [
                 '{
                   "prop1": "a",
                   "prop2": "b"
@@ -188,7 +188,7 @@ class AdditionalPropertiesTest extends BaseTestCase
                   "type": "object",
                   "additionalProperties": true
                 }'
-            ),
-        );
+            ],
+        ];
     }
 }

--- a/tests/Constraints/ArraysTest.php
+++ b/tests/Constraints/ArraysTest.php
@@ -15,8 +15,8 @@ class ArraysTest extends BaseTestCase
 
     public function getInvalidTests()
     {
-        return array(
-            array(
+        return [
+            [
                 '{
                   "array":[1,2,"a"]
                 }',
@@ -29,8 +29,8 @@ class ArraysTest extends BaseTestCase
                     }
                   }
                 }'
-            ),
-            array(
+            ],
+            [
                 '{
                   "array":[1,2,"a"]
                 }',
@@ -44,8 +44,8 @@ class ArraysTest extends BaseTestCase
                     }
                   }
                 }'
-            ),
-            array(
+            ],
+            [
                 '{
                   "array":[1,2,null]
                 }',
@@ -58,8 +58,8 @@ class ArraysTest extends BaseTestCase
                     }
                   }
                 }'
-            ),
-            array(
+            ],
+            [
                 '{"data": [1, 2, 3, "foo"]}',
                 '{
                     "type": "object",
@@ -71,8 +71,8 @@ class ArraysTest extends BaseTestCase
                         }
                     }
                 }'
-            ),
-            array( // Test array items.enum where type string fail validation if value(s) is/are not in items.enum
+            ],
+            [ // Test array items.enum where type string fail validation if value(s) is/are not in items.enum
                 '{"data": ["a", "b"]}',
                 '{
                     "type": "object",
@@ -86,8 +86,8 @@ class ArraysTest extends BaseTestCase
                         }
                     }
                 }'
-            ),
-            array( // Test array items.enum where type integer fail validation if value(s) is/are not in items.enum
+            ],
+            [ // Test array items.enum where type integer fail validation if value(s) is/are not in items.enum
                 '{"data": [1, 2]}',
                 '{
                     "type": "object",
@@ -101,8 +101,8 @@ class ArraysTest extends BaseTestCase
                         }
                     }
                 }'
-            ),
-            array( // Test array items.enum where type number fail validation if value(s) is/are not in items.enum
+            ],
+            [ // Test array items.enum where type number fail validation if value(s) is/are not in items.enum
                 '{"data": [1.25, 2.25]}',
                 '{
                     "type": "object",
@@ -116,14 +116,14 @@ class ArraysTest extends BaseTestCase
                         }
                     }
                 }'
-            )
-        );
+            ]
+        ];
     }
 
     public function getValidTests()
     {
-        return array(
-            array(
+        return [
+            [
                 '{
                   "array":[1,2,"a"]
                 }',
@@ -133,8 +133,8 @@ class ArraysTest extends BaseTestCase
                     "array":{"type":"array"}
                   }
                 }'
-            ),
-            array(
+            ],
+            [
                 '{
                   "array":[1,2,"a"]
                 }',
@@ -148,8 +148,8 @@ class ArraysTest extends BaseTestCase
                     }
                   }
                 }'
-            ),
-            array(
+            ],
+            [
                 '{"data": [1, 2, 3, 4]}',
                 '{
                     "type": "object",
@@ -161,8 +161,8 @@ class ArraysTest extends BaseTestCase
                         }
                     }
                 }'
-            ),
-            array(
+            ],
+            [
                 '{"data": [1, "foo", false]}',
                 '{
                     "type": "object",
@@ -173,8 +173,8 @@ class ArraysTest extends BaseTestCase
                         }
                     }
                 }'
-            ),
-            array(
+            ],
+            [
                 '{"data": [1, "foo", false]}',
                 '{
                     "type": "object",
@@ -185,8 +185,8 @@ class ArraysTest extends BaseTestCase
                         }
                     }
                 }'
-            ),
-            array(
+            ],
+            [
                 '{"data": [1, 2, 3, 4, 5]}',
                 '{
                     "type": "object",
@@ -197,8 +197,8 @@ class ArraysTest extends BaseTestCase
                         }
                     }
                 }'
-            ),
-            array( // test more schema items than array items
+            ],
+            [ // test more schema items than array items
                 '{"data": [1, 2]}',
                 '{
                     "type": "object",
@@ -213,8 +213,8 @@ class ArraysTest extends BaseTestCase
                         }
                     }
                 }'
-            ),
-            array( // Test array items.enum where type string passes validation if value(s) is/are in items.enum
+            ],
+            [ // Test array items.enum where type string passes validation if value(s) is/are in items.enum
                 '{"data": ["c", "c", "b"]}',
                 '{
                     "type": "object",
@@ -228,8 +228,8 @@ class ArraysTest extends BaseTestCase
                         }
                     }
                 }'
-            ),
-            array( // Test array items.enum where type integer passes validation if value(s) is/are in items.enum
+            ],
+            [ // Test array items.enum where type integer passes validation if value(s) is/are in items.enum
                 '{"data": [1, 1, 2]}',
                 '{
                     "type": "object",
@@ -243,8 +243,8 @@ class ArraysTest extends BaseTestCase
                         }
                     }
                 }'
-            ),
-            array( // Test array items.enum where type number passes validation if value(s) is/are in items.enum
+            ],
+            [ // Test array items.enum where type number passes validation if value(s) is/are in items.enum
                 '{"data": [1.25, 1.25, 2.25]}',
                 '{
                     "type": "object",
@@ -258,7 +258,7 @@ class ArraysTest extends BaseTestCase
                         }
                     }
                 }'
-            )
-        );
+            ]
+        ];
     }
 }

--- a/tests/Constraints/BaseTestCase.php
+++ b/tests/Constraints/BaseTestCase.php
@@ -26,7 +26,7 @@ abstract class BaseTestCase extends VeryBaseTestCase
     /**
      * @dataProvider getInvalidTests
      */
-    public function testInvalidCases($input, $schema, $checkMode = Constraint::CHECK_MODE_NORMAL, $errors = array())
+    public function testInvalidCases($input, $schema, $checkMode = Constraint::CHECK_MODE_NORMAL, $errors = [])
     {
         $checkMode = $checkMode === null ? Constraint::CHECK_MODE_NORMAL : $checkMode;
         if ($this->validateSchema) {
@@ -46,7 +46,7 @@ abstract class BaseTestCase extends VeryBaseTestCase
         $this->assertTrue((bool) ($errorMask & Validator::ERROR_DOCUMENT_VALIDATION));
         $this->assertGreaterThan(0, $validator->numErrors());
 
-        if (array() !== $errors) {
+        if ([] !== $errors) {
             $this->assertEquals($errors, $validator->getErrors(), print_r($validator->getErrors(), true));
         }
         $this->assertFalse($validator->isValid(), print_r($validator->getErrors(), true));
@@ -55,7 +55,7 @@ abstract class BaseTestCase extends VeryBaseTestCase
     /**
      * @dataProvider getInvalidForAssocTests
      */
-    public function testInvalidCasesUsingAssoc($input, $schema, $checkMode = Constraint::CHECK_MODE_TYPE_CAST, $errors = array())
+    public function testInvalidCasesUsingAssoc($input, $schema, $checkMode = Constraint::CHECK_MODE_TYPE_CAST, $errors = [])
     {
         $checkMode = $checkMode === null ? Constraint::CHECK_MODE_TYPE_CAST : $checkMode;
         if ($this->validateSchema) {
@@ -78,7 +78,7 @@ abstract class BaseTestCase extends VeryBaseTestCase
         $this->assertTrue((bool) ($errorMask & Validator::ERROR_DOCUMENT_VALIDATION));
         $this->assertGreaterThan(0, $validator->numErrors());
 
-        if (array() !== $errors) {
+        if ([] !== $errors) {
             $this->assertEquals($errors, $validator->getErrors(), print_r($validator->getErrors(), true));
         }
         $this->assertFalse($validator->isValid(), print_r($validator->getErrors(), true));

--- a/tests/Constraints/BasicTypesTest.php
+++ b/tests/Constraints/BasicTypesTest.php
@@ -16,8 +16,8 @@ class BasicTypesTest extends BaseTestCase
 
     public function getInvalidTests()
     {
-        return array(
-            array(
+        return [
+            [
                 '{
                   "string":null
                 }',
@@ -28,8 +28,8 @@ class BasicTypesTest extends BaseTestCase
                   },
                   "additionalProperties":false
                 }'
-            ),
-            array(
+            ],
+            [
                 '{
                   "number":null
                 }',
@@ -40,8 +40,8 @@ class BasicTypesTest extends BaseTestCase
                   },
                   "additionalProperties":false
                 }'
-            ),
-            array(
+            ],
+            [
                 '{
                   "integer":null
                 }',
@@ -52,8 +52,8 @@ class BasicTypesTest extends BaseTestCase
                   },
                   "additionalProperties":false
                 }'
-            ),
-            array(
+            ],
+            [
                 '{
                   "boolean":null
                 }',
@@ -64,8 +64,8 @@ class BasicTypesTest extends BaseTestCase
                   },
                   "additionalProperties":false
                 }'
-            ),
-            array(
+            ],
+            [
                 '{
                   "object":null
                 }',
@@ -76,8 +76,8 @@ class BasicTypesTest extends BaseTestCase
                   },
                   "additionalProperties":false
                 }'
-            ),
-            array(
+            ],
+            [
                 '{
                   "array":null
                 }',
@@ -88,8 +88,8 @@ class BasicTypesTest extends BaseTestCase
                   },
                   "additionalProperties":false
                 }'
-            ),
-            array(
+            ],
+            [
                 '{
                   "null":1
                 }',
@@ -100,14 +100,14 @@ class BasicTypesTest extends BaseTestCase
                   },
                   "additionalProperties":false
                 }'
-            )
-        );
+            ]
+        ];
     }
 
     public function getValidTests()
     {
-        return array(
-            array(
+        return [
+            [
                 '{
                   "string":"string test",
                   "number":1,
@@ -144,7 +144,7 @@ class BasicTypesTest extends BaseTestCase
                   },
                   "additionalProperties":false
                 }'
-            )
-        );
+            ]
+        ];
     }
 }

--- a/tests/Constraints/CoerciveTest.php
+++ b/tests/Constraints/CoerciveTest.php
@@ -27,162 +27,162 @@ class CoerciveTest extends VeryBaseTestCase
     public function dataCoerceCases()
     {
         // check type conversions
-        $types = array(
+        $types = [
             // toType
-            'string' => array(
+            'string' => [
                 //    fromType      fromValue       toValue         valid   Test Number
-                array('string',     '"ABC"',        'ABC',          true),  // #0
-                array('integer',    '45',           '45',           true),  // #1
-                array('boolean',    'true',         'true',         true),  // #2
-                array('boolean',    'false',        'false',        true),  // #3
-                array('NULL',       'null',         '',             true),  // #4
-                array('array',      '[45]',         '45',           true),  // #5
-                array('object',     '{"a":"b"}',    null,           false), // #6
-                array('array',      '[{"a":"b"}]',  null,           false), // #7
-                array('array',      '[1,2]',  		array(1, 2),     false), // #8
-            ),
-            'integer' => array(
-                array('string',     '"45"',         45,             true),  // #9
-                array('integer',    '45',           45,             true),  // #10
-                array('boolean',    'true',         1,              true),  // #11
-                array('boolean',    'false',        0,              true),  // #12
-                array('NULL',       'null',         0,              true),  // #13
-                array('array',      '["-45"]',      -45,            true),  // #14
-                array('object',     '{"a":"b"}',    null,           false), // #15
-                array('array',      '["ABC"]',      null,           false), // #16
-            ),
-            'boolean' => array(
-                array('string',     '"true"',       true,           true),  // #17
-                array('integer',    '1',            true,           true),  // #18
-                array('boolean',    'true',         true,           true),  // #19
-                array('NULL',       'null',         false,          true),  // #20
-                array('array',      '["true"]',     true,           true),  // #21
-                array('object',     '{"a":"b"}',    null,           false), // #22
-                array('string',     '""',           null,           false), // #23
-                array('string',     '"ABC"',        null,           false), // #24
-                array('integer',    '2',            null,           false), // #25
-            ),
-            'NULL' => array(
-                array('string',     '""',           null,           true),  // #26
-                array('integer',    '0',            null,           true),  // #27
-                array('boolean',    'false',        null,           true),  // #28
-                array('NULL',       'null',         null,           true),  // #29
-                array('array',      '[0]',          null,           true),  // #30
-                array('object',     '{"a":"b"}',    null,           false), // #31
-                array('string',     '"null"',       null,           false), // #32
-                array('integer',    '-1',           null,           false), // #33
-            ),
-            'array' => array(
-                array('string',     '"ABC"',        array('ABC'),   true),  // #34
-                array('integer',    '45',           array(45),      true),  // #35
-                array('boolean',    'true',         array(true),    true),  // #36
-                array('NULL',       'null',         array(null),    true),  // #37
-                array('array',      '["ABC"]',      array('ABC'),   true),  // #38
-                array('object',     '{"a":"b"}',    null,           false), // #39
-            ),
-        );
+                ['string',     '"ABC"',        'ABC',          true],  // #0
+                ['integer',    '45',           '45',           true],  // #1
+                ['boolean',    'true',         'true',         true],  // #2
+                ['boolean',    'false',        'false',        true],  // #3
+                ['NULL',       'null',         '',             true],  // #4
+                ['array',      '[45]',         '45',           true],  // #5
+                ['object',     '{"a":"b"}',    null,           false], // #6
+                ['array',      '[{"a":"b"}]',  null,           false], // #7
+                ['array',      '[1,2]',  		[1, 2],     false], // #8
+            ],
+            'integer' => [
+                ['string',     '"45"',         45,             true],  // #9
+                ['integer',    '45',           45,             true],  // #10
+                ['boolean',    'true',         1,              true],  // #11
+                ['boolean',    'false',        0,              true],  // #12
+                ['NULL',       'null',         0,              true],  // #13
+                ['array',      '["-45"]',      -45,            true],  // #14
+                ['object',     '{"a":"b"}',    null,           false], // #15
+                ['array',      '["ABC"]',      null,           false], // #16
+            ],
+            'boolean' => [
+                ['string',     '"true"',       true,           true],  // #17
+                ['integer',    '1',            true,           true],  // #18
+                ['boolean',    'true',         true,           true],  // #19
+                ['NULL',       'null',         false,          true],  // #20
+                ['array',      '["true"]',     true,           true],  // #21
+                ['object',     '{"a":"b"}',    null,           false], // #22
+                ['string',     '""',           null,           false], // #23
+                ['string',     '"ABC"',        null,           false], // #24
+                ['integer',    '2',            null,           false], // #25
+            ],
+            'NULL' => [
+                ['string',     '""',           null,           true],  // #26
+                ['integer',    '0',            null,           true],  // #27
+                ['boolean',    'false',        null,           true],  // #28
+                ['NULL',       'null',         null,           true],  // #29
+                ['array',      '[0]',          null,           true],  // #30
+                ['object',     '{"a":"b"}',    null,           false], // #31
+                ['string',     '"null"',       null,           false], // #32
+                ['integer',    '-1',           null,           false], // #33
+            ],
+            'array' => [
+                ['string',     '"ABC"',        ['ABC'],   true],  // #34
+                ['integer',    '45',           [45],      true],  // #35
+                ['boolean',    'true',         [true],    true],  // #36
+                ['NULL',       'null',         [null],    true],  // #37
+                ['array',      '["ABC"]',      ['ABC'],   true],  // #38
+                ['object',     '{"a":"b"}',    null,           false], // #39
+            ],
+        ];
 
         // #40 check multiple types (first valid)
-        $tests[] = array(
+        $tests[] = [
             '{"properties":{"propertyOne":{"type":["number", "string"]}}}',
             '{"propertyOne":42}',
             'integer', 'integer', 42, true
-        );
+        ];
 
         // #41 check multiple types (last valid)
-        $tests[] = array(
+        $tests[] = [
             '{"properties":{"propertyOne":{"type":["number", "string"]}}}',
             '{"propertyOne":"42"}',
             'string', 'string', '42', true
-        );
+        ];
 
         // #42 check the meaning of life
-        $tests[] = array(
+        $tests[] = [
             '{"properties":{"propertyOne":{"type":"any"}}}',
             '{"propertyOne":"42"}',
             'string', 'string', '42', true
-        );
+        ];
 
         // #43 check turple coercion
-        $tests[] = array(
+        $tests[] = [
             '{"properties":{"propertyOne":{"type":"array","items":[{"type":"number"},{"type":"string"}]}}}',
             '{"propertyOne":["42", 42]}',
-            'array', 'array', array(42, '42'), true
-        );
+            'array', 'array', [42, '42'], true
+        ];
 
         // #44 check early coercion
-        $tests[] = array(
+        $tests[] = [
             '{"properties":{"propertyOne":{"type":["object", "number", "string"]}}}',
             '{"propertyOne":"42"}',
             'string', 'integer', 42, true, Constraint::CHECK_MODE_EARLY_COERCE
-        );
+        ];
 
         // #45 check multiple types (none valid)
-        $tests[] = array(
+        $tests[] = [
             '{"properties":{"propertyOne":{"type":["number", "boolean"]}}}',
             '{"propertyOne":"42"}',
             'string', 'integer', 42, true
-        );
+        ];
 
         // #46 check coercion with "const"
-        $tests[] = array(
+        $tests[] = [
             '{"properties":{"propertyOne":{"type":"string","const":"42"}}}',
             '{"propertyOne":42}',
             'integer', 'string', '42', true
-        );
+        ];
 
         // #47 check coercion with "const"
-        $tests[] = array(
+        $tests[] = [
             '{"properties":{"propertyOne":{"type":"number","const":42}}}',
             '{"propertyOne":"42"}',
             'string', 'integer', 42, true
-        );
+        ];
 
         // #48 check boolean coercion with "const"
-        $tests[] = array(
+        $tests[] = [
             '{"properties":{"propertyOne":{"type":"boolean","const":false}}}',
             '{"propertyOne":"false"}',
             'string', 'boolean', false, true
-        );
+        ];
 
         // #49 check boolean coercion with "const"
-        $tests[] = array(
+        $tests[] = [
             '{"properties":{"propertyOne":{"type":"boolean","const":true}}}',
             '{"propertyOne":"true"}',
             'string', 'boolean', true, true
-        );
+        ];
 
         // #50 check boolean coercion with "const"
-        $tests[] = array(
+        $tests[] = [
             '{"properties":{"propertyOne":{"type":"boolean","const":true}}}',
             '{"propertyOne":1}',
             'integer', 'boolean', true, true
-        );
+        ];
 
         // #51 check boolean coercion with "const"
-        $tests[] = array(
+        $tests[] = [
             '{"properties":{"propertyOne":{"type":"boolean","const":false}}}',
             '{"propertyOne":"false"}',
             'string', 'boolean', false, true
-        );
+        ];
 
         // #52 check post-coercion validation (to array)
-        $tests[] = array(
+        $tests[] = [
             '{"properties":{"propertyOne":{"type":"array","items":[{"type":"number"}]}}}',
             '{"propertyOne":"ABC"}',
             'string', null, null, false
-        );
+        ];
 
         foreach ($types as $toType => $testCases) {
             foreach ($testCases as $testCase) {
-                $tests[] = array(
+                $tests[] = [
                     sprintf('{"properties":{"propertyOne":{"type":"%s"}}}', strtolower($toType)),
                     sprintf('{"propertyOne":%s}', $testCase[1]),
                     $testCase[0],
                     $toType,
                     $testCase[2],
                     $testCase[3]
-                );
+                ];
             }
         }
 

--- a/tests/Constraints/ConstTest.php
+++ b/tests/Constraints/ConstTest.php
@@ -16,8 +16,8 @@ class ConstTest extends BaseTestCase
 
     public function getInvalidTests()
     {
-        return array(
-            array(
+        return [
+            [
                 '{"value":"foo"}',
                 '{
                   "type":"object",
@@ -26,8 +26,8 @@ class ConstTest extends BaseTestCase
                   },
                   "additionalProperties":false
                 }'
-            ),
-            array(
+            ],
+            [
                 '{"value":5}',
                 '{
                   "type":"object",
@@ -36,8 +36,8 @@ class ConstTest extends BaseTestCase
                   },
                   "additionalProperties":false
                 }'
-            ),
-            array(
+            ],
+            [
                 '{"value":false}',
                 '{
                   "type":"object",
@@ -46,8 +46,8 @@ class ConstTest extends BaseTestCase
                   },
                   "additionalProperties":false
                 }'
-            ),
-            array(
+            ],
+            [
                 '{
                     "value": {
                         "foo": "12"
@@ -64,14 +64,14 @@ class ConstTest extends BaseTestCase
                         }
                     }
                 }'
-            )
-        );
+            ]
+        ];
     }
 
     public function getValidTests()
     {
-        return array(
-            array(
+        return [
+            [
                 '{"value":"bar"}',
                 '{
                   "type":"object",
@@ -80,8 +80,8 @@ class ConstTest extends BaseTestCase
                   },
                   "additionalProperties":false
                 }'
-            ),
-            array(
+            ],
+            [
                 '{"value":false}',
                 '{
                   "type":"object",
@@ -90,8 +90,8 @@ class ConstTest extends BaseTestCase
                   },
                   "additionalProperties":false
                 }'
-            ),
-            array(
+            ],
+            [
                 '{"value":true}',
                 '{
                   "type":"object",
@@ -100,8 +100,8 @@ class ConstTest extends BaseTestCase
                   },
                   "additionalProperties":false
                 }'
-            ),
-            array(
+            ],
+            [
                 '{"value":5}',
                 '{
                   "type":"object",
@@ -110,8 +110,8 @@ class ConstTest extends BaseTestCase
                   },
                   "additionalProperties":false
                 }'
-            ),
-            array(
+            ],
+            [
                 '{
                     "value": {
                         "foo": 12
@@ -128,7 +128,7 @@ class ConstTest extends BaseTestCase
                         }
                     }
                 }'
-            )
-        );
+            ]
+        ];
     }
 }

--- a/tests/Constraints/DefaultPropertiesTest.php
+++ b/tests/Constraints/DefaultPropertiesTest.php
@@ -18,7 +18,7 @@ class DefaultPropertiesTest extends VeryBaseTestCase
 {
     public function getValidTests()
     {
-        return array(
+        return [
             /*
             // This test case was intended to check whether a default value can be applied for the
             // entire object, however testing this case is impossible, because there is no way to
@@ -31,72 +31,72 @@ class DefaultPropertiesTest extends VeryBaseTestCase
                 '"valueOne"'
             ),
             */
-            array(// #0 default value in an empty object
+            [// #0 default value in an empty object
                 '{}',
                 '{"properties":{"propertyOne":{"default":"valueOne"}}}',
                 '{"propertyOne":"valueOne"}'
-            ),
-            array(// #1 default value for top-level property
+            ],
+            [// #1 default value for top-level property
                 '{"propertyOne":"valueOne"}',
                 '{"properties":{"propertyTwo":{"default":"valueTwo"}}}',
                 '{"propertyOne":"valueOne","propertyTwo":"valueTwo"}'
-            ),
-            array(// #2 default value for sub-property
+            ],
+            [// #2 default value for sub-property
                 '{"propertyOne":{}}',
                 '{"properties":{"propertyOne":{"properties":{"propertyTwo":{"default":"valueTwo"}}}}}',
                 '{"propertyOne":{"propertyTwo":"valueTwo"}}'
-            ),
-            array(// #3 default value for sub-property with sibling
+            ],
+            [// #3 default value for sub-property with sibling
                 '{"propertyOne":{"propertyTwo":"valueTwo"}}',
                 '{"properties":{"propertyOne":{"properties":{"propertyThree":{"default":"valueThree"}}}}}',
                 '{"propertyOne":{"propertyTwo":"valueTwo","propertyThree":"valueThree"}}'
-            ),
-            array(// #4 default value for top-level property with type check
+            ],
+            [// #4 default value for top-level property with type check
                 '{"propertyOne":"valueOne"}',
                 '{"properties":{"propertyTwo":{"default":"valueTwo","type":"string"}}}',
                 '{"propertyOne":"valueOne","propertyTwo":"valueTwo"}'
-            ),
-            array(// #5 default value for top-level property with v3 required check
+            ],
+            [// #5 default value for top-level property with v3 required check
                 '{"propertyOne":"valueOne"}',
                 '{"properties":{"propertyTwo":{"default":"valueTwo","required":"true"}}}',
                 '{"propertyOne":"valueOne","propertyTwo":"valueTwo"}'
-            ),
-            array(// #6 default value for top-level property with v4 required check
+            ],
+            [// #6 default value for top-level property with v4 required check
                 '{"propertyOne":"valueOne"}',
                 '{"properties":{"propertyTwo":{"default":"valueTwo"}},"required":["propertyTwo"]}',
                 '{"propertyOne":"valueOne","propertyTwo":"valueTwo"}'
-            ),
-            array(// #7 default value for an already set property
+            ],
+            [// #7 default value for an already set property
                 '{"propertyOne":"alreadySetValueOne"}',
                 '{"properties":{"propertyOne":{"default":"valueOne"}}}',
                 '{"propertyOne":"alreadySetValueOne"}'
-            ),
-            array(// #8 default item value for an array
+            ],
+            [// #8 default item value for an array
                 '["valueOne"]',
                 '{"type":"array","items":[{},{"type":"string","default":"valueTwo"}]}',
                 '["valueOne","valueTwo"]'
-            ),
-            array(// #9 default item value for an empty array
+            ],
+            [// #9 default item value for an empty array
                 '[]',
                 '{"type":"array","items":[{"type":"string","default":"valueOne"}]}',
                 '["valueOne"]'
-            ),
-            array(// #10 property without a default available
+            ],
+            [// #10 property without a default available
                 '{"propertyOne":"alreadySetValueOne"}',
                 '{"properties":{"propertyOne":{"type":"string"}}}',
                 '{"propertyOne":"alreadySetValueOne"}'
-            ),
-            array(// #11 default property value is an object
+            ],
+            [// #11 default property value is an object
                 '{"propertyOne":"valueOne"}',
                 '{"properties":{"propertyTwo":{"default":{}}}}',
                 '{"propertyOne":"valueOne","propertyTwo":{}}'
-            ),
-            array(// #12 default item value is an object
+            ],
+            [// #12 default item value is an object
                 '[]',
                 '{"type":"array","items":[{"default":{}}]}',
                 '[{}]'
-            ),
-            array(// #13 only set required values (draft-04)
+            ],
+            [// #13 only set required values (draft-04)
                 '{}',
                 '{
                     "properties": {
@@ -107,8 +107,8 @@ class DefaultPropertiesTest extends VeryBaseTestCase
                 }',
                 '{"propertyTwo":"valueTwo"}',
                 Constraint::CHECK_MODE_ONLY_REQUIRED_DEFAULTS
-            ),
-            array(// #14 only set required values (draft-03)
+            ],
+            [// #14 only set required values (draft-03)
                 '{}',
                 '{
                     "properties": {
@@ -118,53 +118,53 @@ class DefaultPropertiesTest extends VeryBaseTestCase
                 }',
                 '{"propertyTwo":"valueTwo"}',
                 Constraint::CHECK_MODE_ONLY_REQUIRED_DEFAULTS
-            ),
-            array(// #15 infinite recursion via $ref (object)
+            ],
+            [// #15 infinite recursion via $ref (object)
                 '{}',
                 '{"properties":{"propertyOne": {"$ref": "#","default": "valueOne"}}, "default": {}}',
                 '{"propertyOne":{}}'
-            ),
-            array(// #16 infinite recursion via $ref (array)
+            ],
+            [// #16 infinite recursion via $ref (array)
                 '[]',
                 '{"items":[{"$ref":"#","default":"valueOne"}], "default": []}',
                 '[[]]'
-            ),
-            array(// #17 default top value does not overwrite defined null
+            ],
+            [// #17 default top value does not overwrite defined null
                 'null',
                 '{"default":"valueOne"}',
                 'null'
-            ),
-            array(// #18 default property value does not overwrite defined null
+            ],
+            [// #18 default property value does not overwrite defined null
                 '{"propertyOne":null}',
                 '{"properties":{"propertyOne":{"default":"valueOne"}}}',
                 '{"propertyOne":null}'
-            ),
-            array(// #19 default value in an object is null
+            ],
+            [// #19 default value in an object is null
                 '{}',
                 '{"properties":{"propertyOne":{"default":null}}}',
                 '{"propertyOne":null}'
-            ),
-            array(// #20 default value in an array is null
+            ],
+            [// #20 default value in an array is null
                 '[]',
                 '{"items":[{"default":null}]}',
                 '[null]'
-            ),
-            array(// #21 items might be a schema (instead of an array of schema)
+            ],
+            [// #21 items might be a schema (instead of an array of schema)
                 '[{}]',
                 '{"items":{"properties":{"propertyOne":{"default":"valueOne"}}}}',
                 '[{"propertyOne":"valueOne"}]'
-            ),
-            array(// #22 if items is not an array, it does not create a new item
+            ],
+            [// #22 if items is not an array, it does not create a new item
                 '[]',
                 '{"items":{"properties":{"propertyOne":{"default":"valueOne"}}}}',
                 '[]'
-            ),
-            array(// #23 if items is a schema with a default value and minItems is present, fill the array
+            ],
+            [// #23 if items is a schema with a default value and minItems is present, fill the array
                 '["a"]',
                 '{"items":{"default":"b"}, "minItems": 3}',
                 '["a","b","b"]'
-            ),
-        );
+            ],
+        ];
     }
 
     /**

--- a/tests/Constraints/DependenciesTest.php
+++ b/tests/Constraints/DependenciesTest.php
@@ -16,26 +16,26 @@ class DependenciesTest extends BaseTestCase
 
     public function getInvalidTests()
     {
-        return array(
-            array(
+        return [
+            [
                 '{"bar": 1}',
                 '{
                     "dependencies": {"bar": "foo"}
                 }'
-            ),
-            array(
+            ],
+            [
                 '{"bar": 1}',
                 '{
                     "dependencies": {"bar": ["foo"]}
                 }'
-            ),
-            array(
+            ],
+            [
                 '{"bar": 1, "foo": 1}',
                 '{
                     "dependencies": {"bar": ["foo", "baz"]}
                 }'
-            ),
-            array(
+            ],
+            [
                 '{"bar": 1, "foo": 1}',
                 '{
                     "dependencies": {"bar": {
@@ -44,8 +44,8 @@ class DependenciesTest extends BaseTestCase
                         }
                     }}
                 }'
-            ),
-            array(
+            ],
+            [
                 '{"bar": 1}',
                 '{
                     "dependencies": {"bar": {
@@ -54,8 +54,8 @@ class DependenciesTest extends BaseTestCase
                         }
                     }}
                 }'
-            ),
-            array(
+            ],
+            [
                 '{"bar": 1}',
                 '{
                     "dependencies": {"bar": {
@@ -65,8 +65,8 @@ class DependenciesTest extends BaseTestCase
                         "required": ["foo"]
                     }}
                 }'
-            ),
-            array(
+            ],
+            [
                 '{"bar": true, "foo": "ick"}',
                 '{
                     "dependencies": {"bar": {
@@ -76,56 +76,56 @@ class DependenciesTest extends BaseTestCase
                         }
                     }}
                 }'
-            )
-        );
+            ]
+        ];
     }
 
     public function getValidTests()
     {
-        return array(
-            array(
+        return [
+            [
                 '{}',
                 '{
                     "dependencies": {"bar": "foo"}
                 }'
-            ),
-            array(
+            ],
+            [
                 '{"foo": 1}',
                 '{
                     "dependencies": {"bar": "foo"}
                 }'
-            ),
-            array(
+            ],
+            [
                 '"foo"',
                 '{
                     "dependencies": {"bar": "foo"}
                 }'
-            ),
-            array(
+            ],
+            [
                 '{"bar": 1, "foo": 1}',
                 '{
                     "dependencies": {"bar": "foo"}
                 }'
-            ),
-            array(
+            ],
+            [
                 '{"bar": 1, "foo": 1, "baz": 1}',
                 '{
                     "dependencies": {"bar": ["foo", "baz"]}
                 }'
-            ),
-            array(
+            ],
+            [
                 '{}',
                 '{
                     "dependencies": {"bar": ["foo", "baz"]}
                 }'
-            ),
-            array(
+            ],
+            [
                 '{"foo": 1, "baz": 1}',
                 '{
                     "dependencies": {"bar": ["foo", "baz"]}
                 }'
-            ),
-            array(
+            ],
+            [
                 '{"bar": 1}',
                 '{
                     "dependencies": {"bar": {
@@ -134,8 +134,8 @@ class DependenciesTest extends BaseTestCase
                         }
                     }}
                 }'
-            ),
-            array(
+            ],
+            [
                 '{"bar": 1, "foo": 1}',
                 '{
                     "dependencies": {"bar": {
@@ -145,7 +145,7 @@ class DependenciesTest extends BaseTestCase
                         }
                     }}
                 }'
-            )
-        );
+            ]
+        ];
     }
 }

--- a/tests/Constraints/DisallowTest.php
+++ b/tests/Constraints/DisallowTest.php
@@ -21,8 +21,8 @@ class DisallowTest extends BaseTestCase
 
     public function getInvalidTests()
     {
-        return array(
-            array(
+        return [
+            [
                 '{
                   "value":"The xpto is weird"
                 }',
@@ -35,8 +35,8 @@ class DisallowTest extends BaseTestCase
                     }
                   }
                 }'
-            ),
-            array(
+            ],
+            [
                 '{
                   "value":null
                 }',
@@ -49,8 +49,8 @@ class DisallowTest extends BaseTestCase
                     }
                   }
                 }'
-            ),
-            array(
+            ],
+            [
                 '{"value": 1}',
                 '{
                     "type": "object",
@@ -58,8 +58,8 @@ class DisallowTest extends BaseTestCase
                         "value": {"type": "any", "disallow": "integer"}
                     }
                 }'
-            ),
-            array(
+            ],
+            [
                 '{"value": true}',
                 '{
                     "type": "object",
@@ -67,8 +67,8 @@ class DisallowTest extends BaseTestCase
                         "value": {"type": "any", "disallow": ["integer", "boolean"]}
                     }
                 }'
-            ),
-            array(
+            ],
+            [
                 '{"value": "foo"}',
                 '{
                     "type": "object",
@@ -85,8 +85,8 @@ class DisallowTest extends BaseTestCase
                         }
                     }
                 }'
-            ),
-            array(
+            ],
+            [
                 '{"value": {"foo": "bar"}}',
                 '{
                     "type": "object",
@@ -103,14 +103,14 @@ class DisallowTest extends BaseTestCase
                         }
                     }
                 }'
-            )
-        );
+            ]
+        ];
     }
 
     public function getValidTests()
     {
-        return array(
-            array(
+        return [
+            [
                 '{
                   "value":"The xpto is weird"
                 }',
@@ -123,8 +123,8 @@ class DisallowTest extends BaseTestCase
                     }
                   }
                 }'
-            ),
-            array(
+            ],
+            [
                 '{
                   "value":1
                 }',
@@ -137,8 +137,8 @@ class DisallowTest extends BaseTestCase
                     }
                   }
                 }'
-            ),
-            array(
+            ],
+            [
                 '{"value": {"foo": 1}}',
                 '{
                     "type": "object",
@@ -155,8 +155,8 @@ class DisallowTest extends BaseTestCase
                         }
                     }
                 }'
-            ),
-            array(
+            ],
+            [
                 '{"value": true}',
                 '{
                     "type": "object",
@@ -164,7 +164,7 @@ class DisallowTest extends BaseTestCase
                         "value": {"type": "any", "disallow": "string"}
                     }
                 }'
-            )
-        );
+            ]
+        ];
     }
 }

--- a/tests/Constraints/DivisibleByTest.php
+++ b/tests/Constraints/DivisibleByTest.php
@@ -15,8 +15,8 @@ class DivisibleByTest extends BaseTestCase
 
     public function getInvalidTests()
     {
-        return array(
-            array(
+        return [
+            [
                 '{"value": 5.6333}',
                 '{
                   "type":"object",
@@ -24,8 +24,8 @@ class DivisibleByTest extends BaseTestCase
                     "value":{"type":"number","divisibleBy":3}
                   }
                 }'
-            ),
-            array(
+            ],
+            [
                 '{"value": 35}',
                 '{
                     "type": "object",
@@ -33,8 +33,8 @@ class DivisibleByTest extends BaseTestCase
                         "value": {"type": "integer", "divisibleBy": 1.5}
                     }
                 }'
-            ),
-            array(
+            ],
+            [
                 '{"value": 0.00751}',
                 '{
                     "type": "object",
@@ -42,8 +42,8 @@ class DivisibleByTest extends BaseTestCase
                         "value": {"type": "number", "divisibleBy": 0.0001}
                     }
                 }'
-            ),
-            array(
+            ],
+            [
                 '{"value": 7}',
                 '{
                     "type": "object",
@@ -51,14 +51,14 @@ class DivisibleByTest extends BaseTestCase
                         "value": {"type": "integer", "divisibleBy": 2}
                     }
                 }'
-            )
-        );
+            ]
+        ];
     }
 
     public function getValidTests()
     {
-        return array(
-            array(
+        return [
+            [
                 '{"value": 6}',
                 '{
                   "type":"object",
@@ -66,8 +66,8 @@ class DivisibleByTest extends BaseTestCase
                     "value":{"type":"number","divisibleBy":3}
                   }
                 }'
-            ),
-            array(
+            ],
+            [
                 '{"value": 4.5}',
                 '{
                     "type": "object",
@@ -75,23 +75,23 @@ class DivisibleByTest extends BaseTestCase
                         "value": {"type": "number", "divisibleBy": 1.5}
                     }
                 }'
-            ),
-            array(
+            ],
+            [
                 '{"value": 0.0075}',
                 '{
                     "properties": {
                         "value": {"type": "number", "divisibleBy": 0.0001}
                     }
                 }'
-            ),
-            array(
+            ],
+            [
                 '{"value": 1}',
                 '{
                     "properties": {
                         "value": {"type": "number", "divisibleBy": 0.02}
                     }
                 }'
-            )
-        );
+            ]
+        ];
     }
 }

--- a/tests/Constraints/EnumTest.php
+++ b/tests/Constraints/EnumTest.php
@@ -16,8 +16,8 @@ class EnumTest extends BaseTestCase
 
     public function getInvalidTests()
     {
-        return array(
-            array(
+        return [
+            [
                 '{
                   "value":"Morango"
                 }',
@@ -28,8 +28,8 @@ class EnumTest extends BaseTestCase
                   },
                   "additionalProperties":false
                 }'
-            ),
-            array(
+            ],
+            [
                 '{}',
                 '{
                   "type":"object",
@@ -42,8 +42,8 @@ class EnumTest extends BaseTestCase
                   },
                   "additionalProperties":false
                 }'
-            ),
-            array(
+            ],
+            [
                 '{"value": "4"}',
                 '{
                     "type": "object",
@@ -54,8 +54,8 @@ class EnumTest extends BaseTestCase
                     },
                     "additionalProperties": false
                 }'
-            ),
-            array(
+            ],
+            [
                 '{"value": {"foo": false}}',
                 '{
                     "type": "object",
@@ -66,8 +66,8 @@ class EnumTest extends BaseTestCase
                     },
                     "additionalProperties": false
                 }'
-            ),
-            array(
+            ],
+            [
                 '{
                     "value": {
                         "foo": "12"
@@ -90,14 +90,14 @@ class EnumTest extends BaseTestCase
                         }
                     }
                 }'
-            )
-        );
+            ]
+        ];
     }
 
     public function getValidTests()
     {
-        return array(
-            array(
+        return [
+            [
                 '{
                   "value":"Abacate"
                 }',
@@ -108,8 +108,8 @@ class EnumTest extends BaseTestCase
                   },
                   "additionalProperties":false
                 }'
-            ),
-            array(
+            ],
+            [
                 '{}',
                 '{
                   "type":"object",
@@ -118,8 +118,8 @@ class EnumTest extends BaseTestCase
                   },
                   "additionalProperties":false
                 }'
-            ),
-            array(
+            ],
+            [
                 '{}',
                 '{
                   "type":"object",
@@ -132,8 +132,8 @@ class EnumTest extends BaseTestCase
                   },
                   "additionalProperties":false
                 }'
-            ),
-            array(
+            ],
+            [
                 '{"value": 1}',
                 '{
                     "type": "object",
@@ -141,8 +141,8 @@ class EnumTest extends BaseTestCase
                         "value": {"type": "integer", "enum": [1, 2, 3]}
                     }
                 }'
-            ),
-            array(
+            ],
+            [
                 '{"value": []}',
                 '{
                     "type": "object",
@@ -151,8 +151,8 @@ class EnumTest extends BaseTestCase
                     },
                     "additionalProperties": false
                 }'
-            ),
-            array(
+            ],
+            [
                 '{
                     "value": {
                         "foo": 12
@@ -175,7 +175,7 @@ class EnumTest extends BaseTestCase
                         }
                     }
                 }'
-            )
-        );
+            ]
+        ];
     }
 }

--- a/tests/Constraints/ExtendsTest.php
+++ b/tests/Constraints/ExtendsTest.php
@@ -16,8 +16,8 @@ class ExtendsTest extends BaseTestCase
 
     public function getInvalidTests()
     {
-        return array(
-            array(
+        return [
+            [
                 '{
                   "name":"bruno",
                   "age":50
@@ -36,8 +36,8 @@ class ExtendsTest extends BaseTestCase
                         }
                     }
                 }'
-            ),
-            array(
+            ],
+            [
                 '{
                   "name":"bruno",
                   "age":180
@@ -56,8 +56,8 @@ class ExtendsTest extends BaseTestCase
                         }
                     }
                 }'
-            ),
-            array(
+            ],
+            [
                 '{"foo": 2, "bar": "baz"}',
                 '{
                     "properties": {
@@ -69,8 +69,8 @@ class ExtendsTest extends BaseTestCase
                         }
                     }
                 }'
-            ),
-            array(
+            ],
+            [
                 '{"bar": 2}',
                 '{
                     "properties": {
@@ -89,14 +89,14 @@ class ExtendsTest extends BaseTestCase
                         }
                     ]
                 }'
-            )
-        );
+            ]
+        ];
     }
 
     public function getValidTests()
     {
-        return array(
-            array(
+        return [
+            [
                 '{
                   "name":"bruno",
                   "age":80
@@ -115,8 +115,8 @@ class ExtendsTest extends BaseTestCase
                         }
                     }
                 }'
-            ),
-            array(
+            ],
+            [
                 '{"foo": "baz", "bar": 2}',
                 '{
                     "properties": {
@@ -128,8 +128,8 @@ class ExtendsTest extends BaseTestCase
                         }
                     }
                 }'
-            ),
-            array(
+            ],
+            [
                 '{"foo": "ick", "bar": 2, "baz": null}',
                 '{
                     "properties": {
@@ -148,7 +148,7 @@ class ExtendsTest extends BaseTestCase
                         }
                     ]
                 }'
-            )
-        );
+            ]
+        ];
     }
 }

--- a/tests/Constraints/FactoryTest.php
+++ b/tests/Constraints/FactoryTest.php
@@ -63,19 +63,19 @@ class FactoryTest extends TestCase
 
     public function constraintNameProvider()
     {
-        return array(
-            array('array', 'JsonSchema\Constraints\CollectionConstraint'),
-            array('collection', 'JsonSchema\Constraints\CollectionConstraint'),
-            array('object', 'JsonSchema\Constraints\ObjectConstraint'),
-            array('type', 'JsonSchema\Constraints\TypeConstraint'),
-            array('undefined', 'JsonSchema\Constraints\UndefinedConstraint'),
-            array('string', 'JsonSchema\Constraints\StringConstraint'),
-            array('number', 'JsonSchema\Constraints\NumberConstraint'),
-            array('enum', 'JsonSchema\Constraints\EnumConstraint'),
-            array('const', 'JsonSchema\Constraints\ConstConstraint'),
-            array('format', 'JsonSchema\Constraints\FormatConstraint'),
-            array('schema', 'JsonSchema\Constraints\SchemaConstraint'),
-        );
+        return [
+            ['array', 'JsonSchema\Constraints\CollectionConstraint'],
+            ['collection', 'JsonSchema\Constraints\CollectionConstraint'],
+            ['object', 'JsonSchema\Constraints\ObjectConstraint'],
+            ['type', 'JsonSchema\Constraints\TypeConstraint'],
+            ['undefined', 'JsonSchema\Constraints\UndefinedConstraint'],
+            ['string', 'JsonSchema\Constraints\StringConstraint'],
+            ['number', 'JsonSchema\Constraints\NumberConstraint'],
+            ['enum', 'JsonSchema\Constraints\EnumConstraint'],
+            ['const', 'JsonSchema\Constraints\ConstConstraint'],
+            ['format', 'JsonSchema\Constraints\FormatConstraint'],
+            ['schema', 'JsonSchema\Constraints\SchemaConstraint'],
+        ];
     }
 
     /**
@@ -91,9 +91,9 @@ class FactoryTest extends TestCase
 
     public function invalidConstraintNameProvider()
     {
-        return array(
-            array('invalidConstraintName'),
-        );
+        return [
+            ['invalidConstraintName'],
+        ];
     }
 
     public function testSetConstraintClassExistsCondition()

--- a/tests/Constraints/FormatTest.php
+++ b/tests/Constraints/FormatTest.php
@@ -97,131 +97,131 @@ class FormatTest extends BaseTestCase
 
     public function getValidFormats()
     {
-        return array(
-            array('2001-01-23', 'date'),
-            array('2000-02-29', 'date'),
+        return [
+            ['2001-01-23', 'date'],
+            ['2000-02-29', 'date'],
 
-            array('12:22:01', 'time'),
-            array('00:00:00', 'time'),
-            array('23:59:59', 'time'),
+            ['12:22:01', 'time'],
+            ['00:00:00', 'time'],
+            ['23:59:59', 'time'],
 
-            array('2000-05-01T12:12:12Z', 'date-time'),
-            array('2000-05-01T12:12:12+0100', 'date-time'),
-            array('2000-05-01T12:12:12+01:00', 'date-time'),
-            array('2000-05-01T12:12:12.123456Z', 'date-time'),
-            array('2000-05-01T12:12:12.123Z', 'date-time'),
-            array('2000-05-01T12:12:12.123000Z', 'date-time'),
-            array('2000-05-01T12:12:12.0Z', 'date-time'),
-            array('2000-05-01T12:12:12.000Z', 'date-time'),
-            array('2000-05-01T12:12:12.000000Z', 'date-time'),
+            ['2000-05-01T12:12:12Z', 'date-time'],
+            ['2000-05-01T12:12:12+0100', 'date-time'],
+            ['2000-05-01T12:12:12+01:00', 'date-time'],
+            ['2000-05-01T12:12:12.123456Z', 'date-time'],
+            ['2000-05-01T12:12:12.123Z', 'date-time'],
+            ['2000-05-01T12:12:12.123000Z', 'date-time'],
+            ['2000-05-01T12:12:12.0Z', 'date-time'],
+            ['2000-05-01T12:12:12.000Z', 'date-time'],
+            ['2000-05-01T12:12:12.000000Z', 'date-time'],
 
-            array('0', 'utc-millisec'),
+            ['0', 'utc-millisec'],
 
-            array('aqua', 'color'),
-            array('black', 'color'),
-            array('blue', 'color'),
-            array('fuchsia', 'color'),
-            array('gray', 'color'),
-            array('green', 'color'),
-            array('lime', 'color'),
-            array('maroon', 'color'),
-            array('navy', 'color'),
-            array('olive', 'color'),
-            array('orange', 'color'),
-            array('purple', 'color'),
-            array('red', 'color'),
-            array('silver', 'color'),
-            array('teal', 'color'),
-            array('white', 'color'),
-            array('yellow', 'color'),
-            array('#fff', 'color'),
-            array('#00cc00', 'color'),
+            ['aqua', 'color'],
+            ['black', 'color'],
+            ['blue', 'color'],
+            ['fuchsia', 'color'],
+            ['gray', 'color'],
+            ['green', 'color'],
+            ['lime', 'color'],
+            ['maroon', 'color'],
+            ['navy', 'color'],
+            ['olive', 'color'],
+            ['orange', 'color'],
+            ['purple', 'color'],
+            ['red', 'color'],
+            ['silver', 'color'],
+            ['teal', 'color'],
+            ['white', 'color'],
+            ['yellow', 'color'],
+            ['#fff', 'color'],
+            ['#00cc00', 'color'],
 
-            array('background: blue', 'style'),
-            array('color: #000;', 'style'),
+            ['background: blue', 'style'],
+            ['color: #000;', 'style'],
 
-            array('555 320 1212', 'phone'),
+            ['555 320 1212', 'phone'],
 
-            array('http://bluebox.org', 'uri'),
-            array('//bluebox.org', 'uri-reference'),
-            array('/absolutePathReference/', 'uri-reference'),
-            array('./relativePathReference/', 'uri-reference'),
-            array('./relative:PathReference/', 'uri-reference'),
-            array('relativePathReference/', 'uri-reference'),
-            array('relative/Path:Reference/', 'uri-reference'),
+            ['http://bluebox.org', 'uri'],
+            ['//bluebox.org', 'uri-reference'],
+            ['/absolutePathReference/', 'uri-reference'],
+            ['./relativePathReference/', 'uri-reference'],
+            ['./relative:PathReference/', 'uri-reference'],
+            ['relativePathReference/', 'uri-reference'],
+            ['relative/Path:Reference/', 'uri-reference'],
 
-            array('info@something.edu', 'email'),
+            ['info@something.edu', 'email'],
 
-            array('10.10.10.10', 'ip-address'),
-            array('127.0.0.1', 'ip-address'),
+            ['10.10.10.10', 'ip-address'],
+            ['127.0.0.1', 'ip-address'],
 
-            array('::ff', 'ipv6'),
+            ['::ff', 'ipv6'],
 
-            array('www.example.com', 'host-name'),
-            array('3v4l.org', 'host-name'),
-            array('a-valid-host.com', 'host-name'),
-            array('localhost', 'host-name'),
+            ['www.example.com', 'host-name'],
+            ['3v4l.org', 'host-name'],
+            ['a-valid-host.com', 'host-name'],
+            ['localhost', 'host-name'],
 
-            array('anything', '*'),
-            array('unknown', '*'),
-        );
+            ['anything', '*'],
+            ['unknown', '*'],
+        ];
     }
 
     public function getInvalidFormats()
     {
-        return array(
-            array('January 1st, 1910', 'date'),
-            array('199-01-1', 'date'),
-            array('2012-0-11', 'date'),
-            array('2012-10-1', 'date'),
+        return [
+            ['January 1st, 1910', 'date'],
+            ['199-01-1', 'date'],
+            ['2012-0-11', 'date'],
+            ['2012-10-1', 'date'],
 
-            array('24:01:00', 'time'),
-            array('00:00:60', 'time'),
-            array('25:00:00', 'time'),
+            ['24:01:00', 'time'],
+            ['00:00:60', 'time'],
+            ['25:00:00', 'time'],
 
-            array('invalid_value_2000-05-01T12:12:12Z', 'date-time'),
-            array('2000-05-01T12:12:12Z_invalid_value', 'date-time'),
-            array('1999-1-11T00:00:00Z', 'date-time'),
-            array('1999-01-11T00:00:00+100', 'date-time'),
-            array('1999-01-11T00:00:00+1:00', 'date-time'),
-            array('1999.000Z-01-11T00:00:00+1:00', 'date-time'),
+            ['invalid_value_2000-05-01T12:12:12Z', 'date-time'],
+            ['2000-05-01T12:12:12Z_invalid_value', 'date-time'],
+            ['1999-1-11T00:00:00Z', 'date-time'],
+            ['1999-01-11T00:00:00+100', 'date-time'],
+            ['1999-01-11T00:00:00+1:00', 'date-time'],
+            ['1999.000Z-01-11T00:00:00+1:00', 'date-time'],
 
-            array(PHP_INT_MAX, 'utc-millisec'),
+            [PHP_INT_MAX, 'utc-millisec'],
 
-            array('grey', 'color'),
-            array('#HHH', 'color'),
-            array('#000a', 'color'),
-            array('#aa', 'color'),
+            ['grey', 'color'],
+            ['#HHH', 'color'],
+            ['#000a', 'color'],
+            ['#aa', 'color'],
 
-            array('background; blue', 'style'),
+            ['background; blue', 'style'],
 
-            array('1 123 4424', 'phone'),
+            ['1 123 4424', 'phone'],
 
-            array('htt:/bluebox.org', 'uri'),
-            array('.relative:path/reference/', 'uri'),
-            array('', 'uri'),
-            array('//bluebox.org', 'uri'),
-            array('/absolutePathReference/', 'uri'),
-            array('./relativePathReference/', 'uri'),
-            array('./relative:PathReference/', 'uri'),
-            array('relativePathReference/', 'uri'),
-            array('relative/Path:Reference/', 'uri'),
+            ['htt:/bluebox.org', 'uri'],
+            ['.relative:path/reference/', 'uri'],
+            ['', 'uri'],
+            ['//bluebox.org', 'uri'],
+            ['/absolutePathReference/', 'uri'],
+            ['./relativePathReference/', 'uri'],
+            ['./relative:PathReference/', 'uri'],
+            ['relativePathReference/', 'uri'],
+            ['relative/Path:Reference/', 'uri'],
 
-            array('info@somewhere', 'email'),
+            ['info@somewhere', 'email'],
 
-            array('256.2.2.2', 'ip-address'),
+            ['256.2.2.2', 'ip-address'],
 
-            array(':::ff', 'ipv6'),
+            [':::ff', 'ipv6'],
 
-            array('@localhost', 'host-name'),
-            array('..nohost', 'host-name'),
-        );
+            ['@localhost', 'host-name'],
+            ['..nohost', 'host-name'],
+        ];
     }
 
     public function getValidTests()
     {
-        return array(
-            array(
+        return [
+            [
                 '{ "counter": "10" }',
                 '{
                     "type": "object",
@@ -232,14 +232,14 @@ class FormatTest extends BaseTestCase
                             "pattern": "[0-9]+"
                         }
                     }
-                }'),
-        );
+                }'],
+        ];
     }
 
     public function getInvalidTests()
     {
-        return array(
-            array(
+        return [
+            [
                 '{ "counter": "blue" }',
                 '{
                     "type": "object",
@@ -251,8 +251,8 @@ class FormatTest extends BaseTestCase
                         }
                     }
                 }'
-            ),
-            array(
+            ],
+            [
                 '{ "color": "blueberry" }',
                 '{
                     "type": "object",
@@ -263,7 +263,7 @@ class FormatTest extends BaseTestCase
                         }
                     }
                 }'
-            )
-        );
+            ]
+        ];
     }
 }

--- a/tests/Constraints/MinItemsMaxItemsTest.php
+++ b/tests/Constraints/MinItemsMaxItemsTest.php
@@ -15,8 +15,8 @@ class MinItemsMaxItemsTest extends BaseTestCase
 
     public function getInvalidTests()
     {
-        return array(
-            array(
+        return [
+            [
                 '{
                   "value":[2]
                 }',
@@ -26,8 +26,8 @@ class MinItemsMaxItemsTest extends BaseTestCase
                     "value":{"type":"array","minItems":2,"maxItems":4}
                   }
                 }'
-            ),
-            array(
+            ],
+            [
                 '{
                   "value":[2,2,5,8,5]
                 }',
@@ -37,14 +37,14 @@ class MinItemsMaxItemsTest extends BaseTestCase
                     "value":{"type":"array","minItems":2,"maxItems":4}
                   }
                 }'
-            )
-        );
+            ]
+        ];
     }
 
     public function getValidTests()
     {
-        return array(
-            array(
+        return [
+            [
                 '{
                   "value":[2,2]
                 }',
@@ -54,8 +54,8 @@ class MinItemsMaxItemsTest extends BaseTestCase
                     "value":{"type":"array","minItems":2,"maxItems":4}
                   }
                 }'
-            ),
-            array(
+            ],
+            [
                 '{
                   "value":[2,2,5,8]
                 }',
@@ -65,7 +65,7 @@ class MinItemsMaxItemsTest extends BaseTestCase
                     "value":{"type":"array","minItems":2,"maxItems":4}
                   }
                 }'
-            )
-        );
+            ]
+        ];
     }
 }

--- a/tests/Constraints/MinLengthMaxLengthMultiByteTest.php
+++ b/tests/Constraints/MinLengthMaxLengthMultiByteTest.php
@@ -22,8 +22,8 @@ class MinLengthMaxLengthMultiByteTest extends BaseTestCase
 
     public function getInvalidTests()
     {
-        return array(
-            array(
+        return [
+            [
                 '{
                   "value":"☀"
                 }',
@@ -33,8 +33,8 @@ class MinLengthMaxLengthMultiByteTest extends BaseTestCase
                     "value":{"type":"string","minLength":2,"maxLength":4}
                   }
                 }'
-            ),
-            array(
+            ],
+            [
                 '{
                   "value":"☀☁☂☃☺"
                 }',
@@ -44,14 +44,14 @@ class MinLengthMaxLengthMultiByteTest extends BaseTestCase
                     "value":{"type":"string","minLength":2,"maxLength":4}
                   }
                 }'
-            )
-        );
+            ]
+        ];
     }
 
     public function getValidTests()
     {
-        return array(
-            array(
+        return [
+            [
                 '{
                   "value":"☀☁"
                 }',
@@ -61,8 +61,8 @@ class MinLengthMaxLengthMultiByteTest extends BaseTestCase
                     "value":{"type":"string","minLength":2,"maxLength":4}
                   }
                 }'
-            ),
-            array(
+            ],
+            [
                 '{
                   "value":"☀☁☂☃"
                 }',
@@ -72,7 +72,7 @@ class MinLengthMaxLengthMultiByteTest extends BaseTestCase
                     "value":{"type":"string","minLength":2,"maxLength":4}
                   }
                 }'
-            )
-        );
+            ]
+        ];
     }
 }

--- a/tests/Constraints/MinLengthMaxLengthTest.php
+++ b/tests/Constraints/MinLengthMaxLengthTest.php
@@ -15,8 +15,8 @@ class MinLengthMaxLengthTest extends BaseTestCase
 
     public function getInvalidTests()
     {
-        return array(
-            array(
+        return [
+            [
                 '{
                   "value":"w"
                 }',
@@ -26,8 +26,8 @@ class MinLengthMaxLengthTest extends BaseTestCase
                     "value":{"type":"string","minLength":2,"maxLength":4}
                   }
                 }'
-            ),
-            array(
+            ],
+            [
                 '{
                   "value":"wo7us"
                 }',
@@ -37,14 +37,14 @@ class MinLengthMaxLengthTest extends BaseTestCase
                     "value":{"type":"string","minLength":2,"maxLength":4}
                   }
                 }'
-            )
-        );
+            ]
+        ];
     }
 
     public function getValidTests()
     {
-        return array(
-            array(
+        return [
+            [
                 '{
                   "value":"wo"
                 }',
@@ -54,8 +54,8 @@ class MinLengthMaxLengthTest extends BaseTestCase
                     "value":{"type":"string","minLength":2,"maxLength":4}
                   }
                 }'
-            ),
-            array(
+            ],
+            [
                 '{
                   "value":"wo7u"
                 }',
@@ -65,7 +65,7 @@ class MinLengthMaxLengthTest extends BaseTestCase
                     "value":{"type":"string","minLength":2,"maxLength":4}
                   }
                 }'
-            ),
-        );
+            ],
+        ];
     }
 }

--- a/tests/Constraints/MinMaxPropertiesTest.php
+++ b/tests/Constraints/MinMaxPropertiesTest.php
@@ -18,8 +18,8 @@ class MinMaxPropertiesTest extends BaseTestCase
      */
     public function getValidTests()
     {
-        return array(
-            array(
+        return [
+            [
                 '{
                   "value": {}
                 }',
@@ -29,8 +29,8 @@ class MinMaxPropertiesTest extends BaseTestCase
                     "value": {"type": "object", "minProperties": 0}
                   }
                 }'
-            ),
-            array(
+            ],
+            [
                 '{
                   "value": {}
                 }',
@@ -40,8 +40,8 @@ class MinMaxPropertiesTest extends BaseTestCase
                     "value": {"type": "object", "maxProperties": 1}
                   }
                 }'
-            ),
-            array(
+            ],
+            [
                 '{
                   "value": {}
                 }',
@@ -51,8 +51,8 @@ class MinMaxPropertiesTest extends BaseTestCase
                     "value": {"type": "object", "minProperties": 0,"maxProperties": 1}
                   }
                 }'
-            ),
-            array(
+            ],
+            [
                 '{
                   "value": {"foo": 1, "bar": 2}
                 }',
@@ -62,8 +62,8 @@ class MinMaxPropertiesTest extends BaseTestCase
                     "value": {"type": "object", "minProperties": 1,"maxProperties": 2}
                   }
                 }'
-            ),
-        );
+            ],
+        ];
     }
 
     /**
@@ -71,8 +71,8 @@ class MinMaxPropertiesTest extends BaseTestCase
      */
     public function getInvalidTests()
     {
-        return array(
-            array(
+        return [
+            [
                 '{
                   "value": {}
                 }',
@@ -82,8 +82,8 @@ class MinMaxPropertiesTest extends BaseTestCase
                     "value": {"type": "object", "minProperties": 1}
                   }
                 }'
-            ),
-            array(
+            ],
+            [
                 '{}',
                 '{
                   "type": "object",
@@ -97,8 +97,8 @@ class MinMaxPropertiesTest extends BaseTestCase
                   },
                   "minProperties": 1
                 }'
-            ),
-            array(
+            ],
+            [
                 '{
                   "value": {
                     "propertyOne": "valueOne",
@@ -111,8 +111,8 @@ class MinMaxPropertiesTest extends BaseTestCase
                     "value": {"type": "object", "maxProperties": 1}
                   }
                 }'
-            ),
-            array(
+            ],
+            [
                 '{
                   "value": {"foo": 1, "bar": 2, "baz": 3}
                 }',
@@ -122,8 +122,8 @@ class MinMaxPropertiesTest extends BaseTestCase
                     "value": {"type": "object", "minProperties": 1,"maxProperties": 2}
                   }
                 }'
-            ),
-            array(
+            ],
+            [
                 '{
                   "value": []
                 }',
@@ -132,7 +132,7 @@ class MinMaxPropertiesTest extends BaseTestCase
                     "value": {"minProperties": 1,"maxProperties": 2}
                   }
                 }'
-            ),
-        );
+            ],
+        ];
     }
 }

--- a/tests/Constraints/MinimumMaximumTest.php
+++ b/tests/Constraints/MinimumMaximumTest.php
@@ -15,8 +15,8 @@ class MinimumMaximumTest extends BaseTestCase
 
     public function getInvalidTests()
     {
-        return array(
-            array(
+        return [
+            [
                 '{
                   "value":2
                 }',
@@ -26,8 +26,8 @@ class MinimumMaximumTest extends BaseTestCase
                     "value":{"type":"integer","minimum":4}
                   }
                 }'
-            ),
-            array(
+            ],
+            [
                 '{"value": 3}',
                 '{
                     "type": "object",
@@ -35,8 +35,8 @@ class MinimumMaximumTest extends BaseTestCase
                         "value": {"type": "integer", "minimum": 3, "exclusiveMinimum": true}
                     }
                 }'
-            ),
-            array(
+            ],
+            [
                 '{
                   "value":16
                 }',
@@ -46,8 +46,8 @@ class MinimumMaximumTest extends BaseTestCase
                     "value":{"type":"integer","maximum":8}
                   }
                 }'
-            ),
-            array(
+            ],
+            [
                 '{"value": 8}',
                 '{
                     "type": "object",
@@ -55,8 +55,8 @@ class MinimumMaximumTest extends BaseTestCase
                         "value": {"type": "integer", "maximum": 8, "exclusiveMaximum": true}
                     }
                 }'
-            ),
-            array(
+            ],
+            [
                 '{"value": 4}',
                 '{
                     "type": "object",
@@ -64,8 +64,8 @@ class MinimumMaximumTest extends BaseTestCase
                         "value": {"type": "integer", "exclusiveMinimum": true}
                     }
                 }'
-            ),
-            array(
+            ],
+            [
                 '{"value": 4}',
                 '{
                     "type": "object",
@@ -73,8 +73,8 @@ class MinimumMaximumTest extends BaseTestCase
                         "value": {"type": "integer", "exclusiveMaximum": true}
                     }
                 }'
-            ),
-            array(
+            ],
+            [
                 '{"value": 4}',
                 '{
                     "type": "object",
@@ -82,38 +82,38 @@ class MinimumMaximumTest extends BaseTestCase
                         "value": {"type": "integer", "minimum": 5, "exclusiveMinimum": false}
                     }
                 }'
-            ),
-            array(
+            ],
+            [
                 '{"value": 4}',
                 '{
                     "properties": {
                         "value": {"type": "integer", "maximum": 3, "exclusiveMaximum": false}
                     }
                 }'
-            ),
-            array(
+            ],
+            [
                 '{"value": 0.00}',
                 '{
                     "properties": {
                         "value": {"type": "number", "minimum": 0, "exclusiveMinimum": true}
                     }
                 }'
-            ),
-            array(
+            ],
+            [
                 '{"value": 0.00}',
                 '{
                     "properties": {
                         "value": {"type": "number", "maximum": 0, "exclusiveMaximum": true}
                     }
                 }'
-            )
-        );
+            ]
+        ];
     }
 
     public function getValidTests()
     {
-        return array(
-            array(
+        return [
+            [
                 '{
                   "value":6
                 }',
@@ -123,8 +123,8 @@ class MinimumMaximumTest extends BaseTestCase
                     "value":{"type":"integer","minimum":4}
                   }
                 }'
-            ),
-            array(
+            ],
+            [
                 '{
                   "value":6
                 }',
@@ -134,8 +134,8 @@ class MinimumMaximumTest extends BaseTestCase
                     "value":{"type":"integer","maximum":8}
                   }
                 }'
-            ),
-            array(
+            ],
+            [
                 '{"value": 6}',
                 '{
                     "type": "object",
@@ -143,8 +143,8 @@ class MinimumMaximumTest extends BaseTestCase
                         "value": {"type": "integer", "minimum": 6, "exclusiveMinimum": false}
                     }
                 }'
-            ),
-            array(
+            ],
+            [
                 '{"value": 6}',
                 '{
                     "type": "object",
@@ -152,8 +152,8 @@ class MinimumMaximumTest extends BaseTestCase
                         "value": {"type": "integer", "maximum": 6, "exclusiveMaximum": false}
                     }
                 }'
-            ),
-            array(
+            ],
+            [
                 '{"value": 6}',
                 '{
                     "type": "object",
@@ -161,8 +161,8 @@ class MinimumMaximumTest extends BaseTestCase
                         "value": {"type": "integer", "minimum": 6}
                     }
                 }'
-            ),
-            array(
+            ],
+            [
                 '{"value": 6}',
                 '{
                     "type": "object",
@@ -170,7 +170,7 @@ class MinimumMaximumTest extends BaseTestCase
                         "value": {"type": "integer", "maximum": 6}
                     }
                 }'
-            )
-        );
+            ]
+        ];
     }
 }

--- a/tests/Constraints/NotTest.php
+++ b/tests/Constraints/NotTest.php
@@ -15,8 +15,8 @@ class NotTest extends BaseTestCase
 
     public function getInvalidTests()
     {
-        return array(
-            array(
+        return [
+            [
                 '{
                     "x": [1, 2]
                 }',
@@ -31,8 +31,8 @@ class NotTest extends BaseTestCase
                         }
                     }
                 }'
-            ),
-            array( // check that a missing, required property is correctly validated
+            ],
+            [ // check that a missing, required property is correctly validated
                 '{"y": "foo"}',
                 '{
                     "type": "object",
@@ -45,14 +45,14 @@ class NotTest extends BaseTestCase
                         }
                     }
                 }'
-            )
-        );
+            ]
+        ];
     }
 
     public function getValidTests()
     {
-        return array(
-            array(
+        return [
+            [
                 '{
                     "x": [1]
                 }',
@@ -67,8 +67,8 @@ class NotTest extends BaseTestCase
                         }
                     }
                 }'
-            ),
-            array(
+            ],
+            [
                 '{
                     "x": ["foo", 2]
                 }',
@@ -83,8 +83,8 @@ class NotTest extends BaseTestCase
                         }
                     }
                 }'
-            ),
-            array( // check that a missing, non-required property isn't validated
+            ],
+            [ // check that a missing, non-required property isn't validated
                 '{"y": "foo"}',
                 '{
                     "type": "object",
@@ -96,7 +96,7 @@ class NotTest extends BaseTestCase
                         }
                     }
                 }'
-            )
-        );
+            ]
+        ];
     }
 }

--- a/tests/Constraints/NumberAndIntegerTypesTest.php
+++ b/tests/Constraints/NumberAndIntegerTypesTest.php
@@ -15,8 +15,8 @@ class NumberAndIntegerTypesTest extends BaseTestCase
 
     public function getInvalidTests()
     {
-        return array(
-            array(
+        return [
+            [
                 '{
                   "integer": 1.4
                 }',
@@ -26,8 +26,8 @@ class NumberAndIntegerTypesTest extends BaseTestCase
                     "integer":{"type":"integer"}
                   }
                 }'
-            ),
-            array(
+            ],
+            [
                 '{"integer": 1.001}',
                 '{
                     "type": "object",
@@ -35,8 +35,8 @@ class NumberAndIntegerTypesTest extends BaseTestCase
                         "integer": {"type": "integer"}
                     }
                 }'
-            ),
-            array(
+            ],
+            [
                 '{"integer": true}',
                 '{
                     "type": "object",
@@ -44,8 +44,8 @@ class NumberAndIntegerTypesTest extends BaseTestCase
                         "integer": {"type": "integer"}
                     }
                 }'
-            ),
-            array(
+            ],
+            [
                 '{"number": "x"}',
                 '{
                     "type": "object",
@@ -53,14 +53,14 @@ class NumberAndIntegerTypesTest extends BaseTestCase
                         "number": {"type": "number"}
                     }
                 }'
-            )
-        );
+            ]
+        ];
     }
 
     public function getValidTests()
     {
-        return array(
-            array(
+        return [
+            [
                 '{
                   "integer": 1
                 }',
@@ -70,8 +70,8 @@ class NumberAndIntegerTypesTest extends BaseTestCase
                     "integer":{"type":"integer"}
                   }
                 }'
-            ),
-            array(
+            ],
+            [
                 '{
                   "number": 1.4
                 }',
@@ -81,8 +81,8 @@ class NumberAndIntegerTypesTest extends BaseTestCase
                     "number":{"type":"number"}
                   }
                 }'
-            ),
-            array(
+            ],
+            [
                 '{"number": 1e5}',
                 '{
                     "type": "object",
@@ -90,8 +90,8 @@ class NumberAndIntegerTypesTest extends BaseTestCase
                         "number": {"type": "number"}
                     }
                 }'
-            ),
-            array(
+            ],
+            [
                 '{"number": 1}',
                 '{
                     "type": "object",
@@ -100,8 +100,8 @@ class NumberAndIntegerTypesTest extends BaseTestCase
 
                     }
                 }'
-            ),
-            array(
+            ],
+            [
                 '{"number": -49.89}',
                 '{
                     "type": "object",
@@ -112,7 +112,7 @@ class NumberAndIntegerTypesTest extends BaseTestCase
                         }
                     }
                 }'
-            )
-        );
+            ]
+        ];
     }
 }

--- a/tests/Constraints/OfPropertiesTest.php
+++ b/tests/Constraints/OfPropertiesTest.php
@@ -20,8 +20,8 @@ class OfPropertiesTest extends BaseTestCase
 
     public function getValidTests()
     {
-        return array(
-            array(
+        return [
+            [
                 '{"prop1": "abc"}',
                 '{
                   "type": "object",
@@ -36,8 +36,8 @@ class OfPropertiesTest extends BaseTestCase
                   },
                   "required": ["prop1"]
                 }'
-            ),
-            array(
+            ],
+            [
                 '{"prop1": "abc", "prop2": 23}',
                 '{
                   "type": "object",
@@ -52,14 +52,14 @@ class OfPropertiesTest extends BaseTestCase
                   },
                   "required": ["prop1"]
                 }'
-            ),
-        );
+            ],
+        ];
     }
 
     public function getInvalidTests()
     {
-        return array(
-            array(
+        return [
+            [
                 '{"prop1": "abc", "prop2": []}',
                 '{
                   "type": "object",
@@ -75,46 +75,46 @@ class OfPropertiesTest extends BaseTestCase
                   "required": ["prop1"]
                 }',
                 null,
-                array(
-                    array(
+                [
+                    [
                         'property'   => 'prop2',
                         'pointer'    => '/prop2',
                         'message'    => 'Array value found, but a string is required',
-                        'constraint' => array(
+                        'constraint' => [
                             'name' => 'type',
-                            'params' => array(
+                            'params' => [
                                 'expected'   => 'a string',
                                 'found'      => 'array'
-                            )
-                        ),
+                            ]
+                        ],
                         'context'    => Validator::ERROR_DOCUMENT_VALIDATION
-                    ),
-                    array(
+                    ],
+                    [
                         'property'   => 'prop2',
                         'pointer'    => '/prop2',
                         'message'    => 'Array value found, but a number is required',
-                        'constraint' => array(
+                        'constraint' => [
                             'name' => 'type',
-                            'params' => array(
+                            'params' => [
                                 'expected'   => 'a number',
                                 'found'      => 'array'
-                            )
-                        ),
+                            ]
+                        ],
                         'context'    => Validator::ERROR_DOCUMENT_VALIDATION
-                    ),
-                    array(
+                    ],
+                    [
                         'property'   => 'prop2',
                         'pointer'    => '/prop2',
                         'message'    => 'Failed to match exactly one schema',
-                        'constraint' => array(
+                        'constraint' => [
                             'name' => 'oneOf',
-                            'params' => array()
-                        ),
+                            'params' => []
+                        ],
                         'context'    => Validator::ERROR_DOCUMENT_VALIDATION
-                    ),
-                ),
-            ),
-            array(
+                    ],
+                ],
+            ],
+            [
                 '{"prop1": [1,2]}',
                 '{
                   "type": "object",
@@ -133,8 +133,8 @@ class OfPropertiesTest extends BaseTestCase
                     }
                   }
                 }'
-            ),
-            array(
+            ],
+            [
                 '{"prop1": [1,2]}',
                 '{
                   "type": "object",
@@ -149,8 +149,8 @@ class OfPropertiesTest extends BaseTestCase
                     }
                   }
                 }'
-            ),
-            array(
+            ],
+            [
                 '{"prop1": [1,2]}',
                 '{
                   "type": "object",
@@ -168,8 +168,8 @@ class OfPropertiesTest extends BaseTestCase
                     }
                   }
                 }'
-            ),
-            array(
+            ],
+            [
                 '{"prop1": [1,2]}',
                 '{
                   "type": "object",
@@ -187,8 +187,8 @@ class OfPropertiesTest extends BaseTestCase
                     }
                   }
                 }'
-            ),
-            array(
+            ],
+            [
                 '{"prop1": [1,2]}',
                 '{
                   "type": "object",
@@ -207,8 +207,8 @@ class OfPropertiesTest extends BaseTestCase
                     }
                   }
                 }'
-            ),
-            array(
+            ],
+            [
                 '{"prop1": [1,2]}',
                 '{
                   "type": "object",
@@ -228,8 +228,8 @@ class OfPropertiesTest extends BaseTestCase
                     }
                   }
                 }'
-            )
-        );
+            ]
+        ];
     }
 
     public function testNoPrematureAnyOfException()

--- a/tests/Constraints/PatternPropertiesTest.php
+++ b/tests/Constraints/PatternPropertiesTest.php
@@ -15,200 +15,200 @@ class PatternPropertiesTest extends BaseTestCase
 
     public function getInvalidTests()
     {
-        return array(
+        return [
             // matches pattern but invalid schema for object
-            array(
-                json_encode(array(
-                    'someobject' => array(
+            [
+                json_encode([
+                    'someobject' => [
                         'foobar' => 'foo',
                         'barfoo' => 'bar',
-                    )
-                )),
-                json_encode(array(
+                    ]
+                ]),
+                json_encode([
                     'type' => 'object',
-                    'patternProperties' => array(
-                        '^someobject$' => array(
+                    'patternProperties' => [
+                        '^someobject$' => [
                             'type' => 'object',
                             'additionalProperties' => false,
-                            'properties' => array(
-                                'barfoo' => array(
+                            'properties' => [
+                                'barfoo' => [
                                     'type' => 'string',
-                                ),
-                            )
-                        )
-                    )
-                ))
-            ),
+                                ],
+                            ]
+                        ]
+                    ]
+                ])
+            ],
             // Does not match pattern
-            array(
-                json_encode(array(
+            [
+                json_encode([
                         'regex_us' => false,
-                    )),
-                json_encode(array(
+                ]),
+                json_encode([
                         'type' => 'object',
-                        'patternProperties' => array(
-                            '^[a-z]+_(jp|de)$' => array(
-                                'type' => array('boolean')
-                            )
-                        ),
+                        'patternProperties' => [
+                            '^[a-z]+_(jp|de)$' => [
+                                'type' => ['boolean']
+                            ]
+                        ],
                         'additionalProperties' => false
-                    ))
-            ),
+                ])
+            ],
             // Does not match pattern with unicode
-            array(
-                json_encode(array(
+            [
+                json_encode([
                         '猡猡獛' => false,
-                    )),
-                json_encode(array(
+                ]),
+                json_encode([
                         'type' => 'object',
-                        'patternProperties' => array(
-                            '^[\\x{0080}-\\x{006FFF}]+$' => array(
-                                'type' => array('boolean')
-                            )
-                        ),
+                        'patternProperties' => [
+                            '^[\\x{0080}-\\x{006FFF}]+$' => [
+                                'type' => ['boolean']
+                            ]
+                        ],
                         'additionalProperties' => false
-                    ))
-            ),
+                ])
+            ],
             // An invalid regular expression pattern
-            array(
-                json_encode(array(
+            [
+                json_encode([
                         'regex_us' => false,
-                    )),
-                json_encode(array(
+                ]),
+                json_encode([
                         'type' => 'object',
-                        'patternProperties' => array(
-                            '^[a-z+_jp|de)$' => array(
-                                'type' => array('boolean')
-                            )
-                        ),
+                        'patternProperties' => [
+                            '^[a-z+_jp|de)$' => [
+                                'type' => ['boolean']
+                            ]
+                        ],
                         'additionalProperties' => false
-                    ))
-            ),
-        );
+                ])
+            ],
+        ];
     }
 
     public function getValidTests()
     {
-        return array(
-            array(
+        return [
+            [
                 // validates pattern schema
-                json_encode(array(
-                    'someobject' => array(
+                json_encode([
+                    'someobject' => [
                         'foobar' => 'foo',
                         'barfoo' => 'bar',
-                    ),
-                    'someotherobject' => array(
+                    ],
+                    'someotherobject' => [
                         'foobar' => 1234,
-                    ),
-                    '/products' => array(
-                        'get' => array()
-                    ),
-                    '#products' => array(
-                        'get' => array()
-                    ),
-                    '+products' => array(
-                        'get' => array()
-                    ),
-                    '~products' => array(
-                        'get' => array()
-                    ),
-                    '*products' => array(
-                        'get' => array()
-                    ),
-                    '%products' => array(
-                        'get' => array()
-                    )
-                )),
-                json_encode(array(
+                    ],
+                    '/products' => [
+                        'get' => []
+                    ],
+                    '#products' => [
+                        'get' => []
+                    ],
+                    '+products' => [
+                        'get' => []
+                    ],
+                    '~products' => [
+                        'get' => []
+                    ],
+                    '*products' => [
+                        'get' => []
+                    ],
+                    '%products' => [
+                        'get' => []
+                    ]
+                ]),
+                json_encode([
                     'type' => 'object',
                     'additionalProperties' => false,
-                    'patternProperties' => array(
-                        '^someobject$' => array(
+                    'patternProperties' => [
+                        '^someobject$' => [
                             'type' => 'object',
-                            'properties' => array(
-                                'foobar' => array('type' => 'string'),
-                                'barfoo' => array('type' => 'string'),
-                            ),
-                        ),
-                        '^someotherobject$' => array(
+                            'properties' => [
+                                'foobar' => ['type' => 'string'],
+                                'barfoo' => ['type' => 'string'],
+                            ],
+                        ],
+                        '^someotherobject$' => [
                             'type' => 'object',
-                            'properties' => array(
-                                'foobar' => array('type' => 'number'),
-                            ),
-                        ),
-                        '^/' => array(
+                            'properties' => [
+                                'foobar' => ['type' => 'number'],
+                            ],
+                        ],
+                        '^/' => [
                             'type' => 'object',
-                            'properties' => array(
-                                'get' => array('type' => 'array')
-                            )
-                        ),
-                        '^#' => array(
+                            'properties' => [
+                                'get' => ['type' => 'array']
+                            ]
+                        ],
+                        '^#' => [
                             'type' => 'object',
-                            'properties' => array(
-                                'get' => array('type' => 'array')
-                            )
-                        ),
-                        '^\+' => array(
+                            'properties' => [
+                                'get' => ['type' => 'array']
+                            ]
+                        ],
+                        '^\+' => [
                             'type' => 'object',
-                            'properties' => array(
-                                'get' => array('type' => 'array')
-                            )
-                        ),
-                        '^~' => array(
+                            'properties' => [
+                                'get' => ['type' => 'array']
+                            ]
+                        ],
+                        '^~' => [
                             'type' => 'object',
-                            'properties' => array(
-                                'get' => array('type' => 'array')
-                            )
-                        ),
-                        '^\*' => array(
+                            'properties' => [
+                                'get' => ['type' => 'array']
+                            ]
+                        ],
+                        '^\*' => [
                             'type' => 'object',
-                            'properties' => array(
-                                'get' => array('type' => 'array')
-                            )
-                        ),
-                        '^%' => array(
+                            'properties' => [
+                                'get' => ['type' => 'array']
+                            ]
+                        ],
+                        '^%' => [
                             'type' => 'object',
-                            'properties' => array(
-                                'get' => array('type' => 'array')
-                            )
-                        )
-                    )
-                ))
-            ),
-            array(
-                json_encode(array(
+                            'properties' => [
+                                'get' => ['type' => 'array']
+                            ]
+                        ]
+                    ]
+                ])
+            ],
+            [
+                json_encode([
                         'foobar' => true,
                         'regex_us' => 'foo',
                         'regex_de' => 1234
-                    )),
-                json_encode(array(
+                ]),
+                json_encode([
                         'type' => 'object',
-                        'properties' => array(
-                            'foobar' => array('type' => 'boolean')
-                        ),
-                        'patternProperties' => array(
-                            '^[a-z]+_(us|de)$' => array(
-                                'type' => array('string', 'integer')
-                            )
-                        ),
+                        'properties' => [
+                            'foobar' => ['type' => 'boolean']
+                        ],
+                        'patternProperties' => [
+                            '^[a-z]+_(us|de)$' => [
+                                'type' => ['string', 'integer']
+                            ]
+                        ],
                         'additionalProperties' => false
-                    ))
-            ),
+                ])
+            ],
             // Does match pattern with unicode
-            array(
-                json_encode(array(
+            [
+                json_encode([
                     'ðæſ' => 'unicode',
-                )),
-                json_encode(array(
+                ]),
+                json_encode([
                     'type' => 'object',
-                    'patternProperties' => array(
-                        '^[\\x{0080}-\\x{10FFFF}]+$' => array(
-                            'type' => array('string')
-                        )
-                    ),
+                    'patternProperties' => [
+                        '^[\\x{0080}-\\x{10FFFF}]+$' => [
+                            'type' => ['string']
+                        ]
+                    ],
                     'additionalProperties' => false
-                ))
-            ),
-        );
+                ])
+            ],
+        ];
     }
 }

--- a/tests/Constraints/PatternTest.php
+++ b/tests/Constraints/PatternTest.php
@@ -15,8 +15,8 @@ class PatternTest extends BaseTestCase
 
     public function getInvalidTests()
     {
-        return array(
-            array(
+        return [
+            [
                 '{
                   "value":"Abacates"
                 }',
@@ -27,8 +27,8 @@ class PatternTest extends BaseTestCase
                   },
                   "additionalProperties":false
                 }'
-            ),
-            array(
+            ],
+            [
                 '{"value": "abc"}',
                 '{
                     "type": "object",
@@ -37,8 +37,8 @@ class PatternTest extends BaseTestCase
                     },
                     "additionalProperties": false
                 }'
-            ),
-            array(
+            ],
+            [
                 '{"value": "Ã¼"}',
                 '{
                     "type": "object",
@@ -47,14 +47,14 @@ class PatternTest extends BaseTestCase
                     },
                     "additionalProperties": false
                 }'
-            ),
-        );
+            ],
+        ];
     }
 
     public function getValidTests()
     {
-        return array(
-            array(
+        return [
+            [
                 '{
                   "value":"Abacates"
                 }',
@@ -65,8 +65,8 @@ class PatternTest extends BaseTestCase
                   },
                   "additionalProperties":false
                 }'
-            ),
-            array(
+            ],
+            [
                 '{
                   "value":"Abacates"
                 }',
@@ -77,8 +77,8 @@ class PatternTest extends BaseTestCase
                   },
                   "additionalProperties":false
                 }'
-            ),
-            array(
+            ],
+            [
                 '{"value": "aaa"}',
                 '{
                     "type": "object",
@@ -87,8 +87,8 @@ class PatternTest extends BaseTestCase
                     },
                     "additionalProperties": false
                 }'
-            ),
-            array(
+            ],
+            [
                 '{"value": "↓æ→"}',
                 '{
                     "type": "object",
@@ -97,7 +97,7 @@ class PatternTest extends BaseTestCase
                     },
                     "additionalProperties": false
                 }'
-            )
-        );
+            ]
+        ];
     }
 }

--- a/tests/Constraints/PointerTest.php
+++ b/tests/Constraints/PointerTest.php
@@ -18,124 +18,124 @@ class PointerTest extends TestCase
 
     public function testVariousPointers()
     {
-        $schema = array(
+        $schema = [
             'type' => 'object',
-            'required' => array('prop1', 'prop2', 'prop3', 'prop4'),
-            'properties' => array(
-                'prop1' => array(
+            'required' => ['prop1', 'prop2', 'prop3', 'prop4'],
+            'properties' => [
+                'prop1' => [
                     'type' => 'string'
-                ),
-                'prop2' => array(
+                ],
+                'prop2' => [
                     'type' => 'object',
-                    'required' => array('prop2.1'),
-                    'properties' => array(
-                        'prop2.1' => array(
+                    'required' => ['prop2.1'],
+                    'properties' => [
+                        'prop2.1' => [
                             'type' => 'string'
-                        )
-                    )
-                ),
-                'prop3' => array(
+                        ]
+                    ]
+                ],
+                'prop3' => [
                     'type' => 'object',
-                    'required' => array('prop3/1'),
-                    'properties' => array(
-                        'prop3/1' => array(
+                    'required' => ['prop3/1'],
+                    'properties' => [
+                        'prop3/1' => [
                             'type' => 'object',
-                            'required' => array('prop3/1.1'),
-                            'properties' => array(
-                                'prop3/1.1' => array(
+                            'required' => ['prop3/1.1'],
+                            'properties' => [
+                                'prop3/1.1' => [
                                     'type' => 'string'
-                                )
-                            )
-                        )
-                    )
-                ),
-                'prop4' => array(
+                                ]
+                            ]
+                        ]
+                    ]
+                ],
+                'prop4' => [
                     'type' => 'array',
                     'minItems' => 1,
-                    'items' => array(
+                    'items' => [
                         'type' => 'object',
-                        'required' => array('prop4-child'),
-                        'properties' => array(
-                            'prop4-child' => array(
+                        'required' => ['prop4-child'],
+                        'properties' => [
+                            'prop4-child' => [
                                 'type' => 'string'
-                            )
-                        )
-                    )
-                )
-            )
-        );
+                            ]
+                        ]
+                    ]
+                ]
+            ]
+        ];
 
-        $value = array(
-            'prop2' => array(
+        $value = [
+            'prop2' => [
                 'foo' => 'bar'
-            ),
-            'prop3' => array(
-                'prop3/1' => array(
+            ],
+            'prop3' => [
+                'prop3/1' => [
                     'foo' => 'bar'
-                )
-            ),
-            'prop4' => array(
-                array(
+                ]
+            ],
+            'prop4' => [
+                [
                     'foo' => 'bar'
-                )
-            )
-        );
+                ]
+            ]
+        ];
 
         $validator = new Validator();
         $checkValue = json_decode(json_encode($value));
         $validator->validate($checkValue, json_decode(json_encode($schema)));
 
         $this->assertEquals(
-            array(
-                array(
+            [
+                [
                     'property' => 'prop1',
                     'pointer' => '/prop1',
                     'message' => 'The property prop1 is required',
-                    'constraint' => array(
+                    'constraint' => [
                         'name' => 'required',
-                        'params' => array(
+                        'params' => [
                             'property' => 'prop1'
-                        )
-                    ),
+                        ]
+                    ],
                     'context'    => Validator::ERROR_DOCUMENT_VALIDATION
-                ),
-                array(
+                ],
+                [
                     'property' => 'prop2.prop2.1',
                     'pointer' => '/prop2/prop2.1',
                     'message' => 'The property prop2.1 is required',
-                    'constraint' => array(
+                    'constraint' => [
                         'name' => 'required',
-                        'params' => array(
+                        'params' => [
                             'property' => 'prop2.1'
-                        )
-                    ),
+                        ]
+                    ],
                     'context'    => Validator::ERROR_DOCUMENT_VALIDATION
-                ),
-                array(
+                ],
+                [
                     'property' => 'prop3.prop3/1.prop3/1.1',
                     'pointer' => '/prop3/prop3~11/prop3~11.1',
                     'message' => 'The property prop3/1.1 is required',
-                    'constraint' => array(
+                    'constraint' => [
                         'name' => 'required',
-                        'params' => array(
+                        'params' => [
                             'property' => 'prop3/1.1'
-                        )
-                    ),
+                        ]
+                    ],
                     'context'    => Validator::ERROR_DOCUMENT_VALIDATION
-                ),
-                array(
+                ],
+                [
                     'property' => 'prop4[0].prop4-child',
                     'pointer' => '/prop4/0/prop4-child',
                     'message' => 'The property prop4-child is required',
-                    'constraint' => array(
+                    'constraint' => [
                         'name' => 'required',
-                        'params' => array(
+                        'params' => [
                             'property' => 'prop4-child'
-                        )
-                    ),
+                        ]
+                    ],
                     'context'    => Validator::ERROR_DOCUMENT_VALIDATION
-                )
-            ),
+                ]
+            ],
             $validator->getErrors()
         );
     }

--- a/tests/Constraints/ReadOnlyTest.php
+++ b/tests/Constraints/ReadOnlyTest.php
@@ -16,8 +16,8 @@ class ReadOnlyTest extends BaseTestCase
     public function getInvalidTests()
     {
         //is readonly really required?
-        return array(
-            array(
+        return [
+            [
                 '{ "number": [] }',
                 '{
                   "type":"object",
@@ -25,14 +25,14 @@ class ReadOnlyTest extends BaseTestCase
                     "number":{"type":"string","readonly":true}
                   }
                 }'
-            )
-        );
+            ]
+        ];
     }
 
     public function getValidTests()
     {
-        return array(
-            array(
+        return [
+            [
                 '{
                   "number": "1.4"
                 }',
@@ -42,7 +42,7 @@ class ReadOnlyTest extends BaseTestCase
                     "number":{"type":"string","readonly":true}
                   }
                 }'
-            )
-        );
+            ]
+        ];
     }
 }

--- a/tests/Constraints/RequireTest.php
+++ b/tests/Constraints/RequireTest.php
@@ -15,8 +15,8 @@ class RequireTest extends BaseTestCase
 
     public function getInvalidTests()
     {
-        return array(
-            array(
+        return [
+            [
                 '{
                   "state":"DF"
                 }',
@@ -27,14 +27,14 @@ class RequireTest extends BaseTestCase
                     "city":{"type":"string"}
                   }
                 }'
-            )
-        );
+            ]
+        ];
     }
 
     public function getValidTests()
     {
-        return array(
-            array(
+        return [
+            [
                 '{
                   "state":"DF",
                   "city":"Brasília"
@@ -46,7 +46,7 @@ class RequireTest extends BaseTestCase
                     "city":{"type":"string"}
                   }
                 }'
-            )
-        );
+            ]
+        ];
     }
 }

--- a/tests/Constraints/RequiredPropertyTest.php
+++ b/tests/Constraints/RequiredPropertyTest.php
@@ -115,8 +115,8 @@ class RequiredPropertyTest extends BaseTestCase
 
     public function getInvalidTests()
     {
-        return array(
-            array(
+        return [
+            [
                 '{}',
                 '{
                   "type":"object",
@@ -124,8 +124,8 @@ class RequiredPropertyTest extends BaseTestCase
                     "number":{"type":"number","required":true}
                   }
                 }'
-            ),
-            array(
+            ],
+            [
                 '{}',
                 '{
                     "type": "object",
@@ -134,8 +134,8 @@ class RequiredPropertyTest extends BaseTestCase
                     },
                     "required": ["number"]
                 }'
-            ),
-            array(
+            ],
+            [
                 '{
                     "foo": {}
                 }',
@@ -151,8 +151,8 @@ class RequiredPropertyTest extends BaseTestCase
                         }
                     }
                 }'
-            ),
-            array(
+            ],
+            [
                 '{
                     "bar": 1.4
                  }',
@@ -164,14 +164,14 @@ class RequiredPropertyTest extends BaseTestCase
                     },
                     "required": ["bar"]
                 }'
-            ),
-            array(
+            ],
+            [
                 '{}',
                 '{
                     "required": ["foo"]
                 }'
-            ),
-            array(
+            ],
+            [
                 '{
                 }',
                 '{
@@ -180,8 +180,8 @@ class RequiredPropertyTest extends BaseTestCase
                         "foo": { "required": true }
                     }
                 }'
-            ),
-            array(
+            ],
+            [
                 '{
                   "string":{}
                 }',
@@ -191,8 +191,8 @@ class RequiredPropertyTest extends BaseTestCase
                     "string":{"type":"string", "required": true}
                   }
                 }'
-            ),
-            array(
+            ],
+            [
                 '{
                   "number":{}
                 }',
@@ -202,8 +202,8 @@ class RequiredPropertyTest extends BaseTestCase
                     "number":{"type":"number", "required": true}
                   }
                 }'
-            ),
-            array(
+            ],
+            [
                 '{
                   "integer":{}
                 }',
@@ -213,8 +213,8 @@ class RequiredPropertyTest extends BaseTestCase
                     "integer":{"type":"integer", "required": true}
                   }
                 }'
-            ),
-            array(
+            ],
+            [
                 '{
                   "boolean":{}
                 }',
@@ -224,8 +224,8 @@ class RequiredPropertyTest extends BaseTestCase
                     "boolean":{"type":"boolean", "required": true}
                   }
                 }'
-            ),
-            array(
+            ],
+            [
                 '{
                   "array":{}
                 }',
@@ -236,8 +236,8 @@ class RequiredPropertyTest extends BaseTestCase
                   }
                 }',
                 Constraint::CHECK_MODE_NORMAL
-            ),
-            array(
+            ],
+            [
                 '{
                   "null":{}
                 }',
@@ -247,8 +247,8 @@ class RequiredPropertyTest extends BaseTestCase
                     "null":{"type":"null", "required": true}
                   }
                 }'
-            ),
-            array(
+            ],
+            [
                 '{
                   "foo": {"baz": 1.5}
                 }',
@@ -264,8 +264,8 @@ class RequiredPropertyTest extends BaseTestCase
                     }
                   }
                 }'
-            ),
-            array(
+            ],
+            [
                 '{
                   "foo": {"baz": 1.5}
                 }',
@@ -280,14 +280,14 @@ class RequiredPropertyTest extends BaseTestCase
                     }
                   }
                 }'
-            ),
-        );
+            ],
+        ];
     }
 
     public function getValidTests()
     {
-        return array(
-            array(
+        return [
+            [
                 '{
                   "number": 1.4
                 }',
@@ -297,8 +297,8 @@ class RequiredPropertyTest extends BaseTestCase
                     "number":{"type":"number","required":true}
                   }
                 }'
-            ),
-            array(
+            ],
+            [
                 '{}',
                 '{
                   "type":"object",
@@ -306,8 +306,8 @@ class RequiredPropertyTest extends BaseTestCase
                     "number":{"type":"number"}
                   }
                 }'
-            ),
-            array(
+            ],
+            [
                 '{}',
                 '{
                   "type":"object",
@@ -315,8 +315,8 @@ class RequiredPropertyTest extends BaseTestCase
                     "number":{"type":"number","required":false}
                   }
                 }'
-            ),
-            array(
+            ],
+            [
                 '{
                   "number": 0
                 }',
@@ -326,8 +326,8 @@ class RequiredPropertyTest extends BaseTestCase
                     "number":{"type":"integer","required":true}
                   }
                 }'
-            ),
-            array(
+            ],
+            [
                 '{
                   "is_active": false
                 }',
@@ -337,8 +337,8 @@ class RequiredPropertyTest extends BaseTestCase
                     "is_active":{"type":"boolean","required":true}
                   }
                 }'
-            ),
-            array(
+            ],
+            [
                 '{
                   "status": null
                 }',
@@ -348,8 +348,8 @@ class RequiredPropertyTest extends BaseTestCase
                     "status":{"type":"null","required":true}
                   }
                 }'
-            ),
-            array(
+            ],
+            [
                 '{
                   "users": []
                 }',
@@ -359,8 +359,8 @@ class RequiredPropertyTest extends BaseTestCase
                     "users":{"type":"array","required":true}
                   }
                 }'
-            ),
-            array(
+            ],
+            [
                 '{
                     "foo": "foo",
                     "bar": 1.4
@@ -373,8 +373,8 @@ class RequiredPropertyTest extends BaseTestCase
                     },
                     "required": ["bar"]
                 }'
-            ),
-            array(
+            ],
+            [
                 '{
                     "foo": {"bar": 1.5}
                 }',
@@ -391,8 +391,8 @@ class RequiredPropertyTest extends BaseTestCase
                     },
                     "required": ["foo"]
                 }'
-            ),
-            array(
+            ],
+            [
                 '{
                     "foo": {}
                 }',
@@ -402,8 +402,8 @@ class RequiredPropertyTest extends BaseTestCase
                         "foo": { "required": true }
                     }
                 }'
-            ),
-            array(
+            ],
+            [
                 '{
                   "boo": {"bar": 1.5}
                 }',
@@ -419,8 +419,8 @@ class RequiredPropertyTest extends BaseTestCase
                     }
                   }
                 }'
-            ),
-            array(
+            ],
+            [
                 '{
                   "boo": {"bar": 1.5}
                 }',
@@ -435,7 +435,7 @@ class RequiredPropertyTest extends BaseTestCase
                     }
                   }
                 }'
-            ),
-        );
+            ],
+        ];
     }
 }

--- a/tests/Constraints/SchemaValidationTest.php
+++ b/tests/Constraints/SchemaValidationTest.php
@@ -19,8 +19,8 @@ class SchemaValidationTest extends TestCase
 
     public function getInvalidTests()
     {
-        return array(
-            array(// invalid v4 schema (uses v3 require)
+        return [
+            [// invalid v4 schema (uses v3 require)
                 '{
                     "$schema": "http://json-schema.org/draft-04/schema#",
                     "properties": {
@@ -30,8 +30,8 @@ class SchemaValidationTest extends TestCase
                         }
                     }
                 }'
-            ),
-            array(// invalid v4 schema (uses v3 required), use default spec instead of specifying $schema
+            ],
+            [// invalid v4 schema (uses v3 required), use default spec instead of specifying $schema
                 '{
                     "properties": {
                         "propertyOne": {
@@ -40,14 +40,14 @@ class SchemaValidationTest extends TestCase
                         }
                     }
                 }'
-            )
-        );
+            ]
+        ];
     }
 
     public function getValidTests()
     {
-        return array(
-            array(// valid v4 schema (uses v4 require)
+        return [
+            [// valid v4 schema (uses v4 require)
                 '{
                     "$schema": "http://json-schema.org/draft-04/schema#",
                     "properties": {
@@ -57,8 +57,8 @@ class SchemaValidationTest extends TestCase
                     },
                     "required": ["propertyOne"]
                 }'
-            )
-        );
+            ]
+        ];
     }
 
     /**

--- a/tests/Constraints/SelfDefinedSchemaTest.php
+++ b/tests/Constraints/SelfDefinedSchemaTest.php
@@ -17,8 +17,8 @@ class SelfDefinedSchemaTest extends BaseTestCase
 
     public function getInvalidTests()
     {
-        return array(
-            array(
+        return [
+            [
                 '{
                     "$schema": {
                         "$schema": "http://json-schema.org/draft-04/schema#",
@@ -37,14 +37,14 @@ class SelfDefinedSchemaTest extends BaseTestCase
                     "type" : "object"
                 }',
                 ''
-            )
-        );
+            ]
+        ];
     }
 
     public function getValidTests()
     {
-        return array(
-            array(
+        return [
+            [
                 '{
                     "$schema": {
                         "$schema": "http://json-schema.org/draft-04/schema#",
@@ -63,8 +63,8 @@ class SelfDefinedSchemaTest extends BaseTestCase
                     "type" : "object"
                 }',
                 ''
-            )
-        );
+            ]
+        ];
     }
 
     public function testInvalidArgumentException()

--- a/tests/Constraints/TupleTypingTest.php
+++ b/tests/Constraints/TupleTypingTest.php
@@ -15,8 +15,8 @@ class TupleTypingTest extends BaseTestCase
 
     public function getInvalidTests()
     {
-        return array(
-            array(
+        return [
+            [
                 '{
                   "tupleTyping":[2,"a"]
                 }',
@@ -32,8 +32,8 @@ class TupleTypingTest extends BaseTestCase
                     }
                   }
                 }'
-            ),
-            array(
+            ],
+            [
                 '{
                   "tupleTyping":["2",2,true]
                 }',
@@ -50,8 +50,8 @@ class TupleTypingTest extends BaseTestCase
                     }
                   }
                 }'
-            ),
-            array(
+            ],
+            [
                 '{
                   "tupleTyping":["2",2,3]
                 }',
@@ -68,8 +68,8 @@ class TupleTypingTest extends BaseTestCase
                     }
                   }
                 }'
-            ),
-            array(
+            ],
+            [
                 '{"data": [1, "foo", true, 1.5]}',
                 '{
                     "type": "object",
@@ -81,14 +81,14 @@ class TupleTypingTest extends BaseTestCase
                         }
                     }
                 }'
-            )
-        );
+            ]
+        ];
     }
 
     public function getValidTests()
     {
-        return array(
-            array(
+        return [
+            [
                 '{
                   "tupleTyping":["2", 1]
                 }',
@@ -104,8 +104,8 @@ class TupleTypingTest extends BaseTestCase
                     }
                   }
                 }'
-            ),
-            array(
+            ],
+            [
                 '{
                   "tupleTyping":["2",2,3]
                 }',
@@ -121,8 +121,8 @@ class TupleTypingTest extends BaseTestCase
                     }
                   }
                 }'
-            ),
-            array(
+            ],
+            [
                 '{"data": [1, "foo", true]}',
                 '{
                     "type": "object",
@@ -134,7 +134,7 @@ class TupleTypingTest extends BaseTestCase
                         }
                     }
                 }'
-            )
-        );
+            ]
+        ];
     }
 }

--- a/tests/Constraints/TypeTest.php
+++ b/tests/Constraints/TypeTest.php
@@ -29,18 +29,18 @@ class TypeTest extends TestCase
      */
     public function provideIndefiniteArticlesForTypes()
     {
-        return array(
-            array('integer', 'an integer'),
-            array('number', 'a number'),
-            array('boolean', 'a boolean'),
-            array('object', 'an object'),
-            array('array', 'an array'),
-            array('string', 'a string'),
-            array('null', 'a null', array(), 'array'),
-            array(array('string', 'boolean', 'integer'), 'a string, a boolean or an integer'),
-            array(array('string', 'boolean'), 'a string or a boolean'),
-            array(array('string'), 'a string'),
-        );
+        return [
+            ['integer', 'an integer'],
+            ['number', 'a number'],
+            ['boolean', 'a boolean'],
+            ['object', 'an object'],
+            ['array', 'an array'],
+            ['string', 'a string'],
+            ['null', 'a null', [], 'array'],
+            [['string', 'boolean', 'integer'], 'a string, a boolean or an integer'],
+            [['string', 'boolean'], 'a string or a boolean'],
+            [['string'], 'a string'],
+        ];
     }
 
     /**
@@ -49,7 +49,7 @@ class TypeTest extends TestCase
     public function testIndefiniteArticleForTypeInTypeCheckErrorMessage($type, $wording, $value = null, $label = 'NULL')
     {
         $constraint = new TypeConstraint();
-        $constraint->check($value, (object) array('type' => $type));
+        $constraint->check($value, (object) ['type' => $type]);
         $this->assertTypeConstraintError(ucwords($label) . " value found, but $wording is required", $constraint);
     }
 
@@ -96,10 +96,10 @@ class TypeTest extends TestCase
 
     public function validNameWordingDataProvider()
     {
-        $wordings = array();
+        $wordings = [];
 
         foreach (array_keys(TypeConstraint::$wording) as $value) {
-            $wordings[] = array($value);
+            $wordings[] = [$value];
         }
 
         return $wordings;

--- a/tests/Constraints/UnionTypesTest.php
+++ b/tests/Constraints/UnionTypesTest.php
@@ -15,8 +15,8 @@ class UnionTypesTest extends BaseTestCase
 
     public function getInvalidTests()
     {
-        return array(
-            array(
+        return [
+            [
                 '{
                   "stringOrNumber":4.8,
                   "booleanOrNull":5
@@ -28,14 +28,14 @@ class UnionTypesTest extends BaseTestCase
                     "booleanOrNull":{"type":["boolean","null"]}
                   }
                 }'
-            )
-        );
+            ]
+        ];
     }
 
     public function getValidTests()
     {
-        return array(
-            array(
+        return [
+            [
                 '{
                   "stringOrNumber":4.8,
                   "booleanOrNull":false
@@ -47,7 +47,7 @@ class UnionTypesTest extends BaseTestCase
                     "booleanOrNull":{"type":["boolean","null"]}
                   }
                 }'
-            )
-        );
+            ]
+        ];
     }
 }

--- a/tests/Constraints/UnionWithNullValueTest.php
+++ b/tests/Constraints/UnionWithNullValueTest.php
@@ -15,8 +15,8 @@ class UnionWithNullValueTest extends BaseTestCase
 
     public function getInvalidTests()
     {
-        return array(
-            array(
+        return [
+            [
                 '{
                   "stringOrNumber":null,
                   "booleanOrNull":null
@@ -28,14 +28,14 @@ class UnionWithNullValueTest extends BaseTestCase
                     "booleanOrNull":{"type":["boolean","null"]}
                   }
                 }'
-            )
-        );
+            ]
+        ];
     }
 
     public function getValidTests()
     {
-        return array(
-            array(
+        return [
+            [
                 '{
                   "stringOrNumber":12,
                   "booleanOrNull":null
@@ -47,7 +47,7 @@ class UnionWithNullValueTest extends BaseTestCase
                     "booleanOrNull":{"type":["boolean","null"]}
                   }
                 }'
-            )
-        );
+            ]
+        ];
     }
 }

--- a/tests/Constraints/UniqueItemsTest.php
+++ b/tests/Constraints/UniqueItemsTest.php
@@ -15,147 +15,147 @@ class UniqueItemsTest extends BaseTestCase
 
     public function getInvalidTests()
     {
-        return array(
-            array(
+        return [
+            [
                 '[1,2,2]',
                 '{
                   "type":"array",
                   "uniqueItems": true
                 }'
-            ),
-            array(
+            ],
+            [
                 '[{"a":"b"},{"a":"c"},{"a":"b"}]',
                 '{
                   "type":"array",
                   "uniqueItems": true
                 }'
-            ),
-            array(
+            ],
+            [
                 '[{"foo": {"bar" : {"baz" : true}}}, {"foo": {"bar" : {"baz" : true}}}]',
                 '{
                     "type": "array",
                     "uniqueItems": true
                 }'
-            ),
-            array(
+            ],
+            [
                 '[1.0, 1.00, 1]',
                 '{
                     "type": "array",
                     "uniqueItems": true
                 }'
-            ),
-            array(
+            ],
+            [
                 '[["foo"], ["foo"]]',
                 '{
                     "type": "array",
                     "uniqueItems": true
                 }'
-            ),
-            array(
+            ],
+            [
                 '[{}, [1], true, null, {}, 1]',
                 '{
                     "type": "array",
                     "uniqueItems": true
                 }'
-            )
-        );
+            ]
+        ];
     }
 
     public function getValidTests()
     {
-        return array(
-            array(
+        return [
+            [
                 '[1,2,3]',
                 '{
                   "type":"array",
                   "uniqueItems": true
                 }'
-            ),
-            array(
+            ],
+            [
                 '[{"foo": 12}, {"bar": false}]',
                 '{
                     "type": "array",
                     "uniqueItems": true
                 }'
-            ),
-            array(
+            ],
+            [
                 '[1, true]',
                 '{
                     "type": "array",
                     "uniqueItems": true
                 }'
-            ),
-            array(
+            ],
+            [
                 '[0, false]',
                 '{
                     "type": "array",
                     "uniqueItems": true
                 }'
-            ),
-            array(
+            ],
+            [
                 '[{"foo": {"bar" : {"baz" : true}}}, {"foo": {"bar" : {"baz" : false}}}]',
                 '{
                     "type": "array",
                     "uniqueItems": true
                 }'
-            ),
-            array(
+            ],
+            [
                 '[["foo"], ["bar"]]',
                 '{
                     "type": "array",
                     "uniqueItems": true
                 }'
-            ),
-            array(
+            ],
+            [
                 '[{}, [1], true, null, 1]',
                 '{
                     "type": "array",
                     "uniqueItems": true
                 }'
-            ),
+            ],
             // below equals the invalid tests, but with uniqueItems set to false
-            array(
+            [
                 '[1,2,2]',
                 '{
                   "type":"array",
                   "uniqueItems": false
                 }'
-            ),
-            array(
+            ],
+            [
                 '[{"a":"b"},{"a":"c"},{"a":"b"}]',
                 '{
                   "type":"array",
                   "uniqueItems": false
                 }'
-            ),
-            array(
+            ],
+            [
                 '[{"foo": {"bar" : {"baz" : true}}}, {"foo": {"bar" : {"baz" : true}}}]',
                 '{
                     "type": "array",
                     "uniqueItems": false
                 }'
-            ),
-            array(
+            ],
+            [
                 '[1.0, 1.00, 1]',
                 '{
                     "type": "array",
                     "uniqueItems": false
                 }'
-            ),
-            array(
+            ],
+            [
                 '[["foo"], ["foo"]]',
                 '{
                     "type": "array",
                     "uniqueItems": false
                 }'
-            ),
-            array(
+            ],
+            [
                 '[{}, [1], true, null, {}, 1]',
                 '{
                     "type": "array",
                     "uniqueItems": false
                 }'
-            )
-        );
+            ]
+        ];
     }
 }

--- a/tests/Constraints/WrongMessagesFailingTestCaseTest.php
+++ b/tests/Constraints/WrongMessagesFailingTestCaseTest.php
@@ -15,8 +15,8 @@ class WrongMessagesFailingTestCaseTest extends BaseTestCase
 
     public function getInvalidTests()
     {
-        return array(
-            array(
+        return [
+            [
                 '{
                   "stringOrNumber":4.8,
                   "booleanOrNull":["A","B"]
@@ -28,14 +28,14 @@ class WrongMessagesFailingTestCaseTest extends BaseTestCase
                     "booleanOrNull":{"type":["boolean","null"]}
                   }
                 }'
-            )
-        );
+            ]
+        ];
     }
 
     public function getValidTests()
     {
-        return array(
-            array(
+        return [
+            [
                 '{
                   "stringOrNumber":4.8,
                   "booleanOrNull":true
@@ -47,7 +47,7 @@ class WrongMessagesFailingTestCaseTest extends BaseTestCase
                     "booleanOrNull":{"type":["boolean","null"]}
                   }
                 }'
-            )
-        );
+            ]
+        ];
     }
 }

--- a/tests/Drafts/BaseDraftTestCase.php
+++ b/tests/Drafts/BaseDraftTestCase.php
@@ -16,7 +16,7 @@ abstract class BaseDraftTestCase extends BaseTestCase
     {
         $filePaths = $this->getFilePaths();
         $skippedTests = $this->getSkippedTests();
-        $tests = array();
+        $tests = [];
 
         foreach ($filePaths as $path) {
             foreach (glob($path . '/*.json') as $file) {
@@ -33,7 +33,7 @@ abstract class BaseDraftTestCase extends BaseTestCase
                         if ($isValid === $test->valid) {
                             $tests[
                                 $this->createDataSetPath($filename, $suiteDescription, $testCaseDescription)
-                            ] = array(json_encode($test->data), json_encode($suite->schema));
+                            ] = [json_encode($test->data), json_encode($suite->schema)];
                         }
                     }
                 }

--- a/tests/Drafts/Draft3Test.php
+++ b/tests/Drafts/Draft3Test.php
@@ -22,10 +22,10 @@ class Draft3Test extends BaseDraftTestCase
      */
     protected function getFilePaths()
     {
-        return array(
+        return [
             realpath(__DIR__ . $this->relativeTestsRoot . '/draft3'),
             realpath(__DIR__ . $this->relativeTestsRoot . '/draft3/optional')
-        );
+        ];
     }
 
     public function getInvalidForAssocTests()
@@ -55,12 +55,12 @@ class Draft3Test extends BaseDraftTestCase
      */
     protected function getSkippedTests()
     {
-        return array(
+        return [
             // Optional
             'bignum.json',
             'format.json',
             'jsregex.json',
             'zeroTerminatedFloats.json'
-        );
+        ];
     }
 }

--- a/tests/Drafts/Draft4Test.php
+++ b/tests/Drafts/Draft4Test.php
@@ -22,10 +22,10 @@ class Draft4Test extends BaseDraftTestCase
      */
     protected function getFilePaths()
     {
-        return array(
+        return [
             realpath(__DIR__ . $this->relativeTestsRoot . '/draft4'),
             realpath(__DIR__ . $this->relativeTestsRoot . '/draft4/optional')
-        );
+        ];
     }
 
     public function getInvalidForAssocTests()
@@ -55,13 +55,13 @@ class Draft4Test extends BaseDraftTestCase
      */
     protected function getSkippedTests()
     {
-        return array(
+        return [
             // Optional
             'bignum.json',
             'format.json',
             'zeroTerminatedFloats.json',
             // Required
             'not.json' // only one test case failing
-        );
+        ];
     }
 }

--- a/tests/Entity/JsonPointerTest.php
+++ b/tests/Entity/JsonPointerTest.php
@@ -47,67 +47,67 @@ class JsonPointerTest extends TestCase
      */
     public function getTestData()
     {
-        return array(
-            'testDataSet_01' => array(
+        return [
+            'testDataSet_01' => [
                 'testValue'                    => '#/definitions/date',
                 'expectedFileName'             => '',
-                'expectedPropertyPaths'        => array('definitions', 'date'),
+                'expectedPropertyPaths'        => ['definitions', 'date'],
                 'expectedPropertyPathAsString' => '#/definitions/date',
                 'expectedToString'             => '#/definitions/date'
-            ),
-            'testDataSet_02' => array(
+            ],
+            'testDataSet_02' => [
                 'testValue'                    => 'http://www.example.com/definitions.json#/definitions/date',
                 'expectedFileName'             => 'http://www.example.com/definitions.json',
-                'expectedPropertyPaths'        => array('definitions', 'date'),
+                'expectedPropertyPaths'        => ['definitions', 'date'],
                 'expectedPropertyPathAsString' => '#/definitions/date',
                 'expectedToString'             => 'http://www.example.com/definitions.json#/definitions/date'
-            ),
-            'testDataSet_03' => array(
+            ],
+            'testDataSet_03' => [
                 'testValue'                    => '/tmp/schema.json#definitions/common/date/',
                 'expectedFileName'             => '/tmp/schema.json',
-                'expectedPropertyPaths'        => array('definitions', 'common', 'date'),
+                'expectedPropertyPaths'        => ['definitions', 'common', 'date'],
                 'expectedPropertyPathAsString' => '#/definitions/common/date',
                 'expectedToString'             => '/tmp/schema.json#/definitions/common/date'
-            ),
-            'testDataSet_04' => array(
+            ],
+            'testDataSet_04' => [
                 'testValue'                    => './definitions.json#',
                 'expectedFileName'             => './definitions.json',
-                'expectedPropertyPaths'        => array(),
+                'expectedPropertyPaths'        => [],
                 'expectedPropertyPathAsString' => '#',
                 'expectedToString'             => './definitions.json#'
-            ),
-            'testDataSet_05' => array(
+            ],
+            'testDataSet_05' => [
                 'testValue'                    => '/schema.json#~0definitions~1general/%custom%25',
                 'expectedFileName'             => '/schema.json',
-                'expectedPropertyPaths'        => array('~definitions/general', '%custom%'),
+                'expectedPropertyPaths'        => ['~definitions/general', '%custom%'],
                 'expectedPropertyPathAsString' => '#/~0definitions~1general/%25custom%25',
                 'expectedToString'             => '/schema.json#/~0definitions~1general/%25custom%25'
-            ),
-            'testDataSet_06' => array(
+            ],
+            'testDataSet_06' => [
                 'testValue'                    => '#/items/0',
                 'expectedFileName'             => '',
-                'expectedPropertyPaths'        => array('items', '0'),
+                'expectedPropertyPaths'        => ['items', '0'],
                 'expectedPropertyPathAsString' => '#/items/0',
                 'expectedToString'             => '#/items/0'
-            )
-        );
+            ]
+        ];
     }
 
     public function testJsonPointerWithPropertyPaths()
     {
         $initial = new JsonPointer('#/definitions/date');
 
-        $this->assertEquals(array('definitions', 'date'), $initial->getPropertyPaths());
+        $this->assertEquals(['definitions', 'date'], $initial->getPropertyPaths());
         $this->assertEquals('#/definitions/date', $initial->getPropertyPathAsString());
 
-        $modified = $initial->withPropertyPaths(array('~definitions/general', '%custom%'));
+        $modified = $initial->withPropertyPaths(['~definitions/general', '%custom%']);
 
         $this->assertNotSame($initial, $modified);
 
-        $this->assertEquals(array('definitions', 'date'), $initial->getPropertyPaths());
+        $this->assertEquals(['definitions', 'date'], $initial->getPropertyPaths());
         $this->assertEquals('#/definitions/date', $initial->getPropertyPathAsString());
 
-        $this->assertEquals(array('~definitions/general', '%custom%'), $modified->getPropertyPaths());
+        $this->assertEquals(['~definitions/general', '%custom%'], $modified->getPropertyPaths());
         $this->assertEquals('#/~0definitions~1general/%25custom%25', $modified->getPropertyPathAsString());
     }
 

--- a/tests/Iterators/ObjectIteratorTest.php
+++ b/tests/Iterators/ObjectIteratorTest.php
@@ -18,21 +18,21 @@ class ObjectIteratorTest extends TestCase
 
     public function setUp(): void
     {
-        $this->testObject = (object) array(
-            'subOne' => (object) array(
+        $this->testObject = (object) [
+            'subOne' => (object) [
                 'propertyOne' => 'valueOne',
                 'propertyTwo' => 'valueTwo',
                 'propertyThree' => 'valueThree'
-            ),
-            'subTwo' => (object) array(
+            ],
+            'subTwo' => (object) [
                 'propertyFour' => 'valueFour',
-                'subThree' => (object) array(
+                'subThree' => (object) [
                     'propertyFive' => 'valueFive',
                     'propertySix' => 'valueSix'
-                )
-            ),
+                ]
+            ],
             'propertySeven' => 'valueSeven'
-        );
+        ];
     }
 
     public function testCreate()

--- a/tests/RefTest.php
+++ b/tests/RefTest.php
@@ -16,10 +16,10 @@ class RefTest extends TestCase
 {
     public function dataRefIgnoresSiblings()
     {
-        return array(
+        return [
             // #0 check that $ref is resolved and the instance is validated against
             // the referenced schema
-            array(
+            [
                 '{
                     "definitions":{"test": {"type": "integer"}},
                     "properties": {
@@ -28,9 +28,9 @@ class RefTest extends TestCase
                 }',
                 '{"propertyOne": "not an integer"}',
                 false
-            ),
+            ],
             // #1 check that sibling properties of $ref are ignored during validation
-            array(
+            [
                 '{
                     "definitions":{
                         "test": {"type": "integer"}
@@ -44,9 +44,9 @@ class RefTest extends TestCase
                 }',
                 '{"propertyOne": 10}',
                 true
-            ),
+            ],
             // #2 infinite-loop / unresolveable circular reference
-            array(
+            [
                 '{
                     "definitions": {
                         "test1": {"$ref": "#/definitions/test2"},
@@ -57,8 +57,8 @@ class RefTest extends TestCase
                 '{"propertyOne": 5}',
                 true,
                 '\JsonSchema\Exception\UnresolvableJsonPointerException'
-            )
-        );
+            ]
+        ];
     }
 
     /** @dataProvider dataRefIgnoresSiblings */

--- a/tests/Rfc3339Test.php
+++ b/tests/Rfc3339Test.php
@@ -31,46 +31,46 @@ class Rfc3339Test extends TestCase
 
     public function provideValidFormats()
     {
-        return array(
-            array(
+        return [
+            [
                 '2000-05-01T12:12:12Z',
                 \DateTime::createFromFormat('Y-m-d\TH:i:s', '2000-05-01T12:12:12', new \DateTimeZone('UTC'))
-            ),
-            array(
+            ],
+            [
                 '2000-05-01T12:12:12+0100',
                 \DateTime::createFromFormat('Y-m-d\TH:i:sP', '2000-05-01T12:12:12+01:00')
-            ),
-            array(
+            ],
+            [
                 '2000-05-01T12:12:12+01:00',
                 \DateTime::createFromFormat('Y-m-d\TH:i:sP', '2000-05-01T12:12:12+01:00')
-            ),
-            array(
+            ],
+            [
                 '2000-05-01T12:12:12.123456Z',
                 \DateTime::createFromFormat('Y-m-d\TH:i:s.u', '2000-05-01T12:12:12.123456', new \DateTimeZone('UTC'))
-            ),
-            array(
+            ],
+            [
                 '2000-05-01T12:12:12.123Z',
                 \DateTime::createFromFormat('Y-m-d\TH:i:s.u', '2000-05-01T12:12:12.123000', new \DateTimeZone('UTC'))
-            ),
-            array(
+            ],
+            [
                 '2000-05-01 12:12:12.123Z',
                 \DateTime::createFromFormat('Y-m-d H:i:s.u', '2000-05-01 12:12:12.123000', new \DateTimeZone('UTC'))
-            ),
-            array(
+            ],
+            [
                 '2000-05-01 12:12:12.123456Z',
                 \DateTime::createFromFormat('Y-m-d H:i:s.u', '2000-05-01 12:12:12.123456', new \DateTimeZone('UTC'))
-            )
-        );
+            ]
+        ];
     }
 
     public function provideInvalidFormats()
     {
-        return array(
-            array('1999-1-11T00:00:00Z'),
-            array('1999-01-11T00:00:00+100'),
-            array('1999-01-11T00:00:00+1:00'),
-            array('1999-01-01  00:00:00Z'),
-            array('1999-1-11 00:00:00Z')
-        );
+        return [
+            ['1999-1-11T00:00:00Z'],
+            ['1999-01-11T00:00:00+100'],
+            ['1999-01-11T00:00:00+1:00'],
+            ['1999-01-01  00:00:00Z'],
+            ['1999-1-11 00:00:00Z']
+        ];
     }
 }

--- a/tests/SchemaStorageTest.php
+++ b/tests/SchemaStorageTest.php
@@ -27,7 +27,7 @@ class SchemaStorageTest extends TestCase
         $schemaStorage = new SchemaStorage($uriRetriever->reveal());
 
         $this->assertEquals(
-            (object) array('type' => 'string'),
+            (object) ['type' => 'string'],
             $schemaStorage->resolveRef("$mainSchemaPath#/definitions/house/properties/door")
         );
     }
@@ -131,61 +131,61 @@ class SchemaStorageTest extends TestCase
      */
     private function getMainSchema()
     {
-        return (object) array(
+        return (object) [
             'version' => 'v1',
             '$schema' => 'http://json-schema.org/draft-04/schema#',
             'id' => 'http://www.example.com/schema.json',
             'type' => 'object',
             'additionalProperties' => true,
-            'required' => array(
+            'required' => [
                 'car'
-            ),
-            'properties' => (object) array(
-                'car' => (object) array(
+            ],
+            'properties' => (object) [
+                'car' => (object) [
                     '$ref' => 'http://www.my-domain.com/schema2.json#/definitions/car'
-                ),
-                'house' => (object) array(
+                ],
+                'house' => (object) [
                     'additionalProperties' => true,
                     '$ref' => '#/definitions/house'
-                ),
-                'yard' => (object) array(
+                ],
+                'yard' => (object) [
                     'type' => 'object',
                     'additionalProperties' => false,
-                    'properties' => (object) array(
+                    'properties' => (object) [
                         '$ref' => '#/definitions/yardproperties'
-                    )
-                )
-            ),
-            'definitions' => (object) array(
-                'house'  => (object) array(
+                    ]
+                ]
+            ],
+            'definitions' => (object) [
+                'house'  => (object) [
                     'type' => 'object',
                     'additionalProperties' => false,
-                    'required' => array(
+                    'required' => [
                         'door',
                         'window'
-                    ),
-                    'properties' => (object) array(
-                        'door' => (object) array(
+                    ],
+                    'properties' => (object) [
+                        'door' => (object) [
                             'type' => 'string'
-                        ),
-                        'window' => (object) array(
+                        ],
+                        'window' => (object) [
                             'type' => 'string'
-                        ),
-                        'house' => (object) array(
+                        ],
+                        'house' => (object) [
                             '$ref' => '#/definitions/house'
-                        )
-                    )
-                ),
-                'yardproperties' => (object) array(
-                    'tree'=>(object) array(
+                        ]
+                    ]
+                ],
+                'yardproperties' => (object) [
+                    'tree'=>(object) [
                         'type' => 'string'
-                    ),
-                    'pool'=>(object) array(
+                    ],
+                    'pool'=>(object) [
                         'type' => 'string'
-                    )
-                )
-            )
-        );
+                    ]
+                ]
+            ]
+        ];
     }
 
     /**
@@ -193,29 +193,29 @@ class SchemaStorageTest extends TestCase
      */
     private function getSchema2()
     {
-        return (object) array(
+        return (object) [
             'version' => 'v1',
             '$schema' => 'http://json-schema.org/draft-04/schema#',
             'id' => 'http://www.my-domain.com/schema2.json',
-            'definitions' => (object) array(
-                'car' => (object) array(
+            'definitions' => (object) [
+                'car' => (object) [
                     'type' => 'object',
                     'additionalProperties' => false,
-                    'properties' => (object) array(
-                        'id' => (object) array(
+                    'properties' => (object) [
+                        'id' => (object) [
                             'type' => 'integer'
-                        ),
-                        'name' => (object) array(
+                        ],
+                        'name' => (object) [
                             'type' => 'string',
                             'minLength' => 1
-                        ),
-                        'wheel' => (object) array(
+                        ],
+                        'wheel' => (object) [
                             '$ref' => './schema3.json#/wheel'
-                        )
-                    )
-                )
-            )
-        );
+                        ]
+                    ]
+                ]
+            ]
+        ];
     }
 
     /**
@@ -223,24 +223,24 @@ class SchemaStorageTest extends TestCase
      */
     private function getSchema3()
     {
-        return (object) array(
+        return (object) [
             'version' => 'v1',
             '$schema' => 'http://json-schema.org/draft-04/schema#',
             'title' => 'wheel',
-            'wheel' => (object) array(
-                'properties' => (object) array(
-                    'spokes' => (object) array(
+            'wheel' => (object) [
+                'properties' => (object) [
+                    'spokes' => (object) [
                         'type' => 'integer'
-                    ),
-                    'size' => (object) array(
+                    ],
+                    'size' => (object) [
                         'type' => 'integer'
-                    ),
-                    'car' => (object) array(
+                    ],
+                    'car' => (object) [
                         '$ref' => './schema2.json#/definitions/car'
-                    )
-                )
-            )
-        );
+                    ]
+                ]
+            ]
+        ];
     }
 
     /**
@@ -248,28 +248,28 @@ class SchemaStorageTest extends TestCase
      */
     private function getInvalidSchema()
     {
-        return (object) array(
+        return (object) [
             'version' => 'v1',
             '$schema' => 'http://json-schema.org/draft-04/schema#',
             'type' => 'object',
-            'properties' => (object) array(
-                'spokes' => (object) array(
+            'properties' => (object) [
+                'spokes' => (object) [
                     'type' => 'integer'
-                ),
-                'size' => (object) array(
+                ],
+                'size' => (object) [
                     'type' => 'integer'
-                ),
-                'car' => (object) array(
+                ],
+                'car' => (object) [
                     '$ref' => '#/definitions/car'
-                )
-            ),
-            'definitions' => (object) array(
-                'date' => (object) array(
+                ]
+            ],
+            'definitions' => (object) [
+                'date' => (object) [
                     'type' => 'string',
                     'pattern' => '^[0-9]{4}-(0[1-9]|1[0-2])-(0[1-9]|[1-2][0-9]|3[0-1])$'
-                )
-            )
-        );
+                ]
+            ]
+        ];
     }
 
     public function testGetUriRetriever()

--- a/tests/Uri/Retrievers/CurlTest.php
+++ b/tests/Uri/Retrievers/CurlTest.php
@@ -43,9 +43,9 @@ namespace JsonSchema\Uri\Retrievers
 
         if ($uri === realpath(__DIR__ . '/../../fixtures/foobar.json')) {
             // return file with headers
-            $headers = implode("\n", array(
+            $headers = implode("\n", [
                 'Content-Type: application/json'
-            ));
+            ]);
 
             return sprintf("%s\r\n\r\n%s", $headers, file_get_contents($uri));
         } elseif ($uri === realpath(__DIR__ . '/../../fixtures') . '/foobar-noheader.json') {

--- a/tests/Uri/Retrievers/FileGetContentsTest.php
+++ b/tests/Uri/Retrievers/FileGetContentsTest.php
@@ -34,8 +34,8 @@ class FileGetContentsTest extends TestCase
         $fetchContentType = $reflector->getMethod('fetchContentType');
         $fetchContentType->setAccessible(true);
 
-        $this->assertTrue($fetchContentType->invoke($res, array('Content-Type: application/json')));
-        $this->assertFalse($fetchContentType->invoke($res, array('X-Some-Header: whateverValue')));
+        $this->assertTrue($fetchContentType->invoke($res, ['Content-Type: application/json']));
+        $this->assertFalse($fetchContentType->invoke($res, ['X-Some-Header: whateverValue']));
     }
 
     public function testCanHandleHttp301PermanentRedirect()

--- a/tests/Uri/Retrievers/PredefinedArrayTest.php
+++ b/tests/Uri/Retrievers/PredefinedArrayTest.php
@@ -15,10 +15,10 @@ class PredefinedArrayTest extends TestCase
     public function setUp(): void
     {
         $this->retriever = new PredefinedArray(
-            array(
+            [
                 'http://acme.com/schemas/person#'  => 'THE_PERSON_SCHEMA',
                 'http://acme.com/schemas/address#' => 'THE_ADDRESS_SCHEMA',
-            ),
+            ],
             'THE_CONTENT_TYPE'
         );
     }

--- a/tests/Uri/UriResolverTest.php
+++ b/tests/Uri/UriResolverTest.php
@@ -17,11 +17,11 @@ class UriResolverTest extends TestCase
     public function testParse()
     {
         $this->assertEquals(
-            array(
+            [
                 'scheme'    => 'http',
                 'authority' => 'example.org',
                 'path'      => '/path/to/file.json'
-            ),
+            ],
             $this->resolver->parse('http://example.org/path/to/file.json')
         );
     }
@@ -29,13 +29,13 @@ class UriResolverTest extends TestCase
     public function testParseAnchor()
     {
         $this->assertEquals(
-            array(
+            [
                 'scheme'    => 'http',
                 'authority' => 'example.org',
                 'path'      => '/path/to/file.json',
                 'query'     => '',
                 'fragment'  => 'foo'
-            ),
+            ],
             $this->resolver->parse('http://example.org/path/to/file.json#foo')
         );
     }
@@ -174,13 +174,13 @@ class UriResolverTest extends TestCase
         $split = $this->resolver->parse($uri);
 
         // check that the URI was split as expected
-        $this->assertEquals(array(
+        $this->assertEquals([
             'scheme' => 'scheme',
             'authority' => 'user:password@authority',
             'path' => '/path',
             'query' => 'query',
             'fragment' => 'fragment'
-        ), $split);
+        ], $split);
 
         // check that the recombined URI matches the original input
         $this->assertEquals($uri, $this->resolver->generate($split));

--- a/tests/Uri/UriRetrieverTest.php
+++ b/tests/Uri/UriRetrieverTest.php
@@ -145,16 +145,16 @@ EOF;
 }
 EOF;
 
-        return array(
-            array($childSchema, $parentSchema)
-        );
+        return [
+            [$childSchema, $parentSchema]
+        ];
     }
 
     public function testResolvePointerNoFragment()
     {
-        $schema = (object) array(
+        $schema = (object) [
             'title' => 'schema'
-        );
+        ];
 
         $retriever = new UriRetriever();
         $this->assertEquals(
@@ -167,14 +167,14 @@ EOF;
 
     public function testResolvePointerFragment()
     {
-        $schema = (object) array(
-            'definitions' => (object) array(
-                'foo' => (object) array(
+        $schema = (object) [
+            'definitions' => (object) [
+                'foo' => (object) [
                     'title' => 'foo'
-                )
-            ),
+                ]
+            ],
             'title' => 'schema'
-        );
+        ];
 
         $retriever = new UriRetriever();
         $this->assertEquals(
@@ -187,14 +187,14 @@ EOF;
 
     public function testResolvePointerFragmentNotFound()
     {
-        $schema = (object) array(
-            'definitions' => (object) array(
-                'foo' => (object) array(
+        $schema = (object) [
+            'definitions' => (object) [
+                'foo' => (object) [
                     'title' => 'foo'
-                )
-            ),
+                ]
+            ],
             'title' => 'schema'
-        );
+        ];
 
         $retriever = new UriRetriever();
 
@@ -206,14 +206,14 @@ EOF;
 
     public function testResolvePointerFragmentNoArray()
     {
-        $schema = (object) array(
-            'definitions' => (object) array(
-                'foo' => array(
+        $schema = (object) [
+            'definitions' => (object) [
+                'foo' => [
                     'title' => 'foo'
-                )
-            ),
+                ]
+            ],
             'title' => 'schema'
-        );
+        ];
 
         $retriever = new UriRetriever();
 
@@ -371,7 +371,7 @@ EOF;
         // inject a schema cache value
         $schemaCache = $reflector->getProperty('schemaCache');
         $schemaCache->setAccessible(true);
-        $schemaCache->setValue($retriever, array('local://test/uri' => 'testSchemaValue'));
+        $schemaCache->setValue($retriever, ['local://test/uri' => 'testSchemaValue']);
 
         // retrieve from schema cache
         $loadSchema = $reflector->getMethod('loadSchema');
@@ -395,13 +395,13 @@ EOF;
     public function testGenerateURI()
     {
         $retriever = new UriRetriever();
-        $components = array(
+        $components = [
             'scheme' => 'scheme',
             'authority' => 'authority',
             'path' => '/path',
             'query' => '?query',
             'fragment' => '#fragment'
-        );
+        ];
         $this->assertEquals('scheme://authority/path?query#fragment', $retriever->generate($components));
     }
 
@@ -416,10 +416,10 @@ EOF;
 
     public function combinedURITests()
     {
-        return array(
-            array('blue', 'http://example.com/red', 'http://example.com/blue'),
-            array('blue', 'http://example.com/', 'http://example.com/blue'),
-        );
+        return [
+            ['blue', 'http://example.com/red', 'http://example.com/blue'],
+            ['blue', 'http://example.com/', 'http://example.com/blue'],
+        ];
     }
 
     /**

--- a/tests/ValidatorTest.php
+++ b/tests/ValidatorTest.php
@@ -26,7 +26,7 @@ class ValidatorTest extends TestCase
         if (defined('HHVM_VERSION')) {
             $this->markTestSkipped('HHVM has no problem with encoding resources');
         }
-        $schema = array('propertyOne' => fopen('php://stdout', 'w'));
+        $schema = ['propertyOne' => fopen('php://stdout', 'w')];
         $data = json_decode('{"propertyOne":[42]}', true);
 
         $validator = new Validator();


### PR DESCRIPTION
As part of #726 this PR replaces the traditional array syntax (`array()`) for the short syntax array (`[]`)

Changes have been made using PHPStorm' Inspect Code feature which was used to detect and replace all occurrences.