### PR TITLE
Update: add ext-json to composer.json to ensure JSON extension availa…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Bump to minimum PHP 7.2 ([#746](https://github.com/jsonrainbow/json-schema/pull/746))
 - Replace traditional syntax array with short syntax array ([#747](https://github.com/jsonrainbow/json-schema/pull/747))
 - Increase phpstan level to 8 with baseline to swallow existing errors ([#673](https://github.com/jsonrainbow/json-schema/pull/673))
+- Add ext-json to composer.json to ensure JSON extension available  ([#759](https://github.com/jsonrainbow/json-schema/pull/759))
 
 ## [6.0.0] - 2024-07-30
 ### Added

--- a/composer.json
+++ b/composer.json
@@ -28,6 +28,7 @@
     ],
     "require": {
         "php": "^7.2 || ^8.0",
+        "ext-json": "*",
         "marc-mabe/php-enum":"^2.0 || ^3.0 || ^4.0",
         "icecave/parity": "^3.0"
     },


### PR DESCRIPTION
## Simply added ext-json to composer.json

'ext-json' is missing in composer. json [#755 ](https://github.com/jsonrainbow/json-schema/issues/755) 
