### PR TITLE
Fix PHP 8.4 deprecation warnings in 6.x

### DIFF
--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -18,6 +18,7 @@ $config
         'no_superfluous_phpdoc_tags' => false,
         'no_useless_else' => true,
         'no_useless_return' => true,
+        'nullable_type_declaration_for_default_null_value' => true,
         'ordered_imports' => true,
         'phpdoc_no_package' => false,
         'phpdoc_order' => true,

--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
         }
     ],
     "require": {
-        "php": ">=5.3.3",
+        "php": ">=7.1",
         "marc-mabe/php-enum":"^2.0 || ^3.0 || ^4.0",
         "icecave/parity": "1.0.0"
     },

--- a/src/JsonSchema/Constraints/BaseConstraint.php
+++ b/src/JsonSchema/Constraints/BaseConstraint.php
@@ -39,12 +39,12 @@ class BaseConstraint
     /**
      * @param Factory $factory
      */
-    public function __construct(Factory $factory = null)
+    public function __construct(?Factory $factory = null)
     {
         $this->factory = $factory ?: new Factory();
     }
 
-    public function addError(ConstraintError $constraint, JsonPointer $path = null, array $more = array())
+    public function addError(ConstraintError $constraint, ?JsonPointer $path = null, array $more = array())
     {
         $message = $constraint ? $constraint->getMessage() : '';
         $name = $constraint ? $constraint->getValue() : '';

--- a/src/JsonSchema/Constraints/CollectionConstraint.php
+++ b/src/JsonSchema/Constraints/CollectionConstraint.php
@@ -23,7 +23,7 @@ class CollectionConstraint extends Constraint
     /**
      * {@inheritdoc}
      */
-    public function check(&$value, $schema = null, JsonPointer $path = null, $i = null)
+    public function check(&$value, $schema = null, ?JsonPointer $path = null, $i = null)
     {
         // Verify minItems
         if (isset($schema->minItems) && count($value) < $schema->minItems) {
@@ -62,7 +62,7 @@ class CollectionConstraint extends Constraint
      * @param JsonPointer|null $path
      * @param string           $i
      */
-    protected function validateItems(&$value, $schema = null, JsonPointer $path = null, $i = null)
+    protected function validateItems(&$value, $schema = null, ?JsonPointer $path = null, $i = null)
     {
         if (is_object($schema->items)) {
             // just one type definition for the whole array

--- a/src/JsonSchema/Constraints/ConstConstraint.php
+++ b/src/JsonSchema/Constraints/ConstConstraint.php
@@ -23,7 +23,7 @@ class ConstConstraint extends Constraint
     /**
      * {@inheritdoc}
      */
-    public function check(&$element, $schema = null, JsonPointer $path = null, $i = null)
+    public function check(&$element, $schema = null, ?JsonPointer $path = null, $i = null)
     {
         // Only validate const if the attribute exists
         if ($element instanceof UndefinedConstraint && (!isset($schema->required) || !$schema->required)) {

--- a/src/JsonSchema/Constraints/Constraint.php
+++ b/src/JsonSchema/Constraints/Constraint.php
@@ -40,7 +40,7 @@ abstract class Constraint extends BaseConstraint implements ConstraintInterface
      *
      * @return JsonPointer;
      */
-    protected function incrementPath(JsonPointer $path = null, $i)
+    protected function incrementPath(?JsonPointer $path = null, $i)
     {
         $path = $path ?: new JsonPointer('');
 
@@ -66,7 +66,7 @@ abstract class Constraint extends BaseConstraint implements ConstraintInterface
      * @param JsonPointer|null $path
      * @param mixed            $i
      */
-    protected function checkArray(&$value, $schema = null, JsonPointer $path = null, $i = null)
+    protected function checkArray(&$value, $schema = null, ?JsonPointer $path = null, $i = null)
     {
         $validator = $this->factory->createInstanceFor('collection');
         $validator->check($value, $schema, $path, $i);
@@ -84,7 +84,7 @@ abstract class Constraint extends BaseConstraint implements ConstraintInterface
      * @param mixed            $additionalProperties
      * @param mixed            $patternProperties
      */
-    protected function checkObject(&$value, $schema = null, JsonPointer $path = null, $properties = null,
+    protected function checkObject(&$value, $schema = null, ?JsonPointer $path = null, $properties = null,
         $additionalProperties = null, $patternProperties = null, $appliedDefaults = array())
     {
         /** @var ObjectConstraint $validator */
@@ -102,7 +102,7 @@ abstract class Constraint extends BaseConstraint implements ConstraintInterface
      * @param JsonPointer|null $path
      * @param mixed            $i
      */
-    protected function checkType(&$value, $schema = null, JsonPointer $path = null, $i = null)
+    protected function checkType(&$value, $schema = null, ?JsonPointer $path = null, $i = null)
     {
         $validator = $this->factory->createInstanceFor('type');
         $validator->check($value, $schema, $path, $i);
@@ -118,7 +118,7 @@ abstract class Constraint extends BaseConstraint implements ConstraintInterface
      * @param JsonPointer|null $path
      * @param mixed            $i
      */
-    protected function checkUndefined(&$value, $schema = null, JsonPointer $path = null, $i = null, $fromDefault = false)
+    protected function checkUndefined(&$value, $schema = null, ?JsonPointer $path = null, $i = null, $fromDefault = false)
     {
         /** @var UndefinedConstraint $validator */
         $validator = $this->factory->createInstanceFor('undefined');
@@ -136,7 +136,7 @@ abstract class Constraint extends BaseConstraint implements ConstraintInterface
      * @param JsonPointer|null $path
      * @param mixed            $i
      */
-    protected function checkString($value, $schema = null, JsonPointer $path = null, $i = null)
+    protected function checkString($value, $schema = null, ?JsonPointer $path = null, $i = null)
     {
         $validator = $this->factory->createInstanceFor('string');
         $validator->check($value, $schema, $path, $i);
@@ -152,7 +152,7 @@ abstract class Constraint extends BaseConstraint implements ConstraintInterface
      * @param JsonPointer $path
      * @param mixed       $i
      */
-    protected function checkNumber($value, $schema = null, JsonPointer $path = null, $i = null)
+    protected function checkNumber($value, $schema = null, ?JsonPointer $path = null, $i = null)
     {
         $validator = $this->factory->createInstanceFor('number');
         $validator->check($value, $schema, $path, $i);
@@ -168,7 +168,7 @@ abstract class Constraint extends BaseConstraint implements ConstraintInterface
      * @param JsonPointer|null $path
      * @param mixed            $i
      */
-    protected function checkEnum($value, $schema = null, JsonPointer $path = null, $i = null)
+    protected function checkEnum($value, $schema = null, ?JsonPointer $path = null, $i = null)
     {
         $validator = $this->factory->createInstanceFor('enum');
         $validator->check($value, $schema, $path, $i);
@@ -184,7 +184,7 @@ abstract class Constraint extends BaseConstraint implements ConstraintInterface
      * @param JsonPointer|null $path
      * @param mixed            $i
      */
-    protected function checkConst($value, $schema = null, JsonPointer $path = null, $i = null)
+    protected function checkConst($value, $schema = null, ?JsonPointer $path = null, $i = null)
     {
         $validator = $this->factory->createInstanceFor('const');
         $validator->check($value, $schema, $path, $i);
@@ -200,7 +200,7 @@ abstract class Constraint extends BaseConstraint implements ConstraintInterface
      * @param JsonPointer|null $path
      * @param mixed            $i
      */
-    protected function checkFormat($value, $schema = null, JsonPointer $path = null, $i = null)
+    protected function checkFormat($value, $schema = null, ?JsonPointer $path = null, $i = null)
     {
         $validator = $this->factory->createInstanceFor('format');
         $validator->check($value, $schema, $path, $i);

--- a/src/JsonSchema/Constraints/Constraint.php
+++ b/src/JsonSchema/Constraints/Constraint.php
@@ -40,7 +40,7 @@ abstract class Constraint extends BaseConstraint implements ConstraintInterface
      *
      * @return JsonPointer;
      */
-    protected function incrementPath(?JsonPointer $path = null, $i)
+    protected function incrementPath(?JsonPointer $path, $i)
     {
         $path = $path ?: new JsonPointer('');
 

--- a/src/JsonSchema/Constraints/ConstraintInterface.php
+++ b/src/JsonSchema/Constraints/ConstraintInterface.php
@@ -40,7 +40,7 @@ interface ConstraintInterface
      * @param JsonPointer|null $path
      * @param array            $more       more array elements to add to the error
      */
-    public function addError(ConstraintError $constraint, JsonPointer $path = null, array $more = array());
+    public function addError(ConstraintError $constraint, ?JsonPointer $path = null, array $more = array());
 
     /**
      * checks if the validator has not raised errors
@@ -61,5 +61,5 @@ interface ConstraintInterface
      *
      * @throws \JsonSchema\Exception\ExceptionInterface
      */
-    public function check(&$value, $schema = null, JsonPointer $path = null, $i = null);
+    public function check(&$value, $schema = null, ?JsonPointer $path = null, $i = null);
 }

--- a/src/JsonSchema/Constraints/EnumConstraint.php
+++ b/src/JsonSchema/Constraints/EnumConstraint.php
@@ -24,7 +24,7 @@ class EnumConstraint extends Constraint
     /**
      * {@inheritdoc}
      */
-    public function check(&$element, $schema = null, JsonPointer $path = null, $i = null)
+    public function check(&$element, $schema = null, ?JsonPointer $path = null, $i = null)
     {
         // Only validate enum if the attribute exists
         if ($element instanceof UndefinedConstraint && (!isset($schema->required) || !$schema->required)) {

--- a/src/JsonSchema/Constraints/Factory.php
+++ b/src/JsonSchema/Constraints/Factory.php
@@ -75,8 +75,8 @@ class Factory
      * @param int                   $checkMode
      */
     public function __construct(
-        SchemaStorageInterface $schemaStorage = null,
-        UriRetrieverInterface $uriRetriever = null,
+        ?SchemaStorageInterface $schemaStorage = null,
+        ?UriRetrieverInterface $uriRetriever = null,
         $checkMode = Constraint::CHECK_MODE_NORMAL
     ) {
         // set provided config options

--- a/src/JsonSchema/Constraints/FormatConstraint.php
+++ b/src/JsonSchema/Constraints/FormatConstraint.php
@@ -25,7 +25,7 @@ class FormatConstraint extends Constraint
     /**
      * {@inheritdoc}
      */
-    public function check(&$element, $schema = null, JsonPointer $path = null, $i = null)
+    public function check(&$element, $schema = null, ?JsonPointer $path = null, $i = null)
     {
         if (!isset($schema->format) || $this->factory->getConfig(self::CHECK_MODE_DISABLE_FORMAT)) {
             return;

--- a/src/JsonSchema/Constraints/NumberConstraint.php
+++ b/src/JsonSchema/Constraints/NumberConstraint.php
@@ -23,7 +23,7 @@ class NumberConstraint extends Constraint
     /**
      * {@inheritdoc}
      */
-    public function check(&$element, $schema = null, JsonPointer $path = null, $i = null)
+    public function check(&$element, $schema = null, ?JsonPointer $path = null, $i = null)
     {
         // Verify minimum
         if (isset($schema->exclusiveMinimum)) {

--- a/src/JsonSchema/Constraints/ObjectConstraint.php
+++ b/src/JsonSchema/Constraints/ObjectConstraint.php
@@ -28,7 +28,7 @@ class ObjectConstraint extends Constraint
     /**
      * {@inheritdoc}
      */
-    public function check(&$element, $schema = null, JsonPointer $path = null, $properties = null,
+    public function check(&$element, $schema = null, ?JsonPointer $path = null, $properties = null,
         $additionalProp = null, $patternProperties = null, $appliedDefaults = array())
     {
         if ($element instanceof UndefinedConstraint) {
@@ -52,7 +52,7 @@ class ObjectConstraint extends Constraint
         $this->validateElement($element, $matches, $schema, $path, $properties, $additionalProp);
     }
 
-    public function validatePatternProperties($element, JsonPointer $path = null, $patternProperties)
+    public function validatePatternProperties($element, ?JsonPointer $path = null, $patternProperties)
     {
         $matches = array();
         foreach ($patternProperties as $pregex => $schema) {
@@ -84,7 +84,7 @@ class ObjectConstraint extends Constraint
      * @param \StdClass        $properties     Properties
      * @param mixed            $additionalProp Additional properties
      */
-    public function validateElement($element, $matches, $schema = null, JsonPointer $path = null,
+    public function validateElement($element, $matches, $schema = null, ?JsonPointer $path = null,
         $properties = null, $additionalProp = null)
     {
         $this->validateMinMaxConstraint($element, $schema, $path);
@@ -129,7 +129,7 @@ class ObjectConstraint extends Constraint
      * @param \stdClass        $properties Property definitions
      * @param JsonPointer|null $path       Path?
      */
-    public function validateProperties(&$element, $properties = null, JsonPointer $path = null)
+    public function validateProperties(&$element, $properties = null, ?JsonPointer $path = null)
     {
         $undefinedConstraint = $this->factory->createInstanceFor('undefined');
 
@@ -171,7 +171,7 @@ class ObjectConstraint extends Constraint
      * @param \stdClass        $objectDefinition ObjectConstraint definition
      * @param JsonPointer|null $path             Path to test?
      */
-    protected function validateMinMaxConstraint($element, $objectDefinition, JsonPointer $path = null)
+    protected function validateMinMaxConstraint($element, $objectDefinition, ?JsonPointer $path = null)
     {
         // Verify minimum number of properties
         if (isset($objectDefinition->minProperties) && !is_object($objectDefinition->minProperties)) {

--- a/src/JsonSchema/Constraints/ObjectConstraint.php
+++ b/src/JsonSchema/Constraints/ObjectConstraint.php
@@ -52,7 +52,7 @@ class ObjectConstraint extends Constraint
         $this->validateElement($element, $matches, $schema, $path, $properties, $additionalProp);
     }
 
-    public function validatePatternProperties($element, ?JsonPointer $path = null, $patternProperties)
+    public function validatePatternProperties($element, ?JsonPointer $path, $patternProperties)
     {
         $matches = array();
         foreach ($patternProperties as $pregex => $schema) {

--- a/src/JsonSchema/Constraints/SchemaConstraint.php
+++ b/src/JsonSchema/Constraints/SchemaConstraint.php
@@ -29,7 +29,7 @@ class SchemaConstraint extends Constraint
     /**
      * {@inheritdoc}
      */
-    public function check(&$element, $schema = null, JsonPointer $path = null, $i = null)
+    public function check(&$element, $schema = null, ?JsonPointer $path = null, $i = null)
     {
         if ($schema !== null) {
             // passed schema

--- a/src/JsonSchema/Constraints/StringConstraint.php
+++ b/src/JsonSchema/Constraints/StringConstraint.php
@@ -23,7 +23,7 @@ class StringConstraint extends Constraint
     /**
      * {@inheritdoc}
      */
-    public function check(&$element, $schema = null, JsonPointer $path = null, $i = null)
+    public function check(&$element, $schema = null, ?JsonPointer $path = null, $i = null)
     {
         // Verify maxLength
         if (isset($schema->maxLength) && $this->strlen($element) > $schema->maxLength) {

--- a/src/JsonSchema/Constraints/TypeConstraint.php
+++ b/src/JsonSchema/Constraints/TypeConstraint.php
@@ -40,7 +40,7 @@ class TypeConstraint extends Constraint
     /**
      * {@inheritdoc}
      */
-    public function check(&$value = null, $schema = null, JsonPointer $path = null, $i = null)
+    public function check(&$value = null, $schema = null, ?JsonPointer $path = null, $i = null)
     {
         $type = isset($schema->type) ? $schema->type : null;
         $isValid = false;

--- a/src/JsonSchema/Constraints/UndefinedConstraint.php
+++ b/src/JsonSchema/Constraints/UndefinedConstraint.php
@@ -32,7 +32,7 @@ class UndefinedConstraint extends Constraint
     /**
      * {@inheritdoc}
      */
-    public function check(&$value, $schema = null, JsonPointer $path = null, $i = null, $fromDefault = false)
+    public function check(&$value, $schema = null, ?JsonPointer $path = null, $i = null, $fromDefault = false)
     {
         if (is_null($schema) || !is_object($schema)) {
             return;

--- a/src/JsonSchema/Exception/JsonDecodingException.php
+++ b/src/JsonSchema/Exception/JsonDecodingException.php
@@ -14,7 +14,7 @@ namespace JsonSchema\Exception;
  */
 class JsonDecodingException extends RuntimeException
 {
-    public function __construct($code = JSON_ERROR_NONE, \Exception $previous = null)
+    public function __construct($code = JSON_ERROR_NONE, ?\Exception $previous = null)
     {
         switch ($code) {
             case JSON_ERROR_DEPTH:

--- a/src/JsonSchema/SchemaStorage.php
+++ b/src/JsonSchema/SchemaStorage.php
@@ -17,8 +17,8 @@ class SchemaStorage implements SchemaStorageInterface
     protected $schemas = array();
 
     public function __construct(
-        UriRetrieverInterface $uriRetriever = null,
-        UriResolverInterface $uriResolver = null
+        ?UriRetrieverInterface $uriRetriever = null,
+        ?UriResolverInterface $uriResolver = null
     ) {
         $this->uriRetriever = $uriRetriever ?: new UriRetriever();
         $this->uriResolver = $uriResolver ?: new UriResolver();

--- a/tests/Constraints/FactoryTest.php
+++ b/tests/Constraints/FactoryTest.php
@@ -30,7 +30,7 @@ class MyBadConstraint
  */
 class MyStringConstraint extends Constraint
 {
-    public function check(&$value, $schema = null, JsonPointer $path = null, $i = null)
+    public function check(&$value, $schema = null, ?JsonPointer $path = null, $i = null)
     {
     }
 }


### PR DESCRIPTION
From https://github.com/jsonrainbow/json-schema/discussions/726#discussioncomment-9976508:

> I think we could do the same there, tag 6.0 then work on 6.1 bumping PHP and doing all the changes

This PR uses a similar strategy as in https://github.com/jsonrainbow/json-schema/pull/731 but for 6.x:
* bump minimum PHP version to 7.1
* fix PHP deprecation warnings