### PR TITLE
build: include php 8.4 in workflow

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -28,6 +28,7 @@ jobs:
           - "8.1"
           - "8.2"
           - "8.3"
+          - "8.4"
         dependencies: [highest]
         experimental: [false]
         include:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Increase phpstan level to 8 with baseline to swallow existing errors ([#673](https://github.com/jsonrainbow/json-schema/pull/673))
 - Add ext-json to composer.json to ensure JSON extension available  ([#759](https://github.com/jsonrainbow/json-schema/pull/759))
 - Add visibility modifiers to class constants ([#757](https://github.com/jsonrainbow/json-schema/pull/757))
+- Include PHP 8.4 in workflow ([#765](https://github.com/jsonrainbow/json-schema/pull/765))
 
 ## [6.0.0] - 2024-07-30
 ### Added


### PR DESCRIPTION
This pull request includes a couple of changes to the continuous integration workflow and the changelog documentation.

Changes to continuous integration workflow:

* [`.github/workflows/continuous-integration.yml`](diffhunk://#diff-c471496bcb3ed47397b73d2e3e3aa41a8a679c86accaed9e05676fd9d5987434R31): Added PHP 8.4 to the list of PHP versions used in the CI pipeline.

Documentation update:

* [`CHANGELOG.md`](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR28): Included an entry for adding PHP 8.4 to the CI workflow.