### PR TITLE
Raise minimum level php enum

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add visibility modifiers to class constants ([#757](https://github.com/jsonrainbow/json-schema/pull/757))
 - Include PHP 8.4 in workflow ([#765](https://github.com/jsonrainbow/json-schema/pull/765))
 - Add `strict_types=1` to all classes in ./src ([#758](https://github.com/jsonrainbow/json-schema/pull/758))
+- Raise minimum level of marc-mabe/php-enum ([#766](https://github.com/jsonrainbow/json-schema/pull/766))
 
 ## [6.0.0] - 2024-07-30
 ### Added

--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
     "require": {
         "php": "^7.2 || ^8.0",
         "ext-json": "*",
-        "marc-mabe/php-enum":"^2.0 || ^3.0 || ^4.0",
+        "marc-mabe/php-enum":"^4.0",
         "icecave/parity": "^3.0"
     },
     "require-dev": {


### PR DESCRIPTION
This pull request includes updates to dependencies and configuration for the project. The most important changes include raising the minimum required version for `marc-mabe/php-enum` and adding PHP 8.4 to the workflow.

Dependency updates:

* [`composer.json`](diffhunk://#diff-d2ab9925cad7eac58e0ff4cc0d251a937ecf49e4b6bf57f8b95aab76648a9d34L32-R32): Raised the minimum required version of `marc-mabe/php-enum` to `^4.0`

Documentation updates:

* [`CHANGELOG.md`](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR31): Added an entry for raising the minimum level of `marc-mabe/php-enum`