### PR TITLE
refactor: Cleanup test from @param annotations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Include PHP 8.4 in workflow ([#765](https://github.com/jsonrainbow/json-schema/pull/765))
 - Add `strict_types=1` to all classes in ./src ([#758](https://github.com/jsonrainbow/json-schema/pull/758))
 - Raise minimum level of marc-mabe/php-enum ([#766](https://github.com/jsonrainbow/json-schema/pull/766))
+- Cleanup test from @param annotations ([#768](https://github.com/jsonrainbow/json-schema/pull/768))
 
 ## [6.0.0] - 2024-07-30
 ### Added

--- a/tests/Constraints/TypeTest.php
+++ b/tests/Constraints/TypeTest.php
@@ -66,11 +66,8 @@ class TypeTest extends TestCase
 
     /**
      * Helper to assert an error message
-     *
-     * @param string         $expected
-     * @param TypeConstraint $actual
      */
-    private function assertTypeConstraintError($expected, TypeConstraint $actual): void
+    private function assertTypeConstraintError(string $expected, TypeConstraint $actual): void
     {
         $actualErrors = $actual->getErrors();
 

--- a/tests/Constraints/VeryBaseTestCase.php
+++ b/tests/Constraints/VeryBaseTestCase.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * This file is part of the JsonSchema package.
  *
@@ -23,10 +25,7 @@ abstract class VeryBaseTestCase extends TestCase
     /** @var object */
     private $jsonSchemaDraft04;
 
-    /**
-     * @param object $schema
-     */
-    protected function getUriRetrieverMock($schema): object
+    protected function getUriRetrieverMock(?object $schema): object
     {
         $relativeTestsRoot = realpath(__DIR__ . '/../../vendor/json-schema/json-schema-test-suite/remotes');
 

--- a/tests/Drafts/BaseDraftTestCase.php
+++ b/tests/Drafts/BaseDraftTestCase.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace JsonSchema\Tests\Drafts;
 
 use JsonSchema\Tests\Constraints\BaseTestCase;
@@ -71,12 +73,8 @@ abstract class BaseDraftTestCase extends BaseTestCase
 
     /**
      * Generates a readable path to Json Schema Test Suite data set under test
-     *
-     * @param string $filename
-     * @param string $suiteDesc
-     * @param string $testCaseDesc
      */
-    private function createDataSetPath($filename, $suiteDesc, $testCaseDesc): string
+    private function createDataSetPath(string $filename, string $suiteDesc, string $testCaseDesc): string
     {
         $separator = ' / ';
 

--- a/tests/Entity/JsonPointerTest.php
+++ b/tests/Entity/JsonPointerTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * This file is part of the JsonSchema package.
  *
@@ -10,6 +12,7 @@
 namespace JsonSchema\Tests\Entity;
 
 use JsonSchema\Entity\JsonPointer;
+use JsonSchema\Exception\InvalidArgumentException;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -20,20 +23,14 @@ use PHPUnit\Framework\TestCase;
 class JsonPointerTest extends TestCase
 {
     /**
-     * @dataProvider getTestData
-     *
-     * @param string $testValue
-     * @param string $expectedFileName
-     * @param array  $expectedPropertyPaths
-     * @param string $expectedPropertyPathAsString
-     * @param string $expectedToString
+     * @dataProvider jsonPointerDataProvider
      */
     public function testJsonPointer(
-        $testValue,
-        $expectedFileName,
-        $expectedPropertyPaths,
-        $expectedPropertyPathAsString,
-        $expectedToString
+        string $testValue,
+        string $expectedFileName,
+        array $expectedPropertyPaths,
+        string $expectedPropertyPathAsString,
+        string $expectedToString
     ): void {
         $jsonPointer = new JsonPointer($testValue);
         $this->assertEquals($expectedFileName, $jsonPointer->getFilename());
@@ -42,51 +39,49 @@ class JsonPointerTest extends TestCase
         $this->assertEquals($expectedToString, (string) $jsonPointer);
     }
 
-    public function getTestData(): array
+    public static function jsonPointerDataProvider(): \Generator
     {
-        return [
-            'testDataSet_01' => [
-                'testValue'                    => '#/definitions/date',
-                'expectedFileName'             => '',
-                'expectedPropertyPaths'        => ['definitions', 'date'],
-                'expectedPropertyPathAsString' => '#/definitions/date',
-                'expectedToString'             => '#/definitions/date'
-            ],
-            'testDataSet_02' => [
-                'testValue'                    => 'http://www.example.com/definitions.json#/definitions/date',
-                'expectedFileName'             => 'http://www.example.com/definitions.json',
-                'expectedPropertyPaths'        => ['definitions', 'date'],
-                'expectedPropertyPathAsString' => '#/definitions/date',
-                'expectedToString'             => 'http://www.example.com/definitions.json#/definitions/date'
-            ],
-            'testDataSet_03' => [
-                'testValue'                    => '/tmp/schema.json#definitions/common/date/',
-                'expectedFileName'             => '/tmp/schema.json',
-                'expectedPropertyPaths'        => ['definitions', 'common', 'date'],
-                'expectedPropertyPathAsString' => '#/definitions/common/date',
-                'expectedToString'             => '/tmp/schema.json#/definitions/common/date'
-            ],
-            'testDataSet_04' => [
-                'testValue'                    => './definitions.json#',
-                'expectedFileName'             => './definitions.json',
-                'expectedPropertyPaths'        => [],
-                'expectedPropertyPathAsString' => '#',
-                'expectedToString'             => './definitions.json#'
-            ],
-            'testDataSet_05' => [
-                'testValue'                    => '/schema.json#~0definitions~1general/%custom%25',
-                'expectedFileName'             => '/schema.json',
-                'expectedPropertyPaths'        => ['~definitions/general', '%custom%'],
-                'expectedPropertyPathAsString' => '#/~0definitions~1general/%25custom%25',
-                'expectedToString'             => '/schema.json#/~0definitions~1general/%25custom%25'
-            ],
-            'testDataSet_06' => [
-                'testValue'                    => '#/items/0',
-                'expectedFileName'             => '',
-                'expectedPropertyPaths'        => ['items', '0'],
-                'expectedPropertyPathAsString' => '#/items/0',
-                'expectedToString'             => '#/items/0'
-            ]
+        yield 'testDataSet_01' => [
+            'testValue'                    => '#/definitions/date',
+            'expectedFileName'             => '',
+            'expectedPropertyPaths'        => ['definitions', 'date'],
+            'expectedPropertyPathAsString' => '#/definitions/date',
+            'expectedToString'             => '#/definitions/date'
+        ];
+        yield 'testDataSet_02' => [
+            'testValue'                    => 'https://www.example.com/definitions.json#/definitions/date',
+            'expectedFileName'             => 'https://www.example.com/definitions.json',
+            'expectedPropertyPaths'        => ['definitions', 'date'],
+            'expectedPropertyPathAsString' => '#/definitions/date',
+            'expectedToString'             => 'https://www.example.com/definitions.json#/definitions/date'
+        ];
+        yield 'testDataSet_03' => [
+            'testValue'                    => '/tmp/schema.json#definitions/common/date/',
+            'expectedFileName'             => '/tmp/schema.json',
+            'expectedPropertyPaths'        => ['definitions', 'common', 'date'],
+            'expectedPropertyPathAsString' => '#/definitions/common/date',
+            'expectedToString'             => '/tmp/schema.json#/definitions/common/date'
+        ];
+        yield 'testDataSet_04' => [
+            'testValue'                    => './definitions.json#',
+            'expectedFileName'             => './definitions.json',
+            'expectedPropertyPaths'        => [],
+            'expectedPropertyPathAsString' => '#',
+            'expectedToString'             => './definitions.json#'
+        ];
+        yield 'testDataSet_05' => [
+            'testValue'                    => '/schema.json#~0definitions~1general/%custom%25',
+            'expectedFileName'             => '/schema.json',
+            'expectedPropertyPaths'        => ['~definitions/general', '%custom%'],
+            'expectedPropertyPathAsString' => '#/~0definitions~1general/%25custom%25',
+            'expectedToString'             => '/schema.json#/~0definitions~1general/%25custom%25'
+        ];
+        yield 'testDataSet_06' => [
+            'testValue'                    => '#/items/0',
+            'expectedFileName'             => '',
+            'expectedPropertyPaths'        => ['items', '0'],
+            'expectedPropertyPathAsString' => '#/items/0',
+            'expectedToString'             => '#/items/0'
         ];
     }
 
@@ -110,7 +105,7 @@ class JsonPointerTest extends TestCase
 
     public function testCreateWithInvalidValue(): void
     {
-        $this->expectException('\JsonSchema\Exception\InvalidArgumentException');
+        $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('Ref value must be a string');
 
         new JsonPointer(null);

--- a/tests/Rfc3339Test.php
+++ b/tests/Rfc3339Test.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace JsonSchema\Tests;
 
 use JsonSchema\Rfc3339;
@@ -8,11 +10,9 @@ use PHPUnit\Framework\TestCase;
 class Rfc3339Test extends TestCase
 {
     /**
-     * @param string         $string
-     * @param \DateTime|null $expected
      * @dataProvider provideValidFormats
      */
-    public function testCreateFromValidString($string, \DateTime $expected): void
+    public function testCreateFromValidString(string $string, \DateTime $expected): void
     {
         $actual = Rfc3339::createFromString($string);
 
@@ -21,56 +21,51 @@ class Rfc3339Test extends TestCase
     }
 
     /**
-     * @param string $string
      * @dataProvider provideInvalidFormats
      */
-    public function testCreateFromInvalidString($string): void
+    public function testCreateFromInvalidString(string $string): void
     {
         $this->assertNull(Rfc3339::createFromString($string), sprintf('String "%s" should not be converted to DateTime', $string));
     }
 
-    public function provideValidFormats(): array
+    public static function provideValidFormats(): \Generator
     {
-        return [
-            [
-                '2000-05-01T12:12:12Z',
-                \DateTime::createFromFormat('Y-m-d\TH:i:s', '2000-05-01T12:12:12', new \DateTimeZone('UTC'))
-            ],
-            [
-                '2000-05-01T12:12:12+0100',
-                \DateTime::createFromFormat('Y-m-d\TH:i:sP', '2000-05-01T12:12:12+01:00')
-            ],
-            [
-                '2000-05-01T12:12:12+01:00',
-                \DateTime::createFromFormat('Y-m-d\TH:i:sP', '2000-05-01T12:12:12+01:00')
-            ],
-            [
-                '2000-05-01T12:12:12.123456Z',
-                \DateTime::createFromFormat('Y-m-d\TH:i:s.u', '2000-05-01T12:12:12.123456', new \DateTimeZone('UTC'))
-            ],
-            [
-                '2000-05-01T12:12:12.123Z',
-                \DateTime::createFromFormat('Y-m-d\TH:i:s.u', '2000-05-01T12:12:12.123000', new \DateTimeZone('UTC'))
-            ],
-            [
-                '2000-05-01 12:12:12.123Z',
-                \DateTime::createFromFormat('Y-m-d H:i:s.u', '2000-05-01 12:12:12.123000', new \DateTimeZone('UTC'))
-            ],
-            [
-                '2000-05-01 12:12:12.123456Z',
-                \DateTime::createFromFormat('Y-m-d H:i:s.u', '2000-05-01 12:12:12.123456', new \DateTimeZone('UTC'))
-            ]
+        yield 'Zulu time' => [
+            '2000-05-01T12:12:12Z',
+            \DateTime::createFromFormat('Y-m-d\TH:i:s', '2000-05-01T12:12:12', new \DateTimeZone('UTC'))
+        ];
+        yield 'With time offset - without colon' => [
+            '2000-05-01T12:12:12+0100',
+            \DateTime::createFromFormat('Y-m-d\TH:i:sP', '2000-05-01T12:12:12+01:00')
+        ];
+        yield 'With time offset - with colon' => [
+            '2000-05-01T12:12:12+01:00',
+            \DateTime::createFromFormat('Y-m-d\TH:i:sP', '2000-05-01T12:12:12+01:00')
+        ];
+        yield 'Zulu time - with microseconds' => [
+            '2000-05-01T12:12:12.123456Z',
+            \DateTime::createFromFormat('Y-m-d\TH:i:s.u', '2000-05-01T12:12:12.123456', new \DateTimeZone('UTC'))
+        ];
+        yield 'Zulu time - with milliseconds' => [
+            '2000-05-01T12:12:12.123Z',
+            \DateTime::createFromFormat('Y-m-d\TH:i:s.u', '2000-05-01T12:12:12.123000', new \DateTimeZone('UTC'))
+        ];
+        yield 'Zulu time - with milliseconds, without T separator' => [
+            '2000-05-01 12:12:12.123Z',
+            \DateTime::createFromFormat('Y-m-d H:i:s.u', '2000-05-01 12:12:12.123000', new \DateTimeZone('UTC'))
+        ];
+        yield 'Zulu time - with microseconds, without T separator' => [
+            '2000-05-01 12:12:12.123456Z',
+            \DateTime::createFromFormat('Y-m-d H:i:s.u', '2000-05-01 12:12:12.123456', new \DateTimeZone('UTC'))
         ];
     }
 
-    public function provideInvalidFormats(): array
+    public static function provideInvalidFormats(): \Generator
     {
-        return [
-            ['1999-1-11T00:00:00Z'],
-            ['1999-01-11T00:00:00+100'],
-            ['1999-01-11T00:00:00+1:00'],
-            ['1999-01-01  00:00:00Z'],
-            ['1999-1-11 00:00:00Z']
-        ];
+        yield 'Missing leading zero in month - with T separator' => ['1999-1-11T00:00:00Z'];
+        yield 'Missing leading zero in timezone offset - without colon' => ['1999-01-11T00:00:00+100'];
+        yield 'Missing leading zero in timezone offset - with colon' => ['1999-01-11T00:00:00+1:00'];
+        yield 'Double space between date and time' => ['1999-01-01  00:00:00Z'];
+        yield 'Missing leading zero in month - without T separator' => ['1999-1-11 00:00:00Z'];
     }
 }


### PR DESCRIPTION
This pull request includes several changes to the test files in the `tests` directory, focusing on enforcing strict types, improving method signatures, and using generators for data providers. The most important changes include adding strict types, refactoring method signatures, and converting data providers to use generators for better performance and readability.

### Enforcing Strict Types:
* Added `declare(strict_types=1);` at the beginning of multiple test files to enforce strict type checking. (`tests/Constraints/FactoryTest.php` [[1]](diffhunk://#diff-66b0ca4f79c76df4451fb0d9fd205ef89117089819fbb1c8a8934d9e3da3f368R10-L30) `tests/Constraints/VeryBaseTestCase.php` [[2]](diffhunk://#diff-c7f68b0d0f1e7794c30511db4ac25608cd1e71f48daadfe2f4a5358cdafb9343R3-R4) `tests/Drafts/BaseDraftTestCase.php` [[3]](diffhunk://#diff-c8b5002eb504138511bd31b5303dfa19cec1224612dbb0c6c8f199cc0248896eR3-R4) `tests/Entity/JsonPointerTest.php` [[4]](diffhunk://#diff-306e8ea8a4102d444a3e9d06f5a51a608876c71d6aeab7a5b165b42b3161a910R3-R4) `tests/Rfc3339Test.php` [[5]](diffhunk://#diff-b619e15fe213c500746f8bad511db70d6539c40438e7e9935a94e6cc0a88c21aR3-R4)

### Refactoring Method Signatures:
* Updated method signatures to use type hints for parameters and return types, improving code clarity and type safety. (`tests/Constraints/FactoryTest.php` [[1]](diffhunk://#diff-66b0ca4f79c76df4451fb0d9fd205ef89117089819fbb1c8a8934d9e3da3f368L40-L143) `tests/Constraints/TypeTest.php` [[2]](diffhunk://#diff-cefda80a627383237df078ae1d2b97aa196c63874eb7ae4f95200c0d7af320adL69-R70) `tests/Constraints/VeryBaseTestCase.php` [[3]](diffhunk://#diff-c7f68b0d0f1e7794c30511db4ac25608cd1e71f48daadfe2f4a5358cdafb9343L26-R28) `tests/Drafts/BaseDraftTestCase.php` [[4]](diffhunk://#diff-c8b5002eb504138511bd31b5303dfa19cec1224612dbb0c6c8f199cc0248896eL74-R77) `tests/Entity/JsonPointerTest.php` [[5]](diffhunk://#diff-306e8ea8a4102d444a3e9d06f5a51a608876c71d6aeab7a5b165b42b3161a910R15) `tests/Rfc3339Test.php` [[6]](diffhunk://#diff-b619e15fe213c500746f8bad511db70d6539c40438e7e9935a94e6cc0a88c21aL11-R15)

### Using Generators for Data Providers:
* Converted array-based data providers to use generators, enhancing performance and readability. (`tests/Constraints/FactoryTest.php` [[1]](diffhunk://#diff-66b0ca4f79c76df4451fb0d9fd205ef89117089819fbb1c8a8934d9e3da3f368L40-L143) `tests/Entity/JsonPointerTest.php` [[2]](diffhunk://#diff-306e8ea8a4102d444a3e9d06f5a51a608876c71d6aeab7a5b165b42b3161a910L45-L89) `tests/Rfc3339Test.php` [[3]](diffhunk://#diff-b619e15fe213c500746f8bad511db70d6539c40438e7e9935a94e6cc0a88c21aL24-R69)