### PR TITLE
Remove obsolete check if FILTER_FLAG_EMAIL_UNICODE is defined

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add `strict_types=1` to all classes in ./src ([#758](https://github.com/jsonrainbow/json-schema/pull/758))
 - Raise minimum level of marc-mabe/php-enum ([#766](https://github.com/jsonrainbow/json-schema/pull/766))
 - Cleanup test from @param annotations ([#768](https://github.com/jsonrainbow/json-schema/pull/768))
+- Remove obsolete PHP 7.1 version check ([#772](https://github.com/jsonrainbow/json-schema/pull/772))
 
 ## [6.0.0] - 2024-07-30
 ### Added

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -336,11 +336,6 @@ parameters:
 			path: src/JsonSchema/Constraints/FormatConstraint.php
 
 		-
-			message: "#^Strict comparison using \\=\\=\\= between null and non\\-falsy\\-string\\|false will always evaluate to false\\.$#"
-			count: 1
-			path: src/JsonSchema/Constraints/FormatConstraint.php
-
-		-
 			message: "#^Method JsonSchema\\\\Constraints\\\\NumberConstraint\\:\\:check\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: src/JsonSchema/Constraints/NumberConstraint.php

--- a/src/JsonSchema/Constraints/FormatConstraint.php
+++ b/src/JsonSchema/Constraints/FormatConstraint.php
@@ -133,12 +133,7 @@ class FormatConstraint extends Constraint
                 break;
 
             case 'email':
-                $filterFlags = FILTER_NULL_ON_FAILURE;
-                if (defined('FILTER_FLAG_EMAIL_UNICODE')) {
-                    // Only available from PHP >= 7.1.0, so ignore it for coverage checks
-                    $filterFlags |= constant('FILTER_FLAG_EMAIL_UNICODE'); // @codeCoverageIgnore
-                }
-                if (null === filter_var($element, FILTER_VALIDATE_EMAIL, $filterFlags)) {
+                if (null === filter_var($element, FILTER_VALIDATE_EMAIL, FILTER_NULL_ON_FAILURE | FILTER_FLAG_EMAIL_UNICODE)) {
                     $this->addError(ConstraintError::FORMAT_EMAIL(), $path, ['format' => $schema->format]);
                 }
                 break;


### PR DESCRIPTION
`FILTER_FLAG_EMAIL_UNICODE` is available in PHP 7.1 or higher https://www.php.net/manual/en/filter.constants.php#constant.filter-flag-email-unicode and this package does no longer support PHP 7.1 or lower.

Therefore the check can be safely removed.