### PR TITLE
Use phpstan's int-mask-of<T>

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Used PHPStan's int-mask-of<T> type where applicable ([#779](https://github.com/jsonrainbow/json-schema/pull/779))
 
 ## [6.1.0] - 2025-02-04
 ### Added

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -451,7 +451,7 @@ parameters:
 			path: src/JsonSchema/Constraints/StringConstraint.php
 
 		-
-			message: "#^Parameter \\#2 \\$encoding of function mb_strlen expects string\\|null, string\\|false given\\.$#"
+			message: "#^Parameter \\#2 \\$encoding of function mb_strlen expects string, string\\|false given\\.$#"
 			count: 1
 			path: src/JsonSchema/Constraints/StringConstraint.php
 
@@ -971,7 +971,7 @@ parameters:
 			path: src/JsonSchema/Uri/Retrievers/FileGetContents.php
 
 		-
-			message: "#^Parameter \\#1 \\$callback of function set_error_handler expects \\(callable\\(int, string, string, int\\)\\: bool\\)\\|null, Closure\\(mixed, mixed\\)\\: void given\\.$#"
+			message: "#^Parameter \\#1 \\$callback of function set_error_handler expects \\(callable\\(int, string, string, int, array\\)\\: bool\\)\\|null, Closure\\(mixed, mixed\\)\\: void given\\.$#"
 			count: 1
 			path: src/JsonSchema/Uri/Retrievers/FileGetContents.php
 

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -451,7 +451,7 @@ parameters:
 			path: src/JsonSchema/Constraints/StringConstraint.php
 
 		-
-			message: "#^Parameter \\#2 \\$encoding of function mb_strlen expects string, string\\|false given\\.$#"
+			message: "#^Parameter \\#2 \\$encoding of function mb_strlen expects string\\|null, string\\|false given\\.$#"
 			count: 1
 			path: src/JsonSchema/Constraints/StringConstraint.php
 
@@ -971,7 +971,7 @@ parameters:
 			path: src/JsonSchema/Uri/Retrievers/FileGetContents.php
 
 		-
-			message: "#^Parameter \\#1 \\$callback of function set_error_handler expects \\(callable\\(int, string, string, int, array\\)\\: bool\\)\\|null, Closure\\(mixed, mixed\\)\\: void given\\.$#"
+			message: "#^Parameter \\#1 \\$callback of function set_error_handler expects \\(callable\\(int, string, string, int\\)\\: bool\\)\\|null, Closure\\(mixed, mixed\\)\\: void given\\.$#"
 			count: 1
 			path: src/JsonSchema/Uri/Retrievers/FileGetContents.php
 

--- a/src/JsonSchema/Constraints/BaseConstraint.php
+++ b/src/JsonSchema/Constraints/BaseConstraint.php
@@ -30,6 +30,7 @@ class BaseConstraint
 
     /**
      * @var int All error types which have occurred
+     * @phpstan-var int-mask-of<Validator::ERROR_*>
      */
     protected $errorMask = Validator::ERROR_NONE;
 
@@ -129,6 +130,7 @@ class BaseConstraint
      * Get the error mask
      *
      * @return int
+     * @phpstan-return int-mask-of<Validator::ERROR_*>
      */
     public function getErrorMask()
     {

--- a/src/JsonSchema/Validator.php
+++ b/src/JsonSchema/Validator.php
@@ -44,7 +44,8 @@ class Validator extends BaseConstraint
      *
      * @return int
      *
-     * @phpstan-param Constraint::CHECK_MODE_* $checkMode
+     * @phpstan-param int-mask-of<Constraint::CHECK_MODE_*> $checkMode
+     * @phpstan-return int-mask-of<Validator::ERROR_*>
      */
     public function validate(&$value, $schema = null, $checkMode = null)
     {


### PR DESCRIPTION
We are getting phpstan errors when using multiple options of the checkmode (i.e. `Constraint::CHECK_MODE_VALIDATE_SCHEMA | Constraint::CHECK_MODE_EXCEPTIONS`)