### PR TITLE
feat: welcome first time contributors

### DIFF
--- a/.github/workflows/welcome.yml
+++ b/.github/workflows/welcome.yml
@@ -1,0 +1,23 @@
+name: Welcome
+on:
+  pull_request:
+    types: [opened, closed]
+  issues:
+    types: [opened]
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: wow-actions/welcome@v1
+        with:
+          FIRST_ISSUE: |
+            🚀 @{{ author }}, thanks for your contribution! Every idea, bug report, and discussion helps make this project better. Your input is invaluable, and we appreciate the time you took to share it. A maintainer will review it soon—stay awesome! 💡✨
+
+          FIRST_PR: |
+            🎉 You're making a difference! We appreciate your effort and dedication. A reviewer will check it out soon, but in the meantime, give yourself a pat on the back. Keep up the great work! 💪🚀
+
+          FIRST_PR_MERGED: |
+            💖 Welcome @{{ author }} as first-time contributor! Your efforts matter, and we’re so grateful for your contribution. Open source thrives because of people like you. Keep going, keep learning, and know that your work is truly valued. 🌱✨
+
+          STAR_MESSAGE: |
+            ⭐ Enjoying contributing? Star the project! ⭐Your contributions help this project grow, and we'd love your support in another way too! If you find this repo helpful, consider leaving a star 🌟 on GitHub.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Welcome first time contributors ([#782](https://github.com/jsonrainbow/json-schema/pull/782))
+
 ### Changed
 - Used PHPStan's int-mask-of<T> type where applicable ([#779](https://github.com/jsonrainbow/json-schema/pull/779))
 - Fixed some PHPStan errors ([#781](https://github.com/jsonrainbow/json-schema/pull/781))


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow to welcome contributors to the repository. The workflow is triggered by new pull requests and issues, and it sends personalized messages to first-time contributors.

New GitHub Actions workflow:

* [`.github/workflows/welcome.yml`](diffhunk://#diff-cc79bd21359e704d7ea9873084932689e7da7f4fb1f60157453962b7498df3bcR1-R23): Added a new workflow named `Welcome` that triggers on pull request and issue events. It includes steps to send personalized messages to first-time issue reporters, pull request creators, and contributors whose pull requests have been merged.