### PR TITLE
fix: property is passed as integer and cannot be accessed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Create deep copy before checking each sub schema in anyOf ([#792](https://github.com/jsonrainbow/json-schema/pull/792))
 - Correctly set the schema ID when passing it as assoc array ([#794](https://github.com/jsonrainbow/json-schema/pull/794))
 - Create deep copy before checking each sub schema in oneOf when only check_mode_apply_defaults is set ([#795](https://github.com/jsonrainbow/json-schema/pull/795))
+- Additional property casted into int when actually is numeric string ([#784](https://github.com/jsonrainbow/json-schema/pull/784))
 
 ### Changed
 - Used PHPStan's int-mask-of<T> type where applicable ([#779](https://github.com/jsonrainbow/json-schema/pull/779))

--- a/src/JsonSchema/Constraints/ObjectConstraint.php
+++ b/src/JsonSchema/Constraints/ObjectConstraint.php
@@ -159,7 +159,7 @@ class ObjectConstraint extends Constraint
     {
         if (is_array($element) && (isset($element[$property]) || array_key_exists($property, $element)) /*$this->checkMode == self::CHECK_MODE_TYPE_CAST*/) {
             return $element[$property];
-        } elseif (is_object($element) && property_exists($element, $property)) {
+        } elseif (is_object($element) && property_exists($element, (string) $property)) {
             return $element->$property;
         }
 

--- a/tests/Constraints/AdditionalPropertiesTest.php
+++ b/tests/Constraints/AdditionalPropertiesTest.php
@@ -189,6 +189,42 @@ class AdditionalPropertiesTest extends BaseTestCase
                   "additionalProperties": true
                 }'
             ],
+            [
+                '{
+                  "prop1": {
+                    "prop2": "a"
+                  }
+                }',
+                '{
+                  "type": "object",
+                  "additionalProperties": {
+                    "type": "object",
+                    "properties": {
+                      "prop2": {
+                        "type": "string"
+                      }
+                    }
+                  }
+                }'
+            ],
+            [
+                '{
+                  "prop1": {
+                    "123": "a"
+                  }
+                }',
+                '{
+                  "type": "object",
+                  "additionalProperties": {
+                    "type": "object",
+                    "properties": {
+                      "123": {
+                        "type": "string"
+                      }
+                    }
+                  }
+                }'
+            ],
         ];
     }
 }

--- a/tests/Constraints/AdditionalPropertiesTest.php
+++ b/tests/Constraints/AdditionalPropertiesTest.php
@@ -189,40 +189,22 @@ class AdditionalPropertiesTest extends BaseTestCase
                   "additionalProperties": true
                 }'
             ],
-            [
+            'additional property casted into int when actually is numeric string (#784)' => [
                 '{
-                  "prop1": {
-                    "prop2": "a"
-                  }
+                    "prop1": {
+                        "123": "a"
+                    }
                 }',
                 '{
-                  "type": "object",
-                  "additionalProperties": {
                     "type": "object",
-                    "properties": {
-                      "prop2": {
-                        "type": "string"
-                      }
+                    "additionalProperties": {
+                        "type": "object",
+                        "properties": {
+                            "123": {
+                                "type": "string"
+                            }
+                        }
                     }
-                  }
-                }'
-            ],
-            [
-                '{
-                  "prop1": {
-                    "123": "a"
-                  }
-                }',
-                '{
-                  "type": "object",
-                  "additionalProperties": {
-                    "type": "object",
-                    "properties": {
-                      "123": {
-                        "type": "string"
-                      }
-                    }
-                  }
                 }'
             ],
         ];


### PR DESCRIPTION
Hi, I have an error coming from this lib when validating a complex object. There is an object which holds a private property with an unsorted array where key is integer. The array does not start with 0, but may be any positive integer.

Unfortunately I haven't had time to investigate the exact reason, but maybe someone will 🤞 

> TypeError: property_exists(): Argument #2 ($property) must be of type string, int given