### PR TITLE
Update dev tools

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -8,3 +8,4 @@
 /phpstan-baseline.neon export-ignore
 /phpstan.neon export-ignore
 /phpunit.xml.dist export-ignore
+/tools export-ignore

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -14,7 +14,13 @@ jobs:
       matrix:
         php-version:
           - "7.2"
-          - "latest"
+          - "7.3"
+          - "7.4"
+          - "8.0"
+          - "8.1"
+          - "8.2"
+          - "8.3"
+          - "8.4"
 
     steps:
       - name: "Checkout"
@@ -23,9 +29,6 @@ jobs:
       - name: "Install PHP"
         uses: "shivammathur/setup-php@v2"
         with:
-          coverage: "none"
-          extensions: "intl"
-          ini-values: "memory_limit=-1, error_reporting=E_ALL, display_errors=On"
           php-version: "${{ matrix.php-version }}"
 
       - name: "Lint PHP files"

--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -4,9 +4,6 @@ on:
   - push
   - pull_request
 
-env:
-  COMPOSER_FLAGS: "--ansi --no-interaction --no-progress --prefer-dist"
-
 jobs:
   tests:
     name: "PHPStan"
@@ -20,14 +17,10 @@ jobs:
       - name: "Install PHP"
         uses: "shivammathur/setup-php@v2"
         with:
-          coverage: "none"
-          extensions: "intl, zip"
-          ini-values: "memory_limit=-1"
-          php-version: "7.2"
+          php-version: "latest"
 
-      - name: "Update dependencies"
-        run: "composer update ${{ env.COMPOSER_FLAGS }}"
+      - name: "Composer Install"
+        run: composer install && composer --working-dir=tools install
 
       - name: Run PHPStan
-        run: |
-          composer phpstan
+        run: composer phpstan

--- a/.github/workflows/style-check.yml
+++ b/.github/workflows/style-check.yml
@@ -4,9 +4,6 @@ on:
   - push
   - pull_request
 
-env:
-  COMPOSER_FLAGS: "--ansi --no-interaction --no-progress --prefer-dist"
-
 jobs:
   tests:
     name: "Style Check"
@@ -20,14 +17,12 @@ jobs:
       - name: "Install PHP"
         uses: "shivammathur/setup-php@v2"
         with:
-          coverage: "none"
-          extensions: "intl, zip"
-          ini-values: "memory_limit=-1, phar.readonly=0, error_reporting=E_ALL, display_errors=On"
-          php-version: "7.4"
-          tools: composer
+          php-version: "latest"
 
-      - name: "Update dependencies"
-        run: "composer update ${{ env.COMPOSER_FLAGS }}"
+      - name: "Composer Install"
+        run: composer --working-dir=tools install
 
       - name: "Run style-check"
-        run: "composer style-check"
+        run: composer style-check
+        env:
+          PHP_CS_FIXER_IGNORE_ENV: 1

--- a/.gitignore
+++ b/.gitignore
@@ -1,12 +1,12 @@
 /vendor
+/tools/vendor
 /bin
 !/bin/validate-json
 coverage
 .buildpath
 .project
 .settings
-.php_cs
-.php_cs.cache
+/.php-cs-fixer.cache
 composer.lock
 docs-api
 phpunit.xml

--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -4,7 +4,6 @@ $finder = new PhpCsFixer\Finder();
 $config = new PhpCsFixer\Config('json-schema');
 $finder->in(__DIR__);
 
-/* Based on ^2.1 of php-cs-fixer */
 $config
     ->setRules([
         // default

--- a/composer.json
+++ b/composer.json
@@ -33,12 +33,9 @@
         "icecave/parity": "^3.0"
     },
     "require-dev": {
-        "friendsofphp/php-cs-fixer": "~2.2.20 || ~2.19.0",
         "json-schema/json-schema-test-suite": "1.2.0",
         "phpunit/phpunit": "^8.5",
-        "phpspec/prophecy": "^1.19",
-        "phpstan/phpstan": "^1.12",
-        "marc-mabe/php-enum-phpstan": "^2.0"
+        "phpspec/prophecy": "^1.19"
     },
     "extra": {
         "branch-alias": {
@@ -74,11 +71,11 @@
     ],
     "scripts": {
         "coverage": "phpunit --coverage-text",
-        "style-check": "php-cs-fixer fix --dry-run --verbose --diff",
-        "style-fix": "php-cs-fixer fix --verbose",
+        "style-check": "tools/vendor/bin/php-cs-fixer fix --dry-run --verbose --diff",
+        "style-fix": "tools/vendor/bin/php-cs-fixer fix --verbose",
         "test": "phpunit",
         "testOnly": "phpunit --colors --filter",
-        "phpstan": "@php phpstan",
-        "phpstan-generate-baseline": "@php phpstan --generate-baseline"
+        "phpstan": "tools/vendor/bin/phpstan",
+        "phpstan-generate-baseline": "tools/vendor/bin/phpstan --generate-baseline"
     }
 }

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,952 +1,3914 @@
 parameters:
 	ignoreErrors:
 		-
-			message: "#^Method JsonSchema\\\\Constraints\\\\BaseConstraint\\:\\:addError\\(\\) has parameter \\$more with no value type specified in iterable type array\\.$#"
+			message: '#^Cannot access offset ''additionalItems''\|''additionalProp''\|''allOf''\|''anyOf''\|''colorFormat''\|''const''\|''dateFormat''\|''dateTimeFormat''\|''dateUtcFormat''\|''dependencies''\|''disallow''\|''divisibleBy''\|''emailFormat''\|''enum''\|''exclusiveMaximum''\|''exclusiveMinimum''\|''invalidSchema''\|''ipFormat''\|''maximum''\|''maxItems''\|''maxLength''\|''maxProperties''\|''minimum''\|''minItems''\|''minLength''\|''minProperties''\|''missingError''\|''missingMaximum''\|''missingMinimum''\|''multipleOf''\|''not''\|''oneOf''\|''pattern''\|''phoneFormat''\|''pregrex''\|''regexFormat''\|''required''\|''requires''\|''styleFormat''\|''styleHostName''\|''timeFormat''\|''type''\|''uniqueItems''\|''urlFormat''\|''urlRefFormat'' on mixed\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: src/JsonSchema/ConstraintError.php
+
+		-
+			message: '#^Method JsonSchema\\ConstraintError\:\:getMessage\(\) should return string but returns mixed\.$#'
+			identifier: return.type
+			count: 1
+			path: src/JsonSchema/ConstraintError.php
+
+		-
+			message: '#^Binary operation "&" between 0\|1\|2\|3 and mixed results in an error\.$#'
+			identifier: binaryOp.invalid
 			count: 1
 			path: src/JsonSchema/Constraints/BaseConstraint.php
 
 		-
-			message: "#^Method JsonSchema\\\\Constraints\\\\BaseConstraint\\:\\:addErrors\\(\\) has parameter \\$errors with no value type specified in iterable type array\\.$#"
+			message: '#^Binary operation "\|\=" between int and mixed results in an error\.$#'
+			identifier: assignOp.invalid
 			count: 1
 			path: src/JsonSchema/Constraints/BaseConstraint.php
 
 		-
-			message: "#^Method JsonSchema\\\\Constraints\\\\BaseConstraint\\:\\:arrayToObjectRecursive\\(\\) has parameter \\$array with no value type specified in iterable type array\\.$#"
+			message: '#^Cannot access offset ''context'' on mixed\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 2
+			path: src/JsonSchema/Constraints/BaseConstraint.php
+
+		-
+			message: '#^Method JsonSchema\\Constraints\\BaseConstraint\:\:addError\(\) has parameter \$more with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/JsonSchema/Constraints/BaseConstraint.php
 
 		-
-			message: "#^Method JsonSchema\\\\Constraints\\\\BaseConstraint\\:\\:getErrors\\(\\) return type has no value type specified in iterable type array\\.$#"
+			message: '#^Method JsonSchema\\Constraints\\BaseConstraint\:\:addErrors\(\) has parameter \$errors with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/JsonSchema/Constraints/BaseConstraint.php
 
 		-
-			message: "#^Parameter \\#1 \\$json of function json_decode expects string, string\\|false given\\.$#"
+			message: '#^Method JsonSchema\\Constraints\\BaseConstraint\:\:arrayToObjectRecursive\(\) has parameter \$array with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/JsonSchema/Constraints/BaseConstraint.php
 
 		-
-			message: "#^Property JsonSchema\\\\Constraints\\\\BaseConstraint\\:\\:\\$errors type has no value type specified in iterable type array\\.$#"
+			message: '#^Method JsonSchema\\Constraints\\BaseConstraint\:\:getErrors\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/JsonSchema/Constraints/BaseConstraint.php
 
 		-
-			message: "#^Cannot access property \\$additionalItems on stdClass\\|null\\.$#"
+			message: '#^Parameter \#1 \$json of function json_decode expects string, string\|false given\.$#'
+			identifier: argument.type
+			count: 1
+			path: src/JsonSchema/Constraints/BaseConstraint.php
+
+		-
+			message: '#^Property JsonSchema\\Constraints\\BaseConstraint\:\:\$errors type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: src/JsonSchema/Constraints/BaseConstraint.php
+
+		-
+			message: '#^Cannot access offset int\<1, max\> on mixed\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: src/JsonSchema/Constraints/CollectionConstraint.php
+
+		-
+			message: '#^Cannot access property \$additionalItems on stdClass\|null\.$#'
+			identifier: property.nonObject
 			count: 3
 			path: src/JsonSchema/Constraints/CollectionConstraint.php
 
 		-
-			message: "#^Cannot access property \\$items on stdClass\\|null\\.$#"
+			message: '#^Cannot access property \$items on mixed\.$#'
+			identifier: property.nonObject
+			count: 1
+			path: src/JsonSchema/Constraints/CollectionConstraint.php
+
+		-
+			message: '#^Cannot access property \$items on stdClass\|null\.$#'
+			identifier: property.nonObject
 			count: 6
 			path: src/JsonSchema/Constraints/CollectionConstraint.php
 
 		-
-			message: "#^Method JsonSchema\\\\Constraints\\\\CollectionConstraint\\:\\:validateItems\\(\\) has parameter \\$value with no value type specified in iterable type array\\.$#"
+			message: '#^Cannot access property \$maxItems on mixed\.$#'
+			identifier: property.nonObject
 			count: 1
 			path: src/JsonSchema/Constraints/CollectionConstraint.php
 
 		-
-			message: "#^Parameter \\#1 \\$object_or_class of function property_exists expects object\\|string, stdClass\\|null given\\.$#"
+			message: '#^Cannot access property \$minItems on mixed\.$#'
+			identifier: property.nonObject
 			count: 1
 			path: src/JsonSchema/Constraints/CollectionConstraint.php
 
 		-
-			message: "#^Parameter \\#2 \\$schema of method JsonSchema\\\\Constraints\\\\CollectionConstraint\\:\\:validateItems\\(\\) expects stdClass\\|null, object given\\.$#"
+			message: '#^Cannot access property \$uniqueItems on mixed\.$#'
+			identifier: property.nonObject
 			count: 1
 			path: src/JsonSchema/Constraints/CollectionConstraint.php
 
 		-
-			message: "#^Method JsonSchema\\\\Constraints\\\\Constraint\\:\\:checkObject\\(\\) has parameter \\$appliedDefaults with no type specified\\.$#"
+			message: '#^Method JsonSchema\\Constraints\\CollectionConstraint\:\:validateItems\(\) has parameter \$value with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: src/JsonSchema/Constraints/CollectionConstraint.php
+
+		-
+			message: '#^Parameter \#1 \$array of function array_unique expects array, mixed given\.$#'
+			identifier: argument.type
+			count: 1
+			path: src/JsonSchema/Constraints/CollectionConstraint.php
+
+		-
+			message: '#^Parameter \#1 \$object_or_class of function property_exists expects object\|string, stdClass\|null given\.$#'
+			identifier: argument.type
+			count: 1
+			path: src/JsonSchema/Constraints/CollectionConstraint.php
+
+		-
+			message: '#^Parameter \#1 \$value of method JsonSchema\\Constraints\\CollectionConstraint\:\:validateItems\(\) expects array, mixed given\.$#'
+			identifier: argument.type
+			count: 1
+			path: src/JsonSchema/Constraints/CollectionConstraint.php
+
+		-
+			message: '#^Parameter \#1 \$var of function count expects array\|Countable, mixed given\.$#'
+			identifier: argument.type
+			count: 4
+			path: src/JsonSchema/Constraints/CollectionConstraint.php
+
+		-
+			message: '#^Parameter \#2 \$schema of method JsonSchema\\Constraints\\CollectionConstraint\:\:validateItems\(\) expects stdClass\|null, object given\.$#'
+			identifier: argument.type
+			count: 1
+			path: src/JsonSchema/Constraints/CollectionConstraint.php
+
+		-
+			message: '#^Parameter \#2 \$search of function array_key_exists expects array, mixed given\.$#'
+			identifier: argument.type
+			count: 1
+			path: src/JsonSchema/Constraints/CollectionConstraint.php
+
+		-
+			message: '#^Parameter \#4 \$i of method JsonSchema\\Constraints\\CollectionConstraint\:\:validateItems\(\) expects string\|null, mixed given\.$#'
+			identifier: argument.type
+			count: 1
+			path: src/JsonSchema/Constraints/CollectionConstraint.php
+
+		-
+			message: '#^Cannot access property \$const on mixed\.$#'
+			identifier: property.nonObject
+			count: 2
+			path: src/JsonSchema/Constraints/ConstConstraint.php
+
+		-
+			message: '#^Cannot access property \$required on mixed\.$#'
+			identifier: property.nonObject
+			count: 1
+			path: src/JsonSchema/Constraints/ConstConstraint.php
+
+		-
+			message: '#^Method JsonSchema\\Constraints\\Constraint\:\:checkObject\(\) has parameter \$appliedDefaults with no type specified\.$#'
+			identifier: missingType.parameter
 			count: 1
 			path: src/JsonSchema/Constraints/Constraint.php
 
 		-
-			message: "#^Method JsonSchema\\\\Constraints\\\\Constraint\\:\\:checkUndefined\\(\\) has parameter \\$fromDefault with no type specified\\.$#"
+			message: '#^Method JsonSchema\\Constraints\\Constraint\:\:checkUndefined\(\) has parameter \$fromDefault with no type specified\.$#'
+			identifier: missingType.parameter
 			count: 1
 			path: src/JsonSchema/Constraints/Constraint.php
 
 		-
-			message: "#^Property JsonSchema\\\\Constraints\\\\Constraint\\:\\:\\$inlineSchemaProperty has no type specified\\.$#"
+			message: '#^Property JsonSchema\\Constraints\\Constraint\:\:\$inlineSchemaProperty has no type specified\.$#'
+			identifier: missingType.property
 			count: 1
 			path: src/JsonSchema/Constraints/Constraint.php
 
 		-
-			message: "#^Method JsonSchema\\\\Constraints\\\\ConstraintInterface\\:\\:addError\\(\\) has parameter \\$more with no value type specified in iterable type array\\.$#"
+			message: '#^Method JsonSchema\\Constraints\\ConstraintInterface\:\:addError\(\) has parameter \$more with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/JsonSchema/Constraints/ConstraintInterface.php
 
 		-
-			message: "#^Method JsonSchema\\\\Constraints\\\\ConstraintInterface\\:\\:addErrors\\(\\) has parameter \\$errors with no value type specified in iterable type array\\.$#"
+			message: '#^Method JsonSchema\\Constraints\\ConstraintInterface\:\:addErrors\(\) has parameter \$errors with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/JsonSchema/Constraints/ConstraintInterface.php
 
 		-
-			message: "#^Method JsonSchema\\\\Constraints\\\\ConstraintInterface\\:\\:getErrors\\(\\) return type has no value type specified in iterable type array\\.$#"
+			message: '#^Method JsonSchema\\Constraints\\ConstraintInterface\:\:getErrors\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/JsonSchema/Constraints/ConstraintInterface.php
 
 		-
-			message: "#^PHPDoc tag @throws with type JsonSchema\\\\Exception\\\\ExceptionInterface is not subtype of Throwable$#"
+			message: '#^PHPDoc tag @throws with type JsonSchema\\Exception\\ExceptionInterface is not subtype of Throwable$#'
+			identifier: throws.notThrowable
 			count: 1
 			path: src/JsonSchema/Constraints/ConstraintInterface.php
 
 		-
-			message: "#^Method JsonSchema\\\\Constraints\\\\Factory\\:\\:createInstanceFor\\(\\) should return JsonSchema\\\\Constraints\\\\BaseConstraint&JsonSchema\\\\Constraints\\\\ConstraintInterface but returns object\\.$#"
+			message: '#^Argument of an invalid type mixed supplied for foreach, only iterables are supported\.$#'
+			identifier: foreach.nonIterable
+			count: 1
+			path: src/JsonSchema/Constraints/EnumConstraint.php
+
+		-
+			message: '#^Cannot access property \$enum on mixed\.$#'
+			identifier: property.nonObject
+			count: 2
+			path: src/JsonSchema/Constraints/EnumConstraint.php
+
+		-
+			message: '#^Cannot access property \$required on mixed\.$#'
+			identifier: property.nonObject
+			count: 1
+			path: src/JsonSchema/Constraints/EnumConstraint.php
+
+		-
+			message: '#^Method JsonSchema\\Constraints\\Factory\:\:createInstanceFor\(\) should return JsonSchema\\Constraints\\BaseConstraint&JsonSchema\\Constraints\\ConstraintInterface but returns object\.$#'
+			identifier: return.type
 			count: 1
 			path: src/JsonSchema/Constraints/Factory.php
 
 		-
-			message: "#^Method JsonSchema\\\\Constraints\\\\Factory\\:\\:getConfig\\(\\) should return int\\<0, 511\\> but returns int\\.$#"
+			message: '#^Method JsonSchema\\Constraints\\Factory\:\:getConfig\(\) should return int\<0, 511\> but returns int\.$#'
+			identifier: return.type
 			count: 1
 			path: src/JsonSchema/Constraints/Factory.php
 
 		-
-			message: "#^Method JsonSchema\\\\Constraints\\\\Factory\\:\\:getErrorContext\\(\\) should return 1\\|2 but returns int\\.$#"
+			message: '#^Method JsonSchema\\Constraints\\Factory\:\:getErrorContext\(\) should return 1\|2 but returns int\.$#'
+			identifier: return.type
 			count: 1
 			path: src/JsonSchema/Constraints/Factory.php
 
 		-
-			message: "#^Property JsonSchema\\\\Constraints\\\\Factory\\:\\:\\$checkMode \\(int\\<0, 511\\>\\) does not accept int\\.$#"
+			message: '#^Property JsonSchema\\Constraints\\Factory\:\:\$checkMode \(int\<0, 511\>\) does not accept int\.$#'
+			identifier: assign.propertyType
 			count: 2
 			path: src/JsonSchema/Constraints/Factory.php
 
 		-
-			message: "#^Property JsonSchema\\\\Constraints\\\\Factory\\:\\:\\$constraintMap type has no value type specified in iterable type array\\.$#"
+			message: '#^Property JsonSchema\\Constraints\\Factory\:\:\$constraintMap type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/JsonSchema/Constraints/Factory.php
 
 		-
-			message: "#^Property JsonSchema\\\\Constraints\\\\Factory\\:\\:\\$instanceCache \\(array\\<JsonSchema\\\\Constraints\\\\ConstraintInterface\\>\\) does not accept array\\<object\\>\\.$#"
+			message: '#^Property JsonSchema\\Constraints\\Factory\:\:\$instanceCache \(array\<JsonSchema\\Constraints\\ConstraintInterface\>\) does not accept array\<object\>\.$#'
+			identifier: assign.propertyType
 			count: 1
 			path: src/JsonSchema/Constraints/Factory.php
 
 		-
-			message: "#^Property JsonSchema\\\\Constraints\\\\Factory\\:\\:\\$uriRetriever \\(JsonSchema\\\\Uri\\\\UriRetriever\\) does not accept JsonSchema\\\\UriRetrieverInterface\\.$#"
+			message: '#^Property JsonSchema\\Constraints\\Factory\:\:\$uriRetriever \(JsonSchema\\Uri\\UriRetriever\) does not accept JsonSchema\\UriRetrieverInterface\.$#'
+			identifier: assign.propertyType
 			count: 1
 			path: src/JsonSchema/Constraints/Factory.php
 
 		-
-			message: "#^Method JsonSchema\\\\Constraints\\\\FormatConstraint\\:\\:validateColor\\(\\) has no return type specified\\.$#"
+			message: '#^Cannot access property \$format on mixed\.$#'
+			identifier: property.nonObject
 			count: 1
 			path: src/JsonSchema/Constraints/FormatConstraint.php
 
 		-
-			message: "#^Method JsonSchema\\\\Constraints\\\\FormatConstraint\\:\\:validateColor\\(\\) has parameter \\$color with no type specified\\.$#"
+			message: '#^Cannot cast mixed to string\.$#'
+			identifier: cast.string
 			count: 1
 			path: src/JsonSchema/Constraints/FormatConstraint.php
 
 		-
-			message: "#^Method JsonSchema\\\\Constraints\\\\FormatConstraint\\:\\:validateDateTime\\(\\) has no return type specified\\.$#"
+			message: '#^Method JsonSchema\\Constraints\\FormatConstraint\:\:validateColor\(\) has no return type specified\.$#'
+			identifier: missingType.return
 			count: 1
 			path: src/JsonSchema/Constraints/FormatConstraint.php
 
 		-
-			message: "#^Method JsonSchema\\\\Constraints\\\\FormatConstraint\\:\\:validateDateTime\\(\\) has parameter \\$datetime with no type specified\\.$#"
+			message: '#^Method JsonSchema\\Constraints\\FormatConstraint\:\:validateColor\(\) has parameter \$color with no type specified\.$#'
+			identifier: missingType.parameter
 			count: 1
 			path: src/JsonSchema/Constraints/FormatConstraint.php
 
 		-
-			message: "#^Method JsonSchema\\\\Constraints\\\\FormatConstraint\\:\\:validateDateTime\\(\\) has parameter \\$format with no type specified\\.$#"
+			message: '#^Method JsonSchema\\Constraints\\FormatConstraint\:\:validateDateTime\(\) has no return type specified\.$#'
+			identifier: missingType.return
 			count: 1
 			path: src/JsonSchema/Constraints/FormatConstraint.php
 
 		-
-			message: "#^Method JsonSchema\\\\Constraints\\\\FormatConstraint\\:\\:validateHostname\\(\\) has no return type specified\\.$#"
+			message: '#^Method JsonSchema\\Constraints\\FormatConstraint\:\:validateDateTime\(\) has parameter \$datetime with no type specified\.$#'
+			identifier: missingType.parameter
 			count: 1
 			path: src/JsonSchema/Constraints/FormatConstraint.php
 
 		-
-			message: "#^Method JsonSchema\\\\Constraints\\\\FormatConstraint\\:\\:validateHostname\\(\\) has parameter \\$host with no type specified\\.$#"
+			message: '#^Method JsonSchema\\Constraints\\FormatConstraint\:\:validateDateTime\(\) has parameter \$format with no type specified\.$#'
+			identifier: missingType.parameter
 			count: 1
 			path: src/JsonSchema/Constraints/FormatConstraint.php
 
 		-
-			message: "#^Method JsonSchema\\\\Constraints\\\\FormatConstraint\\:\\:validatePhone\\(\\) has no return type specified\\.$#"
+			message: '#^Method JsonSchema\\Constraints\\FormatConstraint\:\:validateHostname\(\) has no return type specified\.$#'
+			identifier: missingType.return
 			count: 1
 			path: src/JsonSchema/Constraints/FormatConstraint.php
 
 		-
-			message: "#^Method JsonSchema\\\\Constraints\\\\FormatConstraint\\:\\:validatePhone\\(\\) has parameter \\$phone with no type specified\\.$#"
+			message: '#^Method JsonSchema\\Constraints\\FormatConstraint\:\:validateHostname\(\) has parameter \$host with no type specified\.$#'
+			identifier: missingType.parameter
 			count: 1
 			path: src/JsonSchema/Constraints/FormatConstraint.php
 
 		-
-			message: "#^Method JsonSchema\\\\Constraints\\\\FormatConstraint\\:\\:validateRegex\\(\\) has no return type specified\\.$#"
+			message: '#^Method JsonSchema\\Constraints\\FormatConstraint\:\:validatePhone\(\) has no return type specified\.$#'
+			identifier: missingType.return
 			count: 1
 			path: src/JsonSchema/Constraints/FormatConstraint.php
 
 		-
-			message: "#^Method JsonSchema\\\\Constraints\\\\FormatConstraint\\:\\:validateRegex\\(\\) has parameter \\$regex with no type specified\\.$#"
+			message: '#^Method JsonSchema\\Constraints\\FormatConstraint\:\:validatePhone\(\) has parameter \$phone with no type specified\.$#'
+			identifier: missingType.parameter
 			count: 1
 			path: src/JsonSchema/Constraints/FormatConstraint.php
 
 		-
-			message: "#^Method JsonSchema\\\\Constraints\\\\FormatConstraint\\:\\:validateStyle\\(\\) has no return type specified\\.$#"
+			message: '#^Method JsonSchema\\Constraints\\FormatConstraint\:\:validateRegex\(\) has no return type specified\.$#'
+			identifier: missingType.return
 			count: 1
 			path: src/JsonSchema/Constraints/FormatConstraint.php
 
 		-
-			message: "#^Method JsonSchema\\\\Constraints\\\\FormatConstraint\\:\\:validateStyle\\(\\) has parameter \\$style with no type specified\\.$#"
+			message: '#^Method JsonSchema\\Constraints\\FormatConstraint\:\:validateRegex\(\) has parameter \$regex with no type specified\.$#'
+			identifier: missingType.parameter
 			count: 1
 			path: src/JsonSchema/Constraints/FormatConstraint.php
 
 		-
-			message: "#^Method JsonSchema\\\\Constraints\\\\NumberConstraint\\:\\:fmod\\(\\) has no return type specified\\.$#"
+			message: '#^Method JsonSchema\\Constraints\\FormatConstraint\:\:validateStyle\(\) has no return type specified\.$#'
+			identifier: missingType.return
+			count: 1
+			path: src/JsonSchema/Constraints/FormatConstraint.php
+
+		-
+			message: '#^Method JsonSchema\\Constraints\\FormatConstraint\:\:validateStyle\(\) has parameter \$style with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: src/JsonSchema/Constraints/FormatConstraint.php
+
+		-
+			message: '#^Parameter \#1 \$format of method DateTime\:\:format\(\) expects string, mixed given\.$#'
+			identifier: argument.type
+			count: 1
+			path: src/JsonSchema/Constraints/FormatConstraint.php
+
+		-
+			message: '#^Parameter \#1 \$format of static method DateTime\:\:createFromFormat\(\) expects string, mixed given\.$#'
+			identifier: argument.type
+			count: 1
+			path: src/JsonSchema/Constraints/FormatConstraint.php
+
+		-
+			message: '#^Parameter \#1 \$str of function rtrim expects string, mixed given\.$#'
+			identifier: argument.type
+			count: 1
+			path: src/JsonSchema/Constraints/FormatConstraint.php
+
+		-
+			message: '#^Parameter \#2 \$subject of function preg_match expects string, mixed given\.$#'
+			identifier: argument.type
+			count: 1
+			path: src/JsonSchema/Constraints/FormatConstraint.php
+
+		-
+			message: '#^Binary operation "\*" between float and mixed results in an error\.$#'
+			identifier: binaryOp.invalid
 			count: 1
 			path: src/JsonSchema/Constraints/NumberConstraint.php
 
 		-
-			message: "#^Method JsonSchema\\\\Constraints\\\\NumberConstraint\\:\\:fmod\\(\\) has parameter \\$number1 with no type specified\\.$#"
+			message: '#^Binary operation "\-" between mixed and float results in an error\.$#'
+			identifier: binaryOp.invalid
 			count: 1
 			path: src/JsonSchema/Constraints/NumberConstraint.php
 
 		-
-			message: "#^Method JsonSchema\\\\Constraints\\\\NumberConstraint\\:\\:fmod\\(\\) has parameter \\$number2 with no type specified\\.$#"
+			message: '#^Binary operation "/" between mixed and mixed results in an error\.$#'
+			identifier: binaryOp.invalid
 			count: 1
 			path: src/JsonSchema/Constraints/NumberConstraint.php
 
 		-
-			message: "#^Argument of an invalid type stdClass supplied for foreach, only iterables are supported\\.$#"
+			message: '#^Cannot access property \$divisibleBy on mixed\.$#'
+			identifier: property.nonObject
+			count: 1
+			path: src/JsonSchema/Constraints/NumberConstraint.php
+
+		-
+			message: '#^Cannot access property \$exclusiveMaximum on mixed\.$#'
+			identifier: property.nonObject
+			count: 1
+			path: src/JsonSchema/Constraints/NumberConstraint.php
+
+		-
+			message: '#^Cannot access property \$exclusiveMinimum on mixed\.$#'
+			identifier: property.nonObject
+			count: 1
+			path: src/JsonSchema/Constraints/NumberConstraint.php
+
+		-
+			message: '#^Cannot access property \$maximum on mixed\.$#'
+			identifier: property.nonObject
+			count: 1
+			path: src/JsonSchema/Constraints/NumberConstraint.php
+
+		-
+			message: '#^Cannot access property \$minimum on mixed\.$#'
+			identifier: property.nonObject
+			count: 1
+			path: src/JsonSchema/Constraints/NumberConstraint.php
+
+		-
+			message: '#^Cannot access property \$multipleOf on mixed\.$#'
+			identifier: property.nonObject
+			count: 1
+			path: src/JsonSchema/Constraints/NumberConstraint.php
+
+		-
+			message: '#^Method JsonSchema\\Constraints\\NumberConstraint\:\:fmod\(\) has no return type specified\.$#'
+			identifier: missingType.return
+			count: 1
+			path: src/JsonSchema/Constraints/NumberConstraint.php
+
+		-
+			message: '#^Method JsonSchema\\Constraints\\NumberConstraint\:\:fmod\(\) has parameter \$number1 with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: src/JsonSchema/Constraints/NumberConstraint.php
+
+		-
+			message: '#^Method JsonSchema\\Constraints\\NumberConstraint\:\:fmod\(\) has parameter \$number2 with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: src/JsonSchema/Constraints/NumberConstraint.php
+
+		-
+			message: '#^Argument of an invalid type mixed supplied for foreach, only iterables are supported\.$#'
+			identifier: foreach.nonIterable
+			count: 2
+			path: src/JsonSchema/Constraints/ObjectConstraint.php
+
+		-
+			message: '#^Argument of an invalid type stdClass supplied for foreach, only iterables are supported\.$#'
+			identifier: foreach.nonIterable
 			count: 1
 			path: src/JsonSchema/Constraints/ObjectConstraint.php
 
 		-
-			message: "#^Argument of an invalid type stdClass\\|null supplied for foreach, only iterables are supported\\.$#"
+			message: '#^Argument of an invalid type stdClass\|null supplied for foreach, only iterables are supported\.$#'
+			identifier: foreach.nonIterable
 			count: 1
 			path: src/JsonSchema/Constraints/ObjectConstraint.php
 
 		-
-			message: "#^Method JsonSchema\\\\Constraints\\\\ObjectConstraint\\:\\:check\\(\\) has parameter \\$additionalProp with no type specified\\.$#"
+			message: '#^Method JsonSchema\\Constraints\\ObjectConstraint\:\:check\(\) has parameter \$additionalProp with no type specified\.$#'
+			identifier: missingType.parameter
 			count: 1
 			path: src/JsonSchema/Constraints/ObjectConstraint.php
 
 		-
-			message: "#^Method JsonSchema\\\\Constraints\\\\ObjectConstraint\\:\\:check\\(\\) has parameter \\$appliedDefaults with no type specified\\.$#"
+			message: '#^Method JsonSchema\\Constraints\\ObjectConstraint\:\:check\(\) has parameter \$appliedDefaults with no type specified\.$#'
+			identifier: missingType.parameter
 			count: 1
 			path: src/JsonSchema/Constraints/ObjectConstraint.php
 
 		-
-			message: "#^Method JsonSchema\\\\Constraints\\\\ObjectConstraint\\:\\:check\\(\\) has parameter \\$patternProperties with no type specified\\.$#"
+			message: '#^Method JsonSchema\\Constraints\\ObjectConstraint\:\:check\(\) has parameter \$patternProperties with no type specified\.$#'
+			identifier: missingType.parameter
 			count: 1
 			path: src/JsonSchema/Constraints/ObjectConstraint.php
 
 		-
-			message: "#^Method JsonSchema\\\\Constraints\\\\ObjectConstraint\\:\\:validateElement\\(\\) has no return type specified\\.$#"
+			message: '#^Method JsonSchema\\Constraints\\ObjectConstraint\:\:validateElement\(\) has no return type specified\.$#'
+			identifier: missingType.return
 			count: 1
 			path: src/JsonSchema/Constraints/ObjectConstraint.php
 
 		-
-			message: "#^Method JsonSchema\\\\Constraints\\\\ObjectConstraint\\:\\:validateElement\\(\\) has parameter \\$matches with no value type specified in iterable type array\\.$#"
+			message: '#^Method JsonSchema\\Constraints\\ObjectConstraint\:\:validateElement\(\) has parameter \$matches with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/JsonSchema/Constraints/ObjectConstraint.php
 
 		-
-			message: "#^Method JsonSchema\\\\Constraints\\\\ObjectConstraint\\:\\:validateMinMaxConstraint\\(\\) has no return type specified\\.$#"
+			message: '#^Method JsonSchema\\Constraints\\ObjectConstraint\:\:validateMinMaxConstraint\(\) has no return type specified\.$#'
+			identifier: missingType.return
 			count: 1
 			path: src/JsonSchema/Constraints/ObjectConstraint.php
 
 		-
-			message: "#^Method JsonSchema\\\\Constraints\\\\ObjectConstraint\\:\\:validatePatternProperties\\(\\) has no return type specified\\.$#"
+			message: '#^Method JsonSchema\\Constraints\\ObjectConstraint\:\:validatePatternProperties\(\) has no return type specified\.$#'
+			identifier: missingType.return
 			count: 1
 			path: src/JsonSchema/Constraints/ObjectConstraint.php
 
 		-
-			message: "#^Method JsonSchema\\\\Constraints\\\\ObjectConstraint\\:\\:validatePatternProperties\\(\\) has parameter \\$element with no type specified\\.$#"
+			message: '#^Method JsonSchema\\Constraints\\ObjectConstraint\:\:validatePatternProperties\(\) has parameter \$element with no type specified\.$#'
+			identifier: missingType.parameter
 			count: 1
 			path: src/JsonSchema/Constraints/ObjectConstraint.php
 
 		-
-			message: "#^Method JsonSchema\\\\Constraints\\\\ObjectConstraint\\:\\:validatePatternProperties\\(\\) has parameter \\$patternProperties with no type specified\\.$#"
+			message: '#^Method JsonSchema\\Constraints\\ObjectConstraint\:\:validatePatternProperties\(\) has parameter \$patternProperties with no type specified\.$#'
+			identifier: missingType.parameter
 			count: 1
 			path: src/JsonSchema/Constraints/ObjectConstraint.php
 
 		-
-			message: "#^Method JsonSchema\\\\Constraints\\\\ObjectConstraint\\:\\:validateProperties\\(\\) has no return type specified\\.$#"
+			message: '#^Method JsonSchema\\Constraints\\ObjectConstraint\:\:validateProperties\(\) has no return type specified\.$#'
+			identifier: missingType.return
 			count: 1
 			path: src/JsonSchema/Constraints/ObjectConstraint.php
 
 		-
-			message: "#^Parameter \\#2 \\$objectDefinition of method JsonSchema\\\\Constraints\\\\ObjectConstraint\\:\\:validateMinMaxConstraint\\(\\) expects stdClass, stdClass\\|null given\\.$#"
+			message: '#^Parameter \#1 \$element of method JsonSchema\\Constraints\\ObjectConstraint\:\:validateElement\(\) expects stdClass, mixed given\.$#'
+			identifier: argument.type
 			count: 1
 			path: src/JsonSchema/Constraints/ObjectConstraint.php
 
 		-
-			message: "#^Property JsonSchema\\\\Constraints\\\\ObjectConstraint\\:\\:\\$appliedDefaults type has no value type specified in iterable type array\\.$#"
+			message: '#^Parameter \#1 \$element of method JsonSchema\\Constraints\\ObjectConstraint\:\:validateMinMaxConstraint\(\) expects stdClass, mixed given\.$#'
+			identifier: argument.type
 			count: 1
 			path: src/JsonSchema/Constraints/ObjectConstraint.php
 
 		-
-			message: "#^Method JsonSchema\\\\Constraints\\\\StringConstraint\\:\\:strlen\\(\\) has no return type specified\\.$#"
+			message: '#^Parameter \#1 \$element of method JsonSchema\\Constraints\\ObjectConstraint\:\:validateProperties\(\) expects stdClass, mixed given\.$#'
+			identifier: argument.type
+			count: 1
+			path: src/JsonSchema/Constraints/ObjectConstraint.php
+
+		-
+			message: '#^Parameter \#1 \$pattern of static method JsonSchema\\Constraints\\BaseConstraint\:\:jsonPatternToPhpRegex\(\) expects string, mixed given\.$#'
+			identifier: argument.type
+			count: 1
+			path: src/JsonSchema/Constraints/ObjectConstraint.php
+
+		-
+			message: '#^Parameter \#2 \$matches of method JsonSchema\\Constraints\\ObjectConstraint\:\:validateElement\(\) expects array, mixed given\.$#'
+			identifier: argument.type
+			count: 1
+			path: src/JsonSchema/Constraints/ObjectConstraint.php
+
+		-
+			message: '#^Parameter \#2 \$objectDefinition of method JsonSchema\\Constraints\\ObjectConstraint\:\:validateMinMaxConstraint\(\) expects stdClass, mixed given\.$#'
+			identifier: argument.type
+			count: 1
+			path: src/JsonSchema/Constraints/ObjectConstraint.php
+
+		-
+			message: '#^Parameter \#2 \$objectDefinition of method JsonSchema\\Constraints\\ObjectConstraint\:\:validateMinMaxConstraint\(\) expects stdClass, stdClass\|null given\.$#'
+			identifier: argument.type
+			count: 1
+			path: src/JsonSchema/Constraints/ObjectConstraint.php
+
+		-
+			message: '#^Parameter \#2 \$properties of method JsonSchema\\Constraints\\ObjectConstraint\:\:validateProperties\(\) expects stdClass\|null, mixed given\.$#'
+			identifier: argument.type
+			count: 1
+			path: src/JsonSchema/Constraints/ObjectConstraint.php
+
+		-
+			message: '#^Parameter \#2 \$property of method JsonSchema\\Constraints\\ObjectConstraint\:\:getProperty\(\) expects string, mixed given\.$#'
+			identifier: argument.type
+			count: 5
+			path: src/JsonSchema/Constraints/ObjectConstraint.php
+
+		-
+			message: '#^Parameter \#2 \$subject of function preg_match expects string, mixed given\.$#'
+			identifier: argument.type
+			count: 1
+			path: src/JsonSchema/Constraints/ObjectConstraint.php
+
+		-
+			message: '#^Parameter \#3 \$schema of method JsonSchema\\Constraints\\ObjectConstraint\:\:validateElement\(\) expects stdClass\|null, mixed given\.$#'
+			identifier: argument.type
+			count: 1
+			path: src/JsonSchema/Constraints/ObjectConstraint.php
+
+		-
+			message: '#^Parameter \#5 \$properties of method JsonSchema\\Constraints\\ObjectConstraint\:\:validateElement\(\) expects stdClass\|null, mixed given\.$#'
+			identifier: argument.type
+			count: 1
+			path: src/JsonSchema/Constraints/ObjectConstraint.php
+
+		-
+			message: '#^Parameter &\$element by\-ref type of method JsonSchema\\Constraints\\ObjectConstraint\:\:validateProperties\(\) expects stdClass, mixed given\.$#'
+			identifier: parameterByRef.type
+			count: 1
+			path: src/JsonSchema/Constraints/ObjectConstraint.php
+
+		-
+			message: '#^Property JsonSchema\\Constraints\\ObjectConstraint\:\:\$appliedDefaults \(array\) does not accept mixed\.$#'
+			identifier: assign.propertyType
+			count: 1
+			path: src/JsonSchema/Constraints/ObjectConstraint.php
+
+		-
+			message: '#^Property JsonSchema\\Constraints\\ObjectConstraint\:\:\$appliedDefaults type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: src/JsonSchema/Constraints/ObjectConstraint.php
+
+		-
+			message: '#^Parameter \#1 \$id of method JsonSchema\\SchemaStorageInterface\:\:getSchema\(\) expects string, mixed given\.$#'
+			identifier: argument.type
+			count: 1
+			path: src/JsonSchema/Constraints/SchemaConstraint.php
+
+		-
+			message: '#^Cannot access property \$maxLength on mixed\.$#'
+			identifier: property.nonObject
 			count: 1
 			path: src/JsonSchema/Constraints/StringConstraint.php
 
 		-
-			message: "#^Method JsonSchema\\\\Constraints\\\\StringConstraint\\:\\:strlen\\(\\) has parameter \\$string with no type specified\\.$#"
+			message: '#^Cannot access property \$minLength on mixed\.$#'
+			identifier: property.nonObject
 			count: 1
 			path: src/JsonSchema/Constraints/StringConstraint.php
 
 		-
-			message: "#^Parameter \\#2 \\$encoding of function mb_strlen expects string, string\\|false given\\.$#"
+			message: '#^Cannot access property \$pattern on mixed\.$#'
+			identifier: property.nonObject
 			count: 1
 			path: src/JsonSchema/Constraints/StringConstraint.php
 
 		-
-			message: "#^Method JsonSchema\\\\Constraints\\\\TypeCheck\\\\LooseTypeCheck\\:\\:isArray\\(\\) has no return type specified\\.$#"
+			message: '#^Method JsonSchema\\Constraints\\StringConstraint\:\:strlen\(\) has no return type specified\.$#'
+			identifier: missingType.return
+			count: 1
+			path: src/JsonSchema/Constraints/StringConstraint.php
+
+		-
+			message: '#^Method JsonSchema\\Constraints\\StringConstraint\:\:strlen\(\) has parameter \$string with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: src/JsonSchema/Constraints/StringConstraint.php
+
+		-
+			message: '#^Parameter \#1 \$pattern of static method JsonSchema\\Constraints\\BaseConstraint\:\:jsonPatternToPhpRegex\(\) expects string, mixed given\.$#'
+			identifier: argument.type
+			count: 1
+			path: src/JsonSchema/Constraints/StringConstraint.php
+
+		-
+			message: '#^Parameter \#1 \$str of function mb_detect_encoding expects string, mixed given\.$#'
+			identifier: argument.type
+			count: 1
+			path: src/JsonSchema/Constraints/StringConstraint.php
+
+		-
+			message: '#^Parameter \#1 \$str of function mb_strlen expects string, mixed given\.$#'
+			identifier: argument.type
+			count: 1
+			path: src/JsonSchema/Constraints/StringConstraint.php
+
+		-
+			message: '#^Parameter \#1 \$string of function strlen expects string, mixed given\.$#'
+			identifier: argument.type
+			count: 1
+			path: src/JsonSchema/Constraints/StringConstraint.php
+
+		-
+			message: '#^Parameter \#2 \$encoding of function mb_strlen expects string, string\|false given\.$#'
+			identifier: argument.type
+			count: 1
+			path: src/JsonSchema/Constraints/StringConstraint.php
+
+		-
+			message: '#^Parameter \#2 \$subject of function preg_match expects string, mixed given\.$#'
+			identifier: argument.type
+			count: 1
+			path: src/JsonSchema/Constraints/StringConstraint.php
+
+		-
+			message: '#^Cannot access offset mixed on mixed\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 2
+			path: src/JsonSchema/Constraints/TypeCheck/LooseTypeCheck.php
+
+		-
+			message: '#^Method JsonSchema\\Constraints\\TypeCheck\\LooseTypeCheck\:\:isArray\(\) has no return type specified\.$#'
+			identifier: missingType.return
 			count: 1
 			path: src/JsonSchema/Constraints/TypeCheck/LooseTypeCheck.php
 
 		-
-			message: "#^Method JsonSchema\\\\Constraints\\\\TypeCheck\\\\LooseTypeCheck\\:\\:isArray\\(\\) has parameter \\$value with no type specified\\.$#"
+			message: '#^Method JsonSchema\\Constraints\\TypeCheck\\LooseTypeCheck\:\:isArray\(\) has parameter \$value with no type specified\.$#'
+			identifier: missingType.parameter
 			count: 1
 			path: src/JsonSchema/Constraints/TypeCheck/LooseTypeCheck.php
 
 		-
-			message: "#^Method JsonSchema\\\\Constraints\\\\TypeCheck\\\\LooseTypeCheck\\:\\:isAssociativeArray\\(\\) has parameter \\$arr with no value type specified in iterable type array\\.$#"
+			message: '#^Method JsonSchema\\Constraints\\TypeCheck\\LooseTypeCheck\:\:isAssociativeArray\(\) has parameter \$arr with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/JsonSchema/Constraints/TypeCheck/LooseTypeCheck.php
 
 		-
-			message: "#^Method JsonSchema\\\\Constraints\\\\TypeCheck\\\\LooseTypeCheck\\:\\:isObject\\(\\) has no return type specified\\.$#"
+			message: '#^Method JsonSchema\\Constraints\\TypeCheck\\LooseTypeCheck\:\:isObject\(\) has no return type specified\.$#'
+			identifier: missingType.return
 			count: 1
 			path: src/JsonSchema/Constraints/TypeCheck/LooseTypeCheck.php
 
 		-
-			message: "#^Method JsonSchema\\\\Constraints\\\\TypeCheck\\\\LooseTypeCheck\\:\\:isObject\\(\\) has parameter \\$value with no type specified\\.$#"
+			message: '#^Method JsonSchema\\Constraints\\TypeCheck\\LooseTypeCheck\:\:isObject\(\) has parameter \$value with no type specified\.$#'
+			identifier: missingType.parameter
 			count: 1
 			path: src/JsonSchema/Constraints/TypeCheck/LooseTypeCheck.php
 
 		-
-			message: "#^Method JsonSchema\\\\Constraints\\\\TypeCheck\\\\LooseTypeCheck\\:\\:propertyCount\\(\\) has no return type specified\\.$#"
+			message: '#^Method JsonSchema\\Constraints\\TypeCheck\\LooseTypeCheck\:\:propertyCount\(\) has no return type specified\.$#'
+			identifier: missingType.return
 			count: 1
 			path: src/JsonSchema/Constraints/TypeCheck/LooseTypeCheck.php
 
 		-
-			message: "#^Method JsonSchema\\\\Constraints\\\\TypeCheck\\\\LooseTypeCheck\\:\\:propertyCount\\(\\) has parameter \\$value with no type specified\\.$#"
+			message: '#^Method JsonSchema\\Constraints\\TypeCheck\\LooseTypeCheck\:\:propertyCount\(\) has parameter \$value with no type specified\.$#'
+			identifier: missingType.parameter
 			count: 1
 			path: src/JsonSchema/Constraints/TypeCheck/LooseTypeCheck.php
 
 		-
-			message: "#^Method JsonSchema\\\\Constraints\\\\TypeCheck\\\\LooseTypeCheck\\:\\:propertyExists\\(\\) has no return type specified\\.$#"
+			message: '#^Method JsonSchema\\Constraints\\TypeCheck\\LooseTypeCheck\:\:propertyExists\(\) has no return type specified\.$#'
+			identifier: missingType.return
 			count: 1
 			path: src/JsonSchema/Constraints/TypeCheck/LooseTypeCheck.php
 
 		-
-			message: "#^Method JsonSchema\\\\Constraints\\\\TypeCheck\\\\LooseTypeCheck\\:\\:propertyExists\\(\\) has parameter \\$property with no type specified\\.$#"
+			message: '#^Method JsonSchema\\Constraints\\TypeCheck\\LooseTypeCheck\:\:propertyExists\(\) has parameter \$property with no type specified\.$#'
+			identifier: missingType.parameter
 			count: 1
 			path: src/JsonSchema/Constraints/TypeCheck/LooseTypeCheck.php
 
 		-
-			message: "#^Method JsonSchema\\\\Constraints\\\\TypeCheck\\\\LooseTypeCheck\\:\\:propertyExists\\(\\) has parameter \\$value with no type specified\\.$#"
+			message: '#^Method JsonSchema\\Constraints\\TypeCheck\\LooseTypeCheck\:\:propertyExists\(\) has parameter \$value with no type specified\.$#'
+			identifier: missingType.parameter
 			count: 1
 			path: src/JsonSchema/Constraints/TypeCheck/LooseTypeCheck.php
 
 		-
-			message: "#^Method JsonSchema\\\\Constraints\\\\TypeCheck\\\\LooseTypeCheck\\:\\:propertyGet\\(\\) has no return type specified\\.$#"
+			message: '#^Method JsonSchema\\Constraints\\TypeCheck\\LooseTypeCheck\:\:propertyGet\(\) has no return type specified\.$#'
+			identifier: missingType.return
 			count: 1
 			path: src/JsonSchema/Constraints/TypeCheck/LooseTypeCheck.php
 
 		-
-			message: "#^Method JsonSchema\\\\Constraints\\\\TypeCheck\\\\LooseTypeCheck\\:\\:propertyGet\\(\\) has parameter \\$property with no type specified\\.$#"
+			message: '#^Method JsonSchema\\Constraints\\TypeCheck\\LooseTypeCheck\:\:propertyGet\(\) has parameter \$property with no type specified\.$#'
+			identifier: missingType.parameter
 			count: 1
 			path: src/JsonSchema/Constraints/TypeCheck/LooseTypeCheck.php
 
 		-
-			message: "#^Method JsonSchema\\\\Constraints\\\\TypeCheck\\\\LooseTypeCheck\\:\\:propertyGet\\(\\) has parameter \\$value with no type specified\\.$#"
+			message: '#^Method JsonSchema\\Constraints\\TypeCheck\\LooseTypeCheck\:\:propertyGet\(\) has parameter \$value with no type specified\.$#'
+			identifier: missingType.parameter
 			count: 1
 			path: src/JsonSchema/Constraints/TypeCheck/LooseTypeCheck.php
 
 		-
-			message: "#^Method JsonSchema\\\\Constraints\\\\TypeCheck\\\\LooseTypeCheck\\:\\:propertySet\\(\\) has no return type specified\\.$#"
+			message: '#^Method JsonSchema\\Constraints\\TypeCheck\\LooseTypeCheck\:\:propertySet\(\) has no return type specified\.$#'
+			identifier: missingType.return
 			count: 1
 			path: src/JsonSchema/Constraints/TypeCheck/LooseTypeCheck.php
 
 		-
-			message: "#^Method JsonSchema\\\\Constraints\\\\TypeCheck\\\\LooseTypeCheck\\:\\:propertySet\\(\\) has parameter \\$data with no type specified\\.$#"
+			message: '#^Method JsonSchema\\Constraints\\TypeCheck\\LooseTypeCheck\:\:propertySet\(\) has parameter \$data with no type specified\.$#'
+			identifier: missingType.parameter
 			count: 1
 			path: src/JsonSchema/Constraints/TypeCheck/LooseTypeCheck.php
 
 		-
-			message: "#^Method JsonSchema\\\\Constraints\\\\TypeCheck\\\\LooseTypeCheck\\:\\:propertySet\\(\\) has parameter \\$property with no type specified\\.$#"
+			message: '#^Method JsonSchema\\Constraints\\TypeCheck\\LooseTypeCheck\:\:propertySet\(\) has parameter \$property with no type specified\.$#'
+			identifier: missingType.parameter
 			count: 1
 			path: src/JsonSchema/Constraints/TypeCheck/LooseTypeCheck.php
 
 		-
-			message: "#^Method JsonSchema\\\\Constraints\\\\TypeCheck\\\\LooseTypeCheck\\:\\:propertySet\\(\\) has parameter \\$value with no type specified\\.$#"
+			message: '#^Method JsonSchema\\Constraints\\TypeCheck\\LooseTypeCheck\:\:propertySet\(\) has parameter \$value with no type specified\.$#'
+			identifier: missingType.parameter
 			count: 1
 			path: src/JsonSchema/Constraints/TypeCheck/LooseTypeCheck.php
 
 		-
-			message: "#^Method JsonSchema\\\\Constraints\\\\TypeCheck\\\\StrictTypeCheck\\:\\:isArray\\(\\) has no return type specified\\.$#"
+			message: '#^Parameter \#1 \$key of function array_key_exists expects int\|string, mixed given\.$#'
+			identifier: argument.type
+			count: 1
+			path: src/JsonSchema/Constraints/TypeCheck/LooseTypeCheck.php
+
+		-
+			message: '#^Parameter \#1 \$var of function count expects array\|Countable, mixed given\.$#'
+			identifier: argument.type
+			count: 1
+			path: src/JsonSchema/Constraints/TypeCheck/LooseTypeCheck.php
+
+		-
+			message: '#^Parameter \#2 \$property_name of function property_exists expects string, mixed given\.$#'
+			identifier: argument.type
+			count: 1
+			path: src/JsonSchema/Constraints/TypeCheck/LooseTypeCheck.php
+
+		-
+			message: '#^Parameter \#2 \$search of function array_key_exists expects array, mixed given\.$#'
+			identifier: argument.type
+			count: 1
+			path: src/JsonSchema/Constraints/TypeCheck/LooseTypeCheck.php
+
+		-
+			message: '#^Method JsonSchema\\Constraints\\TypeCheck\\StrictTypeCheck\:\:isArray\(\) has no return type specified\.$#'
+			identifier: missingType.return
 			count: 1
 			path: src/JsonSchema/Constraints/TypeCheck/StrictTypeCheck.php
 
 		-
-			message: "#^Method JsonSchema\\\\Constraints\\\\TypeCheck\\\\StrictTypeCheck\\:\\:isArray\\(\\) has parameter \\$value with no type specified\\.$#"
+			message: '#^Method JsonSchema\\Constraints\\TypeCheck\\StrictTypeCheck\:\:isArray\(\) has parameter \$value with no type specified\.$#'
+			identifier: missingType.parameter
 			count: 1
 			path: src/JsonSchema/Constraints/TypeCheck/StrictTypeCheck.php
 
 		-
-			message: "#^Method JsonSchema\\\\Constraints\\\\TypeCheck\\\\StrictTypeCheck\\:\\:isObject\\(\\) has no return type specified\\.$#"
+			message: '#^Method JsonSchema\\Constraints\\TypeCheck\\StrictTypeCheck\:\:isObject\(\) has no return type specified\.$#'
+			identifier: missingType.return
 			count: 1
 			path: src/JsonSchema/Constraints/TypeCheck/StrictTypeCheck.php
 
 		-
-			message: "#^Method JsonSchema\\\\Constraints\\\\TypeCheck\\\\StrictTypeCheck\\:\\:isObject\\(\\) has parameter \\$value with no type specified\\.$#"
+			message: '#^Method JsonSchema\\Constraints\\TypeCheck\\StrictTypeCheck\:\:isObject\(\) has parameter \$value with no type specified\.$#'
+			identifier: missingType.parameter
 			count: 1
 			path: src/JsonSchema/Constraints/TypeCheck/StrictTypeCheck.php
 
 		-
-			message: "#^Method JsonSchema\\\\Constraints\\\\TypeCheck\\\\StrictTypeCheck\\:\\:propertyCount\\(\\) has no return type specified\\.$#"
+			message: '#^Method JsonSchema\\Constraints\\TypeCheck\\StrictTypeCheck\:\:propertyCount\(\) has no return type specified\.$#'
+			identifier: missingType.return
 			count: 1
 			path: src/JsonSchema/Constraints/TypeCheck/StrictTypeCheck.php
 
 		-
-			message: "#^Method JsonSchema\\\\Constraints\\\\TypeCheck\\\\StrictTypeCheck\\:\\:propertyCount\\(\\) has parameter \\$value with no type specified\\.$#"
+			message: '#^Method JsonSchema\\Constraints\\TypeCheck\\StrictTypeCheck\:\:propertyCount\(\) has parameter \$value with no type specified\.$#'
+			identifier: missingType.parameter
 			count: 1
 			path: src/JsonSchema/Constraints/TypeCheck/StrictTypeCheck.php
 
 		-
-			message: "#^Method JsonSchema\\\\Constraints\\\\TypeCheck\\\\StrictTypeCheck\\:\\:propertyExists\\(\\) has no return type specified\\.$#"
+			message: '#^Method JsonSchema\\Constraints\\TypeCheck\\StrictTypeCheck\:\:propertyExists\(\) has no return type specified\.$#'
+			identifier: missingType.return
 			count: 1
 			path: src/JsonSchema/Constraints/TypeCheck/StrictTypeCheck.php
 
 		-
-			message: "#^Method JsonSchema\\\\Constraints\\\\TypeCheck\\\\StrictTypeCheck\\:\\:propertyExists\\(\\) has parameter \\$property with no type specified\\.$#"
+			message: '#^Method JsonSchema\\Constraints\\TypeCheck\\StrictTypeCheck\:\:propertyExists\(\) has parameter \$property with no type specified\.$#'
+			identifier: missingType.parameter
 			count: 1
 			path: src/JsonSchema/Constraints/TypeCheck/StrictTypeCheck.php
 
 		-
-			message: "#^Method JsonSchema\\\\Constraints\\\\TypeCheck\\\\StrictTypeCheck\\:\\:propertyExists\\(\\) has parameter \\$value with no type specified\\.$#"
+			message: '#^Method JsonSchema\\Constraints\\TypeCheck\\StrictTypeCheck\:\:propertyExists\(\) has parameter \$value with no type specified\.$#'
+			identifier: missingType.parameter
 			count: 1
 			path: src/JsonSchema/Constraints/TypeCheck/StrictTypeCheck.php
 
 		-
-			message: "#^Method JsonSchema\\\\Constraints\\\\TypeCheck\\\\StrictTypeCheck\\:\\:propertyGet\\(\\) has no return type specified\\.$#"
+			message: '#^Method JsonSchema\\Constraints\\TypeCheck\\StrictTypeCheck\:\:propertyGet\(\) has no return type specified\.$#'
+			identifier: missingType.return
 			count: 1
 			path: src/JsonSchema/Constraints/TypeCheck/StrictTypeCheck.php
 
 		-
-			message: "#^Method JsonSchema\\\\Constraints\\\\TypeCheck\\\\StrictTypeCheck\\:\\:propertyGet\\(\\) has parameter \\$property with no type specified\\.$#"
+			message: '#^Method JsonSchema\\Constraints\\TypeCheck\\StrictTypeCheck\:\:propertyGet\(\) has parameter \$property with no type specified\.$#'
+			identifier: missingType.parameter
 			count: 1
 			path: src/JsonSchema/Constraints/TypeCheck/StrictTypeCheck.php
 
 		-
-			message: "#^Method JsonSchema\\\\Constraints\\\\TypeCheck\\\\StrictTypeCheck\\:\\:propertyGet\\(\\) has parameter \\$value with no type specified\\.$#"
+			message: '#^Method JsonSchema\\Constraints\\TypeCheck\\StrictTypeCheck\:\:propertyGet\(\) has parameter \$value with no type specified\.$#'
+			identifier: missingType.parameter
 			count: 1
 			path: src/JsonSchema/Constraints/TypeCheck/StrictTypeCheck.php
 
 		-
-			message: "#^Method JsonSchema\\\\Constraints\\\\TypeCheck\\\\StrictTypeCheck\\:\\:propertySet\\(\\) has no return type specified\\.$#"
+			message: '#^Method JsonSchema\\Constraints\\TypeCheck\\StrictTypeCheck\:\:propertySet\(\) has no return type specified\.$#'
+			identifier: missingType.return
 			count: 1
 			path: src/JsonSchema/Constraints/TypeCheck/StrictTypeCheck.php
 
 		-
-			message: "#^Method JsonSchema\\\\Constraints\\\\TypeCheck\\\\StrictTypeCheck\\:\\:propertySet\\(\\) has parameter \\$data with no type specified\\.$#"
+			message: '#^Method JsonSchema\\Constraints\\TypeCheck\\StrictTypeCheck\:\:propertySet\(\) has parameter \$data with no type specified\.$#'
+			identifier: missingType.parameter
 			count: 1
 			path: src/JsonSchema/Constraints/TypeCheck/StrictTypeCheck.php
 
 		-
-			message: "#^Method JsonSchema\\\\Constraints\\\\TypeCheck\\\\StrictTypeCheck\\:\\:propertySet\\(\\) has parameter \\$property with no type specified\\.$#"
+			message: '#^Method JsonSchema\\Constraints\\TypeCheck\\StrictTypeCheck\:\:propertySet\(\) has parameter \$property with no type specified\.$#'
+			identifier: missingType.parameter
 			count: 1
 			path: src/JsonSchema/Constraints/TypeCheck/StrictTypeCheck.php
 
 		-
-			message: "#^Method JsonSchema\\\\Constraints\\\\TypeCheck\\\\StrictTypeCheck\\:\\:propertySet\\(\\) has parameter \\$value with no type specified\\.$#"
+			message: '#^Method JsonSchema\\Constraints\\TypeCheck\\StrictTypeCheck\:\:propertySet\(\) has parameter \$value with no type specified\.$#'
+			identifier: missingType.parameter
 			count: 1
 			path: src/JsonSchema/Constraints/TypeCheck/StrictTypeCheck.php
 
 		-
-			message: "#^Method JsonSchema\\\\Constraints\\\\TypeCheck\\\\TypeCheckInterface\\:\\:isArray\\(\\) has no return type specified\\.$#"
+			message: '#^Parameter \#1 \$object_or_class of function property_exists expects object\|string, mixed given\.$#'
+			identifier: argument.type
+			count: 1
+			path: src/JsonSchema/Constraints/TypeCheck/StrictTypeCheck.php
+
+		-
+			message: '#^Parameter \#2 \$property_name of function property_exists expects string, mixed given\.$#'
+			identifier: argument.type
+			count: 1
+			path: src/JsonSchema/Constraints/TypeCheck/StrictTypeCheck.php
+
+		-
+			message: '#^Method JsonSchema\\Constraints\\TypeCheck\\TypeCheckInterface\:\:isArray\(\) has no return type specified\.$#'
+			identifier: missingType.return
 			count: 1
 			path: src/JsonSchema/Constraints/TypeCheck/TypeCheckInterface.php
 
 		-
-			message: "#^Method JsonSchema\\\\Constraints\\\\TypeCheck\\\\TypeCheckInterface\\:\\:isArray\\(\\) has parameter \\$value with no type specified\\.$#"
+			message: '#^Method JsonSchema\\Constraints\\TypeCheck\\TypeCheckInterface\:\:isArray\(\) has parameter \$value with no type specified\.$#'
+			identifier: missingType.parameter
 			count: 1
 			path: src/JsonSchema/Constraints/TypeCheck/TypeCheckInterface.php
 
 		-
-			message: "#^Method JsonSchema\\\\Constraints\\\\TypeCheck\\\\TypeCheckInterface\\:\\:isObject\\(\\) has no return type specified\\.$#"
+			message: '#^Method JsonSchema\\Constraints\\TypeCheck\\TypeCheckInterface\:\:isObject\(\) has no return type specified\.$#'
+			identifier: missingType.return
 			count: 1
 			path: src/JsonSchema/Constraints/TypeCheck/TypeCheckInterface.php
 
 		-
-			message: "#^Method JsonSchema\\\\Constraints\\\\TypeCheck\\\\TypeCheckInterface\\:\\:isObject\\(\\) has parameter \\$value with no type specified\\.$#"
+			message: '#^Method JsonSchema\\Constraints\\TypeCheck\\TypeCheckInterface\:\:isObject\(\) has parameter \$value with no type specified\.$#'
+			identifier: missingType.parameter
 			count: 1
 			path: src/JsonSchema/Constraints/TypeCheck/TypeCheckInterface.php
 
 		-
-			message: "#^Method JsonSchema\\\\Constraints\\\\TypeCheck\\\\TypeCheckInterface\\:\\:propertyCount\\(\\) has no return type specified\\.$#"
+			message: '#^Method JsonSchema\\Constraints\\TypeCheck\\TypeCheckInterface\:\:propertyCount\(\) has no return type specified\.$#'
+			identifier: missingType.return
 			count: 1
 			path: src/JsonSchema/Constraints/TypeCheck/TypeCheckInterface.php
 
 		-
-			message: "#^Method JsonSchema\\\\Constraints\\\\TypeCheck\\\\TypeCheckInterface\\:\\:propertyCount\\(\\) has parameter \\$value with no type specified\\.$#"
+			message: '#^Method JsonSchema\\Constraints\\TypeCheck\\TypeCheckInterface\:\:propertyCount\(\) has parameter \$value with no type specified\.$#'
+			identifier: missingType.parameter
 			count: 1
 			path: src/JsonSchema/Constraints/TypeCheck/TypeCheckInterface.php
 
 		-
-			message: "#^Method JsonSchema\\\\Constraints\\\\TypeCheck\\\\TypeCheckInterface\\:\\:propertyExists\\(\\) has no return type specified\\.$#"
+			message: '#^Method JsonSchema\\Constraints\\TypeCheck\\TypeCheckInterface\:\:propertyExists\(\) has no return type specified\.$#'
+			identifier: missingType.return
 			count: 1
 			path: src/JsonSchema/Constraints/TypeCheck/TypeCheckInterface.php
 
 		-
-			message: "#^Method JsonSchema\\\\Constraints\\\\TypeCheck\\\\TypeCheckInterface\\:\\:propertyExists\\(\\) has parameter \\$property with no type specified\\.$#"
+			message: '#^Method JsonSchema\\Constraints\\TypeCheck\\TypeCheckInterface\:\:propertyExists\(\) has parameter \$property with no type specified\.$#'
+			identifier: missingType.parameter
 			count: 1
 			path: src/JsonSchema/Constraints/TypeCheck/TypeCheckInterface.php
 
 		-
-			message: "#^Method JsonSchema\\\\Constraints\\\\TypeCheck\\\\TypeCheckInterface\\:\\:propertyExists\\(\\) has parameter \\$value with no type specified\\.$#"
+			message: '#^Method JsonSchema\\Constraints\\TypeCheck\\TypeCheckInterface\:\:propertyExists\(\) has parameter \$value with no type specified\.$#'
+			identifier: missingType.parameter
 			count: 1
 			path: src/JsonSchema/Constraints/TypeCheck/TypeCheckInterface.php
 
 		-
-			message: "#^Method JsonSchema\\\\Constraints\\\\TypeCheck\\\\TypeCheckInterface\\:\\:propertyGet\\(\\) has no return type specified\\.$#"
+			message: '#^Method JsonSchema\\Constraints\\TypeCheck\\TypeCheckInterface\:\:propertyGet\(\) has no return type specified\.$#'
+			identifier: missingType.return
 			count: 1
 			path: src/JsonSchema/Constraints/TypeCheck/TypeCheckInterface.php
 
 		-
-			message: "#^Method JsonSchema\\\\Constraints\\\\TypeCheck\\\\TypeCheckInterface\\:\\:propertyGet\\(\\) has parameter \\$property with no type specified\\.$#"
+			message: '#^Method JsonSchema\\Constraints\\TypeCheck\\TypeCheckInterface\:\:propertyGet\(\) has parameter \$property with no type specified\.$#'
+			identifier: missingType.parameter
 			count: 1
 			path: src/JsonSchema/Constraints/TypeCheck/TypeCheckInterface.php
 
 		-
-			message: "#^Method JsonSchema\\\\Constraints\\\\TypeCheck\\\\TypeCheckInterface\\:\\:propertyGet\\(\\) has parameter \\$value with no type specified\\.$#"
+			message: '#^Method JsonSchema\\Constraints\\TypeCheck\\TypeCheckInterface\:\:propertyGet\(\) has parameter \$value with no type specified\.$#'
+			identifier: missingType.parameter
 			count: 1
 			path: src/JsonSchema/Constraints/TypeCheck/TypeCheckInterface.php
 
 		-
-			message: "#^Method JsonSchema\\\\Constraints\\\\TypeCheck\\\\TypeCheckInterface\\:\\:propertySet\\(\\) has no return type specified\\.$#"
+			message: '#^Method JsonSchema\\Constraints\\TypeCheck\\TypeCheckInterface\:\:propertySet\(\) has no return type specified\.$#'
+			identifier: missingType.return
 			count: 1
 			path: src/JsonSchema/Constraints/TypeCheck/TypeCheckInterface.php
 
 		-
-			message: "#^Method JsonSchema\\\\Constraints\\\\TypeCheck\\\\TypeCheckInterface\\:\\:propertySet\\(\\) has parameter \\$data with no type specified\\.$#"
+			message: '#^Method JsonSchema\\Constraints\\TypeCheck\\TypeCheckInterface\:\:propertySet\(\) has parameter \$data with no type specified\.$#'
+			identifier: missingType.parameter
 			count: 1
 			path: src/JsonSchema/Constraints/TypeCheck/TypeCheckInterface.php
 
 		-
-			message: "#^Method JsonSchema\\\\Constraints\\\\TypeCheck\\\\TypeCheckInterface\\:\\:propertySet\\(\\) has parameter \\$property with no type specified\\.$#"
+			message: '#^Method JsonSchema\\Constraints\\TypeCheck\\TypeCheckInterface\:\:propertySet\(\) has parameter \$property with no type specified\.$#'
+			identifier: missingType.parameter
 			count: 1
 			path: src/JsonSchema/Constraints/TypeCheck/TypeCheckInterface.php
 
 		-
-			message: "#^Method JsonSchema\\\\Constraints\\\\TypeCheck\\\\TypeCheckInterface\\:\\:propertySet\\(\\) has parameter \\$value with no type specified\\.$#"
+			message: '#^Method JsonSchema\\Constraints\\TypeCheck\\TypeCheckInterface\:\:propertySet\(\) has parameter \$value with no type specified\.$#'
+			identifier: missingType.parameter
 			count: 1
 			path: src/JsonSchema/Constraints/TypeCheck/TypeCheckInterface.php
 
 		-
-			message: "#^Method JsonSchema\\\\Constraints\\\\TypeConstraint\\:\\:implodeWith\\(\\) has parameter \\$elements with no value type specified in iterable type array\\.$#"
+			message: '#^Binary operation "\." between mixed and '' is an invalid type…'' results in an error\.$#'
+			identifier: binaryOp.invalid
 			count: 1
 			path: src/JsonSchema/Constraints/TypeConstraint.php
 
 		-
-			message: "#^Method JsonSchema\\\\Constraints\\\\TypeConstraint\\:\\:validateType\\(\\) has parameter \\$coerce with no type specified\\.$#"
+			message: '#^Cannot access property \$type on mixed\.$#'
+			identifier: property.nonObject
 			count: 1
 			path: src/JsonSchema/Constraints/TypeConstraint.php
 
 		-
-			message: "#^Method JsonSchema\\\\Constraints\\\\TypeConstraint\\:\\:validateTypeNameWording\\(\\) has no return type specified\\.$#"
+			message: '#^Method JsonSchema\\Constraints\\TypeConstraint\:\:implodeWith\(\) has parameter \$elements with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/JsonSchema/Constraints/TypeConstraint.php
 
 		-
-			message: "#^Method JsonSchema\\\\Constraints\\\\TypeConstraint\\:\\:validateTypesArray\\(\\) has no return type specified\\.$#"
+			message: '#^Method JsonSchema\\Constraints\\TypeConstraint\:\:validateType\(\) has parameter \$coerce with no type specified\.$#'
+			identifier: missingType.parameter
 			count: 1
 			path: src/JsonSchema/Constraints/TypeConstraint.php
 
 		-
-			message: "#^Method JsonSchema\\\\Constraints\\\\TypeConstraint\\:\\:validateTypesArray\\(\\) has parameter \\$type with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/JsonSchema/Constraints/TypeConstraint.php
-
-		-
-			message: "#^Method JsonSchema\\\\Constraints\\\\TypeConstraint\\:\\:validateTypesArray\\(\\) has parameter \\$validTypesWording with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/JsonSchema/Constraints/TypeConstraint.php
-
-		-
-			message: "#^Negated boolean expression is always true\\.$#"
+			message: '#^Method JsonSchema\\Constraints\\TypeConstraint\:\:validateType\(\) should return bool but returns mixed\.$#'
+			identifier: return.type
 			count: 2
 			path: src/JsonSchema/Constraints/TypeConstraint.php
 
 		-
-			message: "#^Parameter \\#3 \\$listEnd of method JsonSchema\\\\Constraints\\\\TypeConstraint\\:\\:implodeWith\\(\\) expects bool, string given\\.$#"
+			message: '#^Method JsonSchema\\Constraints\\TypeConstraint\:\:validateTypeNameWording\(\) has no return type specified\.$#'
+			identifier: missingType.return
 			count: 1
 			path: src/JsonSchema/Constraints/TypeConstraint.php
 
 		-
-			message: "#^Static property JsonSchema\\\\Constraints\\\\TypeConstraint\\:\\:\\$wording \\(array\\<string\\>\\) does not accept default value of type array\\<int\\|string, string\\|null\\>\\.$#"
+			message: '#^Method JsonSchema\\Constraints\\TypeConstraint\:\:validateTypesArray\(\) has no return type specified\.$#'
+			identifier: missingType.return
 			count: 1
 			path: src/JsonSchema/Constraints/TypeConstraint.php
 
 		-
-			message: "#^Method JsonSchema\\\\Constraints\\\\UndefinedConstraint\\:\\:check\\(\\) has parameter \\$fromDefault with no type specified\\.$#"
+			message: '#^Method JsonSchema\\Constraints\\TypeConstraint\:\:validateTypesArray\(\) has parameter \$type with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: src/JsonSchema/Constraints/TypeConstraint.php
+
+		-
+			message: '#^Method JsonSchema\\Constraints\\TypeConstraint\:\:validateTypesArray\(\) has parameter \$validTypesWording with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: src/JsonSchema/Constraints/TypeConstraint.php
+
+		-
+			message: '#^Negated boolean expression is always true\.$#'
+			identifier: booleanNot.alwaysTrue
+			count: 2
+			path: src/JsonSchema/Constraints/TypeConstraint.php
+
+		-
+			message: '#^Parameter \#1 \$array of function reset expects array\|object, mixed given\.$#'
+			identifier: argument.type
+			count: 4
+			path: src/JsonSchema/Constraints/TypeConstraint.php
+
+		-
+			message: '#^Parameter \#1 \$type of method JsonSchema\\Constraints\\TypeConstraint\:\:validateTypeNameWording\(\) expects string, mixed given\.$#'
+			identifier: argument.type
+			count: 2
+			path: src/JsonSchema/Constraints/TypeConstraint.php
+
+		-
+			message: '#^Parameter \#1 \$var of function count expects array\|Countable, mixed given\.$#'
+			identifier: argument.type
+			count: 4
+			path: src/JsonSchema/Constraints/TypeConstraint.php
+
+		-
+			message: '#^Parameter \#2 \$type of method JsonSchema\\Constraints\\TypeConstraint\:\:validateType\(\) expects string, mixed given\.$#'
+			identifier: argument.type
+			count: 3
+			path: src/JsonSchema/Constraints/TypeConstraint.php
+
+		-
+			message: '#^Parameter \#3 \$listEnd of method JsonSchema\\Constraints\\TypeConstraint\:\:implodeWith\(\) expects bool, string given\.$#'
+			identifier: argument.type
+			count: 1
+			path: src/JsonSchema/Constraints/TypeConstraint.php
+
+		-
+			message: '#^Static property JsonSchema\\Constraints\\TypeConstraint\:\:\$wording \(array\<string\>\) does not accept default value of type array\<int\|string, string\|null\>\.$#'
+			identifier: property.defaultValue
+			count: 1
+			path: src/JsonSchema/Constraints/TypeConstraint.php
+
+		-
+			message: '#^Argument of an invalid type mixed supplied for foreach, only iterables are supported\.$#'
+			identifier: foreach.nonIterable
+			count: 6
+			path: src/JsonSchema/Constraints/UndefinedConstraint.php
+
+		-
+			message: '#^Binary operation "\-" between mixed and int\<0, max\> results in an error\.$#'
+			identifier: binaryOp.invalid
 			count: 1
 			path: src/JsonSchema/Constraints/UndefinedConstraint.php
 
 		-
-			message: "#^Method JsonSchema\\\\Constraints\\\\UndefinedConstraint\\:\\:shouldApplyDefaultValue\\(\\) has parameter \\$name with no type specified\\.$#"
+			message: '#^Cannot access offset mixed on mixed\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 2
+			path: src/JsonSchema/Constraints/UndefinedConstraint.php
+
+		-
+			message: '#^Cannot access property \$additionalProperties on mixed\.$#'
+			identifier: property.nonObject
 			count: 1
 			path: src/JsonSchema/Constraints/UndefinedConstraint.php
 
 		-
-			message: "#^Method JsonSchema\\\\Constraints\\\\UndefinedConstraint\\:\\:validateCommonProperties\\(\\) has no return type specified\\.$#"
+			message: '#^Cannot access property \$allOf on mixed\.$#'
+			identifier: property.nonObject
 			count: 1
 			path: src/JsonSchema/Constraints/UndefinedConstraint.php
 
 		-
-			message: "#^Method JsonSchema\\\\Constraints\\\\UndefinedConstraint\\:\\:validateDependencies\\(\\) has no return type specified\\.$#"
+			message: '#^Cannot access property \$anyOf on mixed\.$#'
+			identifier: property.nonObject
 			count: 1
 			path: src/JsonSchema/Constraints/UndefinedConstraint.php
 
 		-
-			message: "#^Method JsonSchema\\\\Constraints\\\\UndefinedConstraint\\:\\:validateOfProperties\\(\\) has no return type specified\\.$#"
+			message: '#^Cannot access property \$const on mixed\.$#'
+			identifier: property.nonObject
 			count: 1
 			path: src/JsonSchema/Constraints/UndefinedConstraint.php
 
 		-
-			message: "#^Method JsonSchema\\\\Constraints\\\\UndefinedConstraint\\:\\:validateTypes\\(\\) has no return type specified\\.$#"
+			message: '#^Cannot access property \$default on mixed\.$#'
+			identifier: property.nonObject
+			count: 3
+			path: src/JsonSchema/Constraints/UndefinedConstraint.php
+
+		-
+			message: '#^Cannot access property \$dependencies on mixed\.$#'
+			identifier: property.nonObject
 			count: 1
 			path: src/JsonSchema/Constraints/UndefinedConstraint.php
 
 		-
-			message: "#^Method JsonSchema\\\\Constraints\\\\UndefinedConstraint\\:\\:validateUri\\(\\) has no return type specified\\.$#"
+			message: '#^Cannot access property \$disallow on mixed\.$#'
+			identifier: property.nonObject
 			count: 1
 			path: src/JsonSchema/Constraints/UndefinedConstraint.php
 
 		-
-			message: "#^Method JsonSchema\\\\Constraints\\\\UndefinedConstraint\\:\\:validateUri\\(\\) has parameter \\$schema with no type specified\\.$#"
+			message: '#^Cannot access property \$enum on mixed\.$#'
+			identifier: property.nonObject
 			count: 1
 			path: src/JsonSchema/Constraints/UndefinedConstraint.php
 
 		-
-			message: "#^Method JsonSchema\\\\Constraints\\\\UndefinedConstraint\\:\\:validateUri\\(\\) has parameter \\$schemaUri with no type specified\\.$#"
+			message: '#^Cannot access property \$extends on mixed\.$#'
+			identifier: property.nonObject
 			count: 1
 			path: src/JsonSchema/Constraints/UndefinedConstraint.php
 
 		-
-			message: "#^Property JsonSchema\\\\Constraints\\\\UndefinedConstraint\\:\\:\\$appliedDefaults type has no value type specified in iterable type array\\.$#"
+			message: '#^Cannot access property \$id on mixed\.$#'
+			identifier: property.nonObject
 			count: 1
 			path: src/JsonSchema/Constraints/UndefinedConstraint.php
 
 		-
-			message: "#^Method JsonSchema\\\\Entity\\\\JsonPointer\\:\\:encodePropertyPaths\\(\\) return type has no value type specified in iterable type array\\.$#"
+			message: '#^Cannot access property \$items on mixed\.$#'
+			identifier: property.nonObject
+			count: 1
+			path: src/JsonSchema/Constraints/UndefinedConstraint.php
+
+		-
+			message: '#^Cannot access property \$not on mixed\.$#'
+			identifier: property.nonObject
+			count: 1
+			path: src/JsonSchema/Constraints/UndefinedConstraint.php
+
+		-
+			message: '#^Cannot access property \$oneOf on mixed\.$#'
+			identifier: property.nonObject
+			count: 1
+			path: src/JsonSchema/Constraints/UndefinedConstraint.php
+
+		-
+			message: '#^Cannot access property \$patternProperties on mixed\.$#'
+			identifier: property.nonObject
+			count: 1
+			path: src/JsonSchema/Constraints/UndefinedConstraint.php
+
+		-
+			message: '#^Cannot access property \$properties on mixed\.$#'
+			identifier: property.nonObject
+			count: 2
+			path: src/JsonSchema/Constraints/UndefinedConstraint.php
+
+		-
+			message: '#^Cannot access property \$required on mixed\.$#'
+			identifier: property.nonObject
+			count: 4
+			path: src/JsonSchema/Constraints/UndefinedConstraint.php
+
+		-
+			message: '#^Method JsonSchema\\Constraints\\UndefinedConstraint\:\:check\(\) has parameter \$fromDefault with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: src/JsonSchema/Constraints/UndefinedConstraint.php
+
+		-
+			message: '#^Method JsonSchema\\Constraints\\UndefinedConstraint\:\:shouldApplyDefaultValue\(\) has parameter \$name with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: src/JsonSchema/Constraints/UndefinedConstraint.php
+
+		-
+			message: '#^Method JsonSchema\\Constraints\\UndefinedConstraint\:\:validateCommonProperties\(\) has no return type specified\.$#'
+			identifier: missingType.return
+			count: 1
+			path: src/JsonSchema/Constraints/UndefinedConstraint.php
+
+		-
+			message: '#^Method JsonSchema\\Constraints\\UndefinedConstraint\:\:validateDependencies\(\) has no return type specified\.$#'
+			identifier: missingType.return
+			count: 1
+			path: src/JsonSchema/Constraints/UndefinedConstraint.php
+
+		-
+			message: '#^Method JsonSchema\\Constraints\\UndefinedConstraint\:\:validateOfProperties\(\) has no return type specified\.$#'
+			identifier: missingType.return
+			count: 1
+			path: src/JsonSchema/Constraints/UndefinedConstraint.php
+
+		-
+			message: '#^Method JsonSchema\\Constraints\\UndefinedConstraint\:\:validateTypes\(\) has no return type specified\.$#'
+			identifier: missingType.return
+			count: 1
+			path: src/JsonSchema/Constraints/UndefinedConstraint.php
+
+		-
+			message: '#^Method JsonSchema\\Constraints\\UndefinedConstraint\:\:validateUri\(\) has no return type specified\.$#'
+			identifier: missingType.return
+			count: 1
+			path: src/JsonSchema/Constraints/UndefinedConstraint.php
+
+		-
+			message: '#^Method JsonSchema\\Constraints\\UndefinedConstraint\:\:validateUri\(\) has parameter \$schema with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: src/JsonSchema/Constraints/UndefinedConstraint.php
+
+		-
+			message: '#^Method JsonSchema\\Constraints\\UndefinedConstraint\:\:validateUri\(\) has parameter \$schemaUri with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: src/JsonSchema/Constraints/UndefinedConstraint.php
+
+		-
+			message: '#^Parameter \#1 \$key of function array_key_exists expects int\|string, mixed given\.$#'
+			identifier: argument.type
+			count: 1
+			path: src/JsonSchema/Constraints/UndefinedConstraint.php
+
+		-
+			message: '#^Parameter \#1 \$object_or_class of function property_exists expects object\|string, mixed given\.$#'
+			identifier: argument.type
+			count: 2
+			path: src/JsonSchema/Constraints/UndefinedConstraint.php
+
+		-
+			message: '#^Parameter \#1 \$uri of method JsonSchema\\UriRetrieverInterface\:\:retrieve\(\) expects string, mixed given\.$#'
+			identifier: argument.type
+			count: 1
+			path: src/JsonSchema/Constraints/UndefinedConstraint.php
+
+		-
+			message: '#^Parameter \#1 \$uri of method JsonSchema\\Uri\\UriResolver\:\:isValid\(\) expects string, mixed given\.$#'
+			identifier: argument.type
+			count: 1
+			path: src/JsonSchema/Constraints/UndefinedConstraint.php
+
+		-
+			message: '#^Parameter \#1 \$var of function count expects array\|Countable, mixed given\.$#'
+			identifier: argument.type
+			count: 3
+			path: src/JsonSchema/Constraints/UndefinedConstraint.php
+
+		-
+			message: '#^Parameter \#2 \$baseUri of method JsonSchema\\UriRetrieverInterface\:\:retrieve\(\) expects string\|null, mixed given\.$#'
+			identifier: argument.type
+			count: 1
+			path: src/JsonSchema/Constraints/UndefinedConstraint.php
+
+		-
+			message: '#^Parameter \#2 \$search of function array_key_exists expects array, mixed given\.$#'
+			identifier: argument.type
+			count: 1
+			path: src/JsonSchema/Constraints/UndefinedConstraint.php
+
+		-
+			message: '#^Parameter \#4 \$i of method JsonSchema\\Constraints\\UndefinedConstraint\:\:validateCommonProperties\(\) expects string, mixed given\.$#'
+			identifier: argument.type
+			count: 1
+			path: src/JsonSchema/Constraints/UndefinedConstraint.php
+
+		-
+			message: '#^Parameter \#4 \$i of method JsonSchema\\Constraints\\UndefinedConstraint\:\:validateTypes\(\) expects string\|null, mixed given\.$#'
+			identifier: argument.type
+			count: 1
+			path: src/JsonSchema/Constraints/UndefinedConstraint.php
+
+		-
+			message: '#^Property JsonSchema\\Constraints\\UndefinedConstraint\:\:\$appliedDefaults type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: src/JsonSchema/Constraints/UndefinedConstraint.php
+
+		-
+			message: '#^Call to function is_string\(\) with string will always evaluate to true\.$#'
+			identifier: function.alreadyNarrowedType
+			count: 2
+			path: src/JsonSchema/Entity/JsonPointer.php
+
+		-
+			message: '#^Cannot cast mixed to string\.$#'
+			identifier: cast.string
 			count: 1
 			path: src/JsonSchema/Entity/JsonPointer.php
 
 		-
-			message: "#^Method JsonSchema\\\\Entity\\\\JsonPointer\\:\\:setFromDefault\\(\\) has no return type specified\\.$#"
+			message: '#^Method JsonSchema\\Entity\\JsonPointer\:\:encodePropertyPaths\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/JsonSchema/Entity/JsonPointer.php
 
 		-
-			message: "#^Method JsonSchema\\\\Entity\\\\JsonPointer\\:\\:withPropertyPaths\\(\\) has parameter \\$propertyPaths with no value type specified in iterable type array\\.$#"
+			message: '#^Method JsonSchema\\Entity\\JsonPointer\:\:setFromDefault\(\) has no return type specified\.$#'
+			identifier: missingType.return
 			count: 1
 			path: src/JsonSchema/Entity/JsonPointer.php
 
 		-
-			message: "#^Method JsonSchema\\\\Exception\\\\JsonDecodingException\\:\\:__construct\\(\\) has parameter \\$code with no type specified\\.$#"
+			message: '#^Method JsonSchema\\Entity\\JsonPointer\:\:withPropertyPaths\(\) has parameter \$propertyPaths with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: src/JsonSchema/Entity/JsonPointer.php
+
+		-
+			message: '#^Method JsonSchema\\Exception\\JsonDecodingException\:\:__construct\(\) has parameter \$code with no type specified\.$#'
+			identifier: missingType.parameter
 			count: 1
 			path: src/JsonSchema/Exception/JsonDecodingException.php
 
 		-
-			message: "#^Class JsonSchema\\\\Iterator\\\\ObjectIterator implements generic interface Iterator but does not specify its types\\: TKey, TValue$#"
+			message: '#^Parameter \#2 \$code of method Exception\:\:__construct\(\) expects int, mixed given\.$#'
+			identifier: argument.type
+			count: 1
+			path: src/JsonSchema/Exception/JsonDecodingException.php
+
+		-
+			message: '#^Call to function is_array\(\) with array will always evaluate to true\.$#'
+			identifier: function.alreadyNarrowedType
 			count: 1
 			path: src/JsonSchema/Iterator/ObjectIterator.php
 
 		-
-			message: "#^Method JsonSchema\\\\Iterator\\\\ObjectIterator\\:\\:buildDataFromObject\\(\\) return type has no value type specified in iterable type array\\.$#"
+			message: '#^Class JsonSchema\\Iterator\\ObjectIterator implements generic interface Iterator but does not specify its types\: TKey, TValue$#'
+			identifier: missingType.generics
 			count: 1
 			path: src/JsonSchema/Iterator/ObjectIterator.php
 
 		-
-			message: "#^Method JsonSchema\\\\Iterator\\\\ObjectIterator\\:\\:getDataFromItem\\(\\) has parameter \\$item with no value type specified in iterable type array\\.$#"
+			message: '#^Method JsonSchema\\Iterator\\ObjectIterator\:\:buildDataFromObject\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/JsonSchema/Iterator/ObjectIterator.php
 
 		-
-			message: "#^Method JsonSchema\\\\Iterator\\\\ObjectIterator\\:\\:getDataFromItem\\(\\) return type has no value type specified in iterable type array\\.$#"
+			message: '#^Method JsonSchema\\Iterator\\ObjectIterator\:\:getDataFromItem\(\) has parameter \$item with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/JsonSchema/Iterator/ObjectIterator.php
 
 		-
-			message: "#^Method JsonSchema\\\\Iterator\\\\ObjectIterator\\:\\:initialize\\(\\) has no return type specified\\.$#"
+			message: '#^Method JsonSchema\\Iterator\\ObjectIterator\:\:getDataFromItem\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/JsonSchema/Iterator/ObjectIterator.php
 
 		-
-			message: "#^Property JsonSchema\\\\Iterator\\\\ObjectIterator\\:\\:\\$data type has no value type specified in iterable type array\\.$#"
+			message: '#^Method JsonSchema\\Iterator\\ObjectIterator\:\:initialize\(\) has no return type specified\.$#'
+			identifier: missingType.return
 			count: 1
 			path: src/JsonSchema/Iterator/ObjectIterator.php
 
 		-
-			message: "#^Result of && is always false\\.$#"
+			message: '#^Parameter \#1 \$item of method JsonSchema\\Iterator\\ObjectIterator\:\:getDataFromItem\(\) expects array\|object, mixed given\.$#'
+			identifier: argument.type
 			count: 1
 			path: src/JsonSchema/Iterator/ObjectIterator.php
 
 		-
-			message: "#^Offset 4 does not exist on array\\{0\\: string, 1\\: non\\-falsy\\-string, 2\\: string, 3\\: non\\-falsy\\-string, 4\\?\\: string, 5\\?\\: non\\-falsy\\-string&numeric\\-string\\}\\.$#"
+			message: '#^Property JsonSchema\\Iterator\\ObjectIterator\:\:\$data type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: src/JsonSchema/Iterator/ObjectIterator.php
+
+		-
+			message: '#^Result of && is always false\.$#'
+			identifier: booleanAnd.alwaysFalse
+			count: 1
+			path: src/JsonSchema/Iterator/ObjectIterator.php
+
+		-
+			message: '#^Offset 4 might not exist on array\{0\: string, 1\: non\-falsy\-string, 2\: string, 3\: non\-falsy\-string, 4\?\: string, 5\?\: non\-falsy\-string&numeric\-string\}\.$#'
+			identifier: offsetAccess.notFound
 			count: 1
 			path: src/JsonSchema/Rfc3339.php
 
 		-
-			message: "#^Offset 5 does not exist on array\\{0\\: string, 1\\: non\\-falsy\\-string, 2\\: string, 3\\: non\\-falsy\\-string, 4\\?\\: string, 5\\?\\: non\\-falsy\\-string&numeric\\-string\\}\\.$#"
+			message: '#^Offset 5 might not exist on array\{0\: string, 1\: non\-falsy\-string, 2\: string, 3\: non\-falsy\-string, 4\?\: string, 5\?\: non\-falsy\-string&numeric\-string\}\.$#'
+			identifier: offsetAccess.notFound
 			count: 1
 			path: src/JsonSchema/Rfc3339.php
 
 		-
-			message: "#^Access to an undefined property object\\:\\:\\$properties\\.$#"
+			message: '#^Access to an undefined property object\:\:\$properties\.$#'
+			identifier: property.notFound
 			count: 3
 			path: src/JsonSchema/SchemaStorage.php
 
 		-
-			message: "#^Argument of an invalid type object supplied for foreach, only iterables are supported\\.$#"
+			message: '#^Argument of an invalid type object supplied for foreach, only iterables are supported\.$#'
+			identifier: foreach.nonIterable
 			count: 1
 			path: src/JsonSchema/SchemaStorage.php
 
 		-
-			message: "#^Call to function is_array\\(\\) with object will always evaluate to false\\.$#"
+			message: '#^Call to function is_array\(\) with object will always evaluate to false\.$#'
+			identifier: function.impossibleType
 			count: 1
 			path: src/JsonSchema/SchemaStorage.php
 
 		-
-			message: "#^Method JsonSchema\\\\SchemaStorage\\:\\:addSchema\\(\\) has no return type specified\\.$#"
+			message: '#^Call to function is_object\(\) with object will always evaluate to true\.$#'
+			identifier: function.alreadyNarrowedType
 			count: 1
 			path: src/JsonSchema/SchemaStorage.php
 
 		-
-			message: "#^Method JsonSchema\\\\SchemaStorage\\:\\:expandRefs\\(\\) has no return type specified\\.$#"
+			message: '#^Cannot access an offset on mixed\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
 			count: 1
 			path: src/JsonSchema/SchemaStorage.php
 
 		-
-			message: "#^Method JsonSchema\\\\SchemaStorage\\:\\:resolveRef\\(\\) has parameter \\$resolveStack with no type specified\\.$#"
+			message: '#^Cannot access offset string on mixed\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 2
+			path: src/JsonSchema/SchemaStorage.php
+
+		-
+			message: '#^Cannot access property \$\$ref on mixed\.$#'
+			identifier: property.nonObject
 			count: 1
 			path: src/JsonSchema/SchemaStorage.php
 
 		-
-			message: "#^Method JsonSchema\\\\SchemaStorage\\:\\:resolveRefSchema\\(\\) has parameter \\$resolveStack with no type specified\\.$#"
+			message: '#^Cannot access property \$format on mixed\.$#'
+			identifier: property.nonObject
+			count: 3
+			path: src/JsonSchema/SchemaStorage.php
+
+		-
+			message: '#^Cannot access property \$id on mixed\.$#'
+			identifier: property.nonObject
+			count: 2
+			path: src/JsonSchema/SchemaStorage.php
+
+		-
+			message: '#^Cannot call method resolve\(\) on mixed\.$#'
+			identifier: method.nonObject
+			count: 2
+			path: src/JsonSchema/SchemaStorage.php
+
+		-
+			message: '#^Cannot call method retrieve\(\) on mixed\.$#'
+			identifier: method.nonObject
 			count: 1
 			path: src/JsonSchema/SchemaStorage.php
 
 		-
-			message: "#^Property JsonSchema\\\\SchemaStorage\\:\\:\\$schemas has no type specified\\.$#"
+			message: '#^Method JsonSchema\\SchemaStorage\:\:addSchema\(\) has no return type specified\.$#'
+			identifier: missingType.return
 			count: 1
 			path: src/JsonSchema/SchemaStorage.php
 
 		-
-			message: "#^Property JsonSchema\\\\SchemaStorage\\:\\:\\$uriResolver has no type specified\\.$#"
+			message: '#^Method JsonSchema\\SchemaStorage\:\:expandRefs\(\) has no return type specified\.$#'
+			identifier: missingType.return
 			count: 1
 			path: src/JsonSchema/SchemaStorage.php
 
 		-
-			message: "#^Property JsonSchema\\\\SchemaStorage\\:\\:\\$uriRetriever has no type specified\\.$#"
+			message: '#^Method JsonSchema\\SchemaStorage\:\:getSchema\(\) should return object but returns mixed\.$#'
+			identifier: return.type
 			count: 1
 			path: src/JsonSchema/SchemaStorage.php
 
 		-
-			message: "#^Result of && is always false\\.$#"
+			message: '#^Method JsonSchema\\SchemaStorage\:\:getUriResolver\(\) should return JsonSchema\\UriResolverInterface but returns mixed\.$#'
+			identifier: return.type
 			count: 1
 			path: src/JsonSchema/SchemaStorage.php
 
 		-
-			message: "#^Method JsonSchema\\\\SchemaStorageInterface\\:\\:addSchema\\(\\) has no return type specified\\.$#"
+			message: '#^Method JsonSchema\\SchemaStorage\:\:getUriRetriever\(\) should return JsonSchema\\UriRetrieverInterface but returns mixed\.$#'
+			identifier: return.type
+			count: 1
+			path: src/JsonSchema/SchemaStorage.php
+
+		-
+			message: '#^Method JsonSchema\\SchemaStorage\:\:resolveRef\(\) has parameter \$resolveStack with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: src/JsonSchema/SchemaStorage.php
+
+		-
+			message: '#^Method JsonSchema\\SchemaStorage\:\:resolveRefSchema\(\) has parameter \$resolveStack with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: src/JsonSchema/SchemaStorage.php
+
+		-
+			message: '#^Method JsonSchema\\SchemaStorage\:\:resolveRefSchema\(\) should return object but returns mixed\.$#'
+			identifier: return.type
+			count: 1
+			path: src/JsonSchema/SchemaStorage.php
+
+		-
+			message: '#^Parameter \#1 \$value of class JsonSchema\\Entity\\JsonPointer constructor expects string, mixed given\.$#'
+			identifier: argument.type
+			count: 1
+			path: src/JsonSchema/SchemaStorage.php
+
+		-
+			message: '#^Parameter \#2 \$base of method JsonSchema\\SchemaStorage\:\:expandRefs\(\) expects string\|null, mixed given\.$#'
+			identifier: argument.type
+			count: 1
+			path: src/JsonSchema/SchemaStorage.php
+
+		-
+			message: '#^Parameter \#2 \$haystack of function in_array expects array, mixed given\.$#'
+			identifier: argument.type
+			count: 1
+			path: src/JsonSchema/SchemaStorage.php
+
+		-
+			message: '#^Parameter \#2 \$search of function array_key_exists expects array, mixed given\.$#'
+			identifier: argument.type
+			count: 1
+			path: src/JsonSchema/SchemaStorage.php
+
+		-
+			message: '#^Property JsonSchema\\SchemaStorage\:\:\$schemas has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: src/JsonSchema/SchemaStorage.php
+
+		-
+			message: '#^Property JsonSchema\\SchemaStorage\:\:\$uriResolver has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: src/JsonSchema/SchemaStorage.php
+
+		-
+			message: '#^Property JsonSchema\\SchemaStorage\:\:\$uriRetriever has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: src/JsonSchema/SchemaStorage.php
+
+		-
+			message: '#^Result of && is always false\.$#'
+			identifier: booleanAnd.alwaysFalse
+			count: 1
+			path: src/JsonSchema/SchemaStorage.php
+
+		-
+			message: '#^Method JsonSchema\\SchemaStorageInterface\:\:addSchema\(\) has no return type specified\.$#'
+			identifier: missingType.return
 			count: 1
 			path: src/JsonSchema/SchemaStorageInterface.php
 
 		-
-			message: "#^Method JsonSchema\\\\Uri\\\\Retrievers\\\\Curl\\:\\:fetchMessageBody\\(\\) has no return type specified\\.$#"
+			message: '#^Method JsonSchema\\Uri\\Retrievers\\Curl\:\:fetchMessageBody\(\) has no return type specified\.$#'
+			identifier: missingType.return
 			count: 1
 			path: src/JsonSchema/Uri/Retrievers/Curl.php
 
 		-
-			message: "#^Offset 1 does not exist on array\\{0\\?\\: string, 1\\?\\: string\\}\\.$#"
+			message: '#^Offset 1 might not exist on array\{0\?\: string, 1\?\: string\}\.$#'
+			identifier: offsetAccess.notFound
 			count: 1
 			path: src/JsonSchema/Uri/Retrievers/Curl.php
 
 		-
-			message: "#^Parameter \\#1 \\$response of method JsonSchema\\\\Uri\\\\Retrievers\\\\Curl\\:\\:fetchContentType\\(\\) expects string, string\\|true given\\.$#"
+			message: '#^Parameter \#1 \$response of method JsonSchema\\Uri\\Retrievers\\Curl\:\:fetchContentType\(\) expects string, mixed given\.$#'
+			identifier: argument.type
 			count: 1
 			path: src/JsonSchema/Uri/Retrievers/Curl.php
 
 		-
-			message: "#^Parameter \\#1 \\$response of method JsonSchema\\\\Uri\\\\Retrievers\\\\Curl\\:\\:fetchMessageBody\\(\\) expects string, string\\|true given\\.$#"
+			message: '#^Parameter \#1 \$response of method JsonSchema\\Uri\\Retrievers\\Curl\:\:fetchMessageBody\(\) expects string, mixed given\.$#'
+			identifier: argument.type
 			count: 1
 			path: src/JsonSchema/Uri/Retrievers/Curl.php
 
 		-
-			message: "#^Property JsonSchema\\\\Uri\\\\Retrievers\\\\Curl\\:\\:\\$messageBody has no type specified\\.$#"
+			message: '#^Parameter \#3 \$value of function curl_setopt expects non\-empty\-string, string given\.$#'
+			identifier: argument.type
 			count: 1
 			path: src/JsonSchema/Uri/Retrievers/Curl.php
 
 		-
-			message: "#^Method JsonSchema\\\\Uri\\\\Retrievers\\\\FileGetContents\\:\\:fetchContentType\\(\\) has parameter \\$headers with no value type specified in iterable type array\\.$#"
+			message: '#^Property JsonSchema\\Uri\\Retrievers\\Curl\:\:\$messageBody has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: src/JsonSchema/Uri/Retrievers/Curl.php
+
+		-
+			message: '#^Method JsonSchema\\Uri\\Retrievers\\FileGetContents\:\:fetchContentType\(\) has parameter \$headers with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/JsonSchema/Uri/Retrievers/FileGetContents.php
 
 		-
-			message: "#^Parameter \\#1 \\$callback of function set_error_handler expects \\(callable\\(int, string, string, int, array\\)\\: bool\\)\\|null, Closure\\(mixed, mixed\\)\\: void given\\.$#"
+			message: '#^Parameter \#1 \$callback of function set_error_handler expects \(callable\(int, string, string, int, array\)\: bool\)\|null, Closure\(mixed, mixed\)\: void given\.$#'
+			identifier: argument.type
 			count: 1
 			path: src/JsonSchema/Uri/Retrievers/FileGetContents.php
 
 		-
-			message: "#^Property JsonSchema\\\\Uri\\\\Retrievers\\\\AbstractRetriever\\:\\:\\$contentType \\(string\\) does not accept null\\.$#"
+			message: '#^Parameter \#1 \$header of static method JsonSchema\\Uri\\Retrievers\\FileGetContents\:\:getContentTypeMatchInHeader\(\) expects string, mixed given\.$#'
+			identifier: argument.type
 			count: 1
 			path: src/JsonSchema/Uri/Retrievers/FileGetContents.php
 
 		-
-			message: "#^Property JsonSchema\\\\Uri\\\\Retrievers\\\\AbstractRetriever\\:\\:\\$contentType \\(string\\) does not accept string\\|null\\.$#"
+			message: '#^Property JsonSchema\\Uri\\Retrievers\\AbstractRetriever\:\:\$contentType \(string\) does not accept null\.$#'
+			identifier: assign.propertyType
 			count: 1
 			path: src/JsonSchema/Uri/Retrievers/FileGetContents.php
 
 		-
-			message: "#^Property JsonSchema\\\\Uri\\\\Retrievers\\\\FileGetContents\\:\\:\\$messageBody has no type specified\\.$#"
+			message: '#^Property JsonSchema\\Uri\\Retrievers\\AbstractRetriever\:\:\$contentType \(string\) does not accept string\|null\.$#'
+			identifier: assign.propertyType
 			count: 1
 			path: src/JsonSchema/Uri/Retrievers/FileGetContents.php
 
 		-
-			message: "#^Method JsonSchema\\\\Uri\\\\Retrievers\\\\PredefinedArray\\:\\:__construct\\(\\) has parameter \\$schemas with no value type specified in iterable type array\\.$#"
+			message: '#^Property JsonSchema\\Uri\\Retrievers\\FileGetContents\:\:\$messageBody has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: src/JsonSchema/Uri/Retrievers/FileGetContents.php
+
+		-
+			message: '#^Method JsonSchema\\Uri\\Retrievers\\PredefinedArray\:\:__construct\(\) has parameter \$schemas with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/JsonSchema/Uri/Retrievers/PredefinedArray.php
 
 		-
-			message: "#^Property JsonSchema\\\\Uri\\\\Retrievers\\\\PredefinedArray\\:\\:\\$schemas type has no value type specified in iterable type array\\.$#"
+			message: '#^Property JsonSchema\\Uri\\Retrievers\\PredefinedArray\:\:\$schemas type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/JsonSchema/Uri/Retrievers/PredefinedArray.php
 
 		-
-			message: "#^Method JsonSchema\\\\Uri\\\\UriResolver\\:\\:generate\\(\\) has parameter \\$components with no value type specified in iterable type array\\.$#"
+			message: '#^Binary operation "\." between ''\#'' and mixed results in an error\.$#'
+			identifier: binaryOp.invalid
 			count: 1
 			path: src/JsonSchema/Uri/UriResolver.php
 
 		-
-			message: "#^Method JsonSchema\\\\Uri\\\\UriResolver\\:\\:normalizePath\\(\\) should return string but returns string\\|null\\.$#"
+			message: '#^Binary operation "\." between ''\?'' and mixed results in an error\.$#'
+			identifier: binaryOp.invalid
 			count: 1
 			path: src/JsonSchema/Uri/UriResolver.php
 
 		-
-			message: "#^Method JsonSchema\\\\Uri\\\\UriResolver\\:\\:parse\\(\\) return type has no value type specified in iterable type array\\.$#"
+			message: '#^Binary operation "\." between mixed and ''\://'' results in an error\.$#'
+			identifier: binaryOp.invalid
 			count: 1
 			path: src/JsonSchema/Uri/UriResolver.php
 
 		-
-			message: "#^Method JsonSchema\\\\Uri\\\\UriResolver\\:\\:resolve\\(\\) should return string but returns string\\|null\\.$#"
+			message: '#^Binary operation "\." between non\-falsy\-string and mixed results in an error\.$#'
+			identifier: binaryOp.invalid
+			count: 2
+			path: src/JsonSchema/Uri/UriResolver.php
+
+		-
+			message: '#^Method JsonSchema\\Uri\\UriResolver\:\:generate\(\) has parameter \$components with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/JsonSchema/Uri/UriResolver.php
 
 		-
-			message: "#^Parameter \\#1 \\$uri of method JsonSchema\\\\Uri\\\\UriResolver\\:\\:parse\\(\\) expects string, string\\|null given\\.$#"
+			message: '#^Method JsonSchema\\Uri\\UriResolver\:\:normalizePath\(\) should return string but returns string\|null\.$#'
+			identifier: return.type
 			count: 1
 			path: src/JsonSchema/Uri/UriResolver.php
 
 		-
-			message: "#^Parameter \\#3 \\$subject of function preg_replace expects array\\|string, string\\|null given\\.$#"
+			message: '#^Method JsonSchema\\Uri\\UriResolver\:\:parse\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/JsonSchema/Uri/UriResolver.php
 
 		-
-			message: "#^Call to function is_null\\(\\) with string will always evaluate to false\\.$#"
+			message: '#^Method JsonSchema\\Uri\\UriResolver\:\:resolve\(\) should return string but returns string\|null\.$#'
+			identifier: return.type
+			count: 1
+			path: src/JsonSchema/Uri/UriResolver.php
+
+		-
+			message: '#^Parameter \#1 \$relativePath of static method JsonSchema\\Uri\\UriResolver\:\:combineRelativePathWithBasePath\(\) expects string, mixed given\.$#'
+			identifier: argument.type
+			count: 1
+			path: src/JsonSchema/Uri/UriResolver.php
+
+		-
+			message: '#^Parameter \#1 \$string of function strlen expects string, mixed given\.$#'
+			identifier: argument.type
+			count: 1
+			path: src/JsonSchema/Uri/UriResolver.php
+
+		-
+			message: '#^Parameter \#1 \$uri of method JsonSchema\\Uri\\UriResolver\:\:parse\(\) expects string, string\|null given\.$#'
+			identifier: argument.type
+			count: 1
+			path: src/JsonSchema/Uri/UriResolver.php
+
+		-
+			message: '#^Parameter \#2 \$basePath of static method JsonSchema\\Uri\\UriResolver\:\:combineRelativePathWithBasePath\(\) expects string, mixed given\.$#'
+			identifier: argument.type
+			count: 1
+			path: src/JsonSchema/Uri/UriResolver.php
+
+		-
+			message: '#^Parameter \#3 \$subject of function preg_replace expects array\<float\|int\|string\>\|string, string\|null given\.$#'
+			identifier: argument.type
+			count: 1
+			path: src/JsonSchema/Uri/UriResolver.php
+
+		-
+			message: '#^Binary operation "\." between ''Fragment "'' and mixed results in an error\.$#'
+			identifier: binaryOp.invalid
+			count: 1
+			path: src/JsonSchema/Uri/UriRetriever.php
+
+		-
+			message: '#^Binary operation "\." between mixed and ''\://'' results in an error\.$#'
+			identifier: binaryOp.invalid
+			count: 1
+			path: src/JsonSchema/Uri/UriRetriever.php
+
+		-
+			message: '#^Binary operation "\." between non\-falsy\-string and mixed results in an error\.$#'
+			identifier: binaryOp.invalid
 			count: 2
 			path: src/JsonSchema/Uri/UriRetriever.php
 
 		-
-			message: "#^Cannot call method retrieve\\(\\) on JsonSchema\\\\Uri\\\\Retrievers\\\\UriRetrieverInterface\\|null\\.$#"
+			message: '#^Binary operation "\.\=" between non\-falsy\-string and mixed results in an error\.$#'
+			identifier: assignOp.invalid
+			count: 2
+			path: src/JsonSchema/Uri/UriRetriever.php
+
+		-
+			message: '#^Call to function is_null\(\) with string will always evaluate to false\.$#'
+			identifier: function.impossibleType
+			count: 2
+			path: src/JsonSchema/Uri/UriRetriever.php
+
+		-
+			message: '#^Cannot call method retrieve\(\) on JsonSchema\\Uri\\Retrievers\\UriRetrieverInterface\|null\.$#'
+			identifier: method.nonObject
 			count: 1
 			path: src/JsonSchema/Uri/UriRetriever.php
 
 		-
-			message: "#^Method JsonSchema\\\\Uri\\\\UriRetriever\\:\\:addInvalidContentTypeEndpoint\\(\\) has no return type specified\\.$#"
+			message: '#^Method JsonSchema\\Uri\\UriRetriever\:\:addInvalidContentTypeEndpoint\(\) has no return type specified\.$#'
+			identifier: missingType.return
 			count: 1
 			path: src/JsonSchema/Uri/UriRetriever.php
 
 		-
-			message: "#^Method JsonSchema\\\\Uri\\\\UriRetriever\\:\\:generate\\(\\) has parameter \\$components with no value type specified in iterable type array\\.$#"
+			message: '#^Method JsonSchema\\Uri\\UriRetriever\:\:generate\(\) has parameter \$components with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/JsonSchema/Uri/UriRetriever.php
 
 		-
-			message: "#^Method JsonSchema\\\\Uri\\\\UriRetriever\\:\\:getUriRetriever\\(\\) should return JsonSchema\\\\Uri\\\\Retrievers\\\\UriRetrieverInterface but returns JsonSchema\\\\Uri\\\\Retrievers\\\\UriRetrieverInterface\\|null\\.$#"
+			message: '#^Method JsonSchema\\Uri\\UriRetriever\:\:getUriRetriever\(\) should return JsonSchema\\Uri\\Retrievers\\UriRetrieverInterface but returns JsonSchema\\Uri\\Retrievers\\UriRetrieverInterface\|null\.$#'
+			identifier: return.type
 			count: 1
 			path: src/JsonSchema/Uri/UriRetriever.php
 
 		-
-			message: "#^Method JsonSchema\\\\Uri\\\\UriRetriever\\:\\:parse\\(\\) return type has no value type specified in iterable type array\\.$#"
+			message: '#^Method JsonSchema\\Uri\\UriRetriever\:\:loadSchema\(\) should return object but returns mixed\.$#'
+			identifier: return.type
 			count: 1
 			path: src/JsonSchema/Uri/UriRetriever.php
 
 		-
-			message: "#^Method JsonSchema\\\\Uri\\\\UriRetriever\\:\\:retrieve\\(\\) has parameter \\$translate with no type specified\\.$#"
+			message: '#^Method JsonSchema\\Uri\\UriRetriever\:\:parse\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/JsonSchema/Uri/UriRetriever.php
 
 		-
-			message: "#^Method JsonSchema\\\\Uri\\\\UriRetriever\\:\\:setTranslation\\(\\) has no return type specified\\.$#"
+			message: '#^Method JsonSchema\\Uri\\UriRetriever\:\:retrieve\(\) has parameter \$translate with no type specified\.$#'
+			identifier: missingType.parameter
 			count: 1
 			path: src/JsonSchema/Uri/UriRetriever.php
 
 		-
-			message: "#^Method JsonSchema\\\\Uri\\\\UriRetriever\\:\\:setTranslation\\(\\) has parameter \\$from with no type specified\\.$#"
+			message: '#^Method JsonSchema\\Uri\\UriRetriever\:\:setTranslation\(\) has no return type specified\.$#'
+			identifier: missingType.return
 			count: 1
 			path: src/JsonSchema/Uri/UriRetriever.php
 
 		-
-			message: "#^Method JsonSchema\\\\Uri\\\\UriRetriever\\:\\:setTranslation\\(\\) has parameter \\$to with no type specified\\.$#"
+			message: '#^Method JsonSchema\\Uri\\UriRetriever\:\:setTranslation\(\) has parameter \$from with no type specified\.$#'
+			identifier: missingType.parameter
 			count: 1
 			path: src/JsonSchema/Uri/UriRetriever.php
 
 		-
-			message: "#^Method JsonSchema\\\\Uri\\\\UriRetriever\\:\\:translate\\(\\) has no return type specified\\.$#"
+			message: '#^Method JsonSchema\\Uri\\UriRetriever\:\:setTranslation\(\) has parameter \$to with no type specified\.$#'
+			identifier: missingType.parameter
 			count: 1
 			path: src/JsonSchema/Uri/UriRetriever.php
 
 		-
-			message: "#^Method JsonSchema\\\\Uri\\\\UriRetriever\\:\\:translate\\(\\) has parameter \\$uri with no type specified\\.$#"
+			message: '#^Method JsonSchema\\Uri\\UriRetriever\:\:translate\(\) has no return type specified\.$#'
+			identifier: missingType.return
 			count: 1
 			path: src/JsonSchema/Uri/UriRetriever.php
 
 		-
-			message: "#^Parameter \\#1 \\$uri of method JsonSchema\\\\Uri\\\\UriRetriever\\:\\:parse\\(\\) expects string, string\\|null given\\.$#"
+			message: '#^Method JsonSchema\\Uri\\UriRetriever\:\:translate\(\) has parameter \$uri with no type specified\.$#'
+			identifier: missingType.parameter
 			count: 1
 			path: src/JsonSchema/Uri/UriRetriever.php
 
 		-
-			message: "#^Property JsonSchema\\\\Uri\\\\UriRetriever\\:\\:\\$allowedInvalidContentTypeEndpoints type has no value type specified in iterable type array\\.$#"
+			message: '#^Parameter \#1 \$fetchUri of method JsonSchema\\Uri\\UriRetriever\:\:loadSchema\(\) expects string, mixed given\.$#'
+			identifier: argument.type
 			count: 1
 			path: src/JsonSchema/Uri/UriRetriever.php
 
 		-
-			message: "#^Property JsonSchema\\\\Uri\\\\UriRetriever\\:\\:\\$translationMap type has no value type specified in iterable type array\\.$#"
+			message: '#^Parameter \#1 \$json of function json_decode expects string, mixed given\.$#'
+			identifier: argument.type
 			count: 1
 			path: src/JsonSchema/Uri/UriRetriever.php
 
 		-
-			message: "#^Method JsonSchema\\\\Validator\\:\\:check\\(\\) has no return type specified\\.$#"
+			message: '#^Parameter \#1 \$relativePath of static method JsonSchema\\Uri\\UriResolver\:\:combineRelativePathWithBasePath\(\) expects string, mixed given\.$#'
+			identifier: argument.type
+			count: 1
+			path: src/JsonSchema/Uri/UriRetriever.php
+
+		-
+			message: '#^Parameter \#1 \$uri of method JsonSchema\\Uri\\UriRetriever\:\:parse\(\) expects string, string\|null given\.$#'
+			identifier: argument.type
+			count: 1
+			path: src/JsonSchema/Uri/UriRetriever.php
+
+		-
+			message: '#^Parameter \#2 \$basePath of static method JsonSchema\\Uri\\UriResolver\:\:combineRelativePathWithBasePath\(\) expects string, mixed given\.$#'
+			identifier: argument.type
+			count: 1
+			path: src/JsonSchema/Uri/UriRetriever.php
+
+		-
+			message: '#^Parameter \#2 \$needle of function strpos expects int\|string, mixed given\.$#'
+			identifier: argument.type
+			count: 1
+			path: src/JsonSchema/Uri/UriRetriever.php
+
+		-
+			message: '#^Parameter \#2 \$replace of function preg_replace expects array\<float\|int\|string\>\|string, mixed given\.$#'
+			identifier: argument.type
+			count: 1
+			path: src/JsonSchema/Uri/UriRetriever.php
+
+		-
+			message: '#^Parameter \#2 \$str of function explode expects string, mixed given\.$#'
+			identifier: argument.type
+			count: 1
+			path: src/JsonSchema/Uri/UriRetriever.php
+
+		-
+			message: '#^Parameter \#3 \$subject of function preg_replace expects array\<float\|int\|string\>\|string, mixed given\.$#'
+			identifier: argument.type
+			count: 2
+			path: src/JsonSchema/Uri/UriRetriever.php
+
+		-
+			message: '#^Property JsonSchema\\Uri\\UriRetriever\:\:\$allowedInvalidContentTypeEndpoints type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: src/JsonSchema/Uri/UriRetriever.php
+
+		-
+			message: '#^Property JsonSchema\\Uri\\UriRetriever\:\:\$schemaCache \(array\<object\>\) does not accept array\<mixed\>\.$#'
+			identifier: assign.propertyType
+			count: 1
+			path: src/JsonSchema/Uri/UriRetriever.php
+
+		-
+			message: '#^Property JsonSchema\\Uri\\UriRetriever\:\:\$translationMap type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: src/JsonSchema/Uri/UriRetriever.php
+
+		-
+			message: '#^Method JsonSchema\\Validator\:\:check\(\) has no return type specified\.$#'
+			identifier: missingType.return
 			count: 1
 			path: src/JsonSchema/Validator.php
 
 		-
-			message: "#^Method JsonSchema\\\\Validator\\:\\:check\\(\\) has parameter \\$schema with no type specified\\.$#"
+			message: '#^Method JsonSchema\\Validator\:\:check\(\) has parameter \$schema with no type specified\.$#'
+			identifier: missingType.parameter
 			count: 1
 			path: src/JsonSchema/Validator.php
 
 		-
-			message: "#^Method JsonSchema\\\\Validator\\:\\:check\\(\\) has parameter \\$value with no type specified\\.$#"
+			message: '#^Method JsonSchema\\Validator\:\:check\(\) has parameter \$value with no type specified\.$#'
+			identifier: missingType.parameter
 			count: 1
 			path: src/JsonSchema/Validator.php
 
 		-
-			message: "#^Method JsonSchema\\\\Validator\\:\\:coerce\\(\\) has no return type specified\\.$#"
+			message: '#^Method JsonSchema\\Validator\:\:coerce\(\) has no return type specified\.$#'
+			identifier: missingType.return
 			count: 1
 			path: src/JsonSchema/Validator.php
 
 		-
-			message: "#^Method JsonSchema\\\\Validator\\:\\:coerce\\(\\) has parameter \\$schema with no type specified\\.$#"
+			message: '#^Method JsonSchema\\Validator\:\:coerce\(\) has parameter \$schema with no type specified\.$#'
+			identifier: missingType.parameter
 			count: 1
 			path: src/JsonSchema/Validator.php
 
 		-
-			message: "#^Method JsonSchema\\\\Validator\\:\\:coerce\\(\\) has parameter \\$value with no type specified\\.$#"
+			message: '#^Method JsonSchema\\Validator\:\:coerce\(\) has parameter \$value with no type specified\.$#'
+			identifier: missingType.parameter
 			count: 1
 			path: src/JsonSchema/Validator.php
+
+		-
+			message: '#^Parameter \#1 \$id of method JsonSchema\\SchemaStorageInterface\:\:addSchema\(\) expects string, mixed given\.$#'
+			identifier: argument.type
+			count: 1
+			path: src/JsonSchema/Validator.php
+
+		-
+			message: '#^Parameter \#1 \$id of method JsonSchema\\SchemaStorageInterface\:\:getSchema\(\) expects string, mixed given\.$#'
+			identifier: argument.type
+			count: 1
+			path: src/JsonSchema/Validator.php
+
+		-
+			message: '#^Parameter \#2 \$schema of method JsonSchema\\SchemaStorageInterface\:\:addSchema\(\) expects object\|null, mixed given\.$#'
+			identifier: argument.type
+			count: 1
+			path: src/JsonSchema/Validator.php
+
+		-
+			message: '#^Method JsonSchema\\Tests\\Constraints\\AdditionalPropertiesTest\:\:getInvalidTests\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: tests/Constraints/AdditionalPropertiesTest.php
+
+		-
+			message: '#^Method JsonSchema\\Tests\\Constraints\\AdditionalPropertiesTest\:\:getValidTests\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: tests/Constraints/AdditionalPropertiesTest.php
+
+		-
+			message: '#^Property JsonSchema\\Tests\\Constraints\\AdditionalPropertiesTest\:\:\$validateSchema has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: tests/Constraints/AdditionalPropertiesTest.php
+
+		-
+			message: '#^Method JsonSchema\\Tests\\Constraints\\ArraysTest\:\:getInvalidTests\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: tests/Constraints/ArraysTest.php
+
+		-
+			message: '#^Method JsonSchema\\Tests\\Constraints\\ArraysTest\:\:getValidTests\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: tests/Constraints/ArraysTest.php
+
+		-
+			message: '#^Property JsonSchema\\Tests\\Constraints\\ArraysTest\:\:\$validateSchema has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: tests/Constraints/ArraysTest.php
+
+		-
+			message: '#^Access to an undefined property object\:\:\$\$schema\.$#'
+			identifier: property.notFound
+			count: 4
+			path: tests/Constraints/BaseTestCase.php
+
+		-
+			message: '#^Binary operation "&" between mixed and 2 results in an error\.$#'
+			identifier: binaryOp.invalid
+			count: 2
+			path: tests/Constraints/BaseTestCase.php
+
+		-
+			message: '#^Binary operation "\|\=" between mixed and 256 results in an error\.$#'
+			identifier: assignOp.invalid
+			count: 4
+			path: tests/Constraints/BaseTestCase.php
+
+		-
+			message: '#^Call to function is_object\(\) with object will always evaluate to true\.$#'
+			identifier: function.alreadyNarrowedType
+			count: 4
+			path: tests/Constraints/BaseTestCase.php
+
+		-
+			message: '#^Method JsonSchema\\Tests\\Constraints\\BaseTestCase\:\:getInvalidForAssocTests\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: tests/Constraints/BaseTestCase.php
+
+		-
+			message: '#^Method JsonSchema\\Tests\\Constraints\\BaseTestCase\:\:getInvalidTests\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: tests/Constraints/BaseTestCase.php
+
+		-
+			message: '#^Method JsonSchema\\Tests\\Constraints\\BaseTestCase\:\:getValidForAssocTests\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: tests/Constraints/BaseTestCase.php
+
+		-
+			message: '#^Method JsonSchema\\Tests\\Constraints\\BaseTestCase\:\:getValidTests\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: tests/Constraints/BaseTestCase.php
+
+		-
+			message: '#^Method JsonSchema\\Tests\\Constraints\\BaseTestCase\:\:testInvalidCases\(\) has parameter \$checkMode with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: tests/Constraints/BaseTestCase.php
+
+		-
+			message: '#^Method JsonSchema\\Tests\\Constraints\\BaseTestCase\:\:testInvalidCases\(\) has parameter \$errors with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: tests/Constraints/BaseTestCase.php
+
+		-
+			message: '#^Method JsonSchema\\Tests\\Constraints\\BaseTestCase\:\:testInvalidCases\(\) has parameter \$input with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: tests/Constraints/BaseTestCase.php
+
+		-
+			message: '#^Method JsonSchema\\Tests\\Constraints\\BaseTestCase\:\:testInvalidCases\(\) has parameter \$schema with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: tests/Constraints/BaseTestCase.php
+
+		-
+			message: '#^Method JsonSchema\\Tests\\Constraints\\BaseTestCase\:\:testInvalidCasesUsingAssoc\(\) has parameter \$checkMode with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: tests/Constraints/BaseTestCase.php
+
+		-
+			message: '#^Method JsonSchema\\Tests\\Constraints\\BaseTestCase\:\:testInvalidCasesUsingAssoc\(\) has parameter \$errors with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: tests/Constraints/BaseTestCase.php
+
+		-
+			message: '#^Method JsonSchema\\Tests\\Constraints\\BaseTestCase\:\:testInvalidCasesUsingAssoc\(\) has parameter \$input with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: tests/Constraints/BaseTestCase.php
+
+		-
+			message: '#^Method JsonSchema\\Tests\\Constraints\\BaseTestCase\:\:testInvalidCasesUsingAssoc\(\) has parameter \$schema with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: tests/Constraints/BaseTestCase.php
+
+		-
+			message: '#^Method JsonSchema\\Tests\\Constraints\\BaseTestCase\:\:testValidCases\(\) has parameter \$checkMode with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: tests/Constraints/BaseTestCase.php
+
+		-
+			message: '#^Method JsonSchema\\Tests\\Constraints\\BaseTestCase\:\:testValidCases\(\) has parameter \$input with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: tests/Constraints/BaseTestCase.php
+
+		-
+			message: '#^Method JsonSchema\\Tests\\Constraints\\BaseTestCase\:\:testValidCases\(\) has parameter \$schema with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: tests/Constraints/BaseTestCase.php
+
+		-
+			message: '#^Method JsonSchema\\Tests\\Constraints\\BaseTestCase\:\:testValidCasesUsingAssoc\(\) has parameter \$checkMode with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: tests/Constraints/BaseTestCase.php
+
+		-
+			message: '#^Method JsonSchema\\Tests\\Constraints\\BaseTestCase\:\:testValidCasesUsingAssoc\(\) has parameter \$input with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: tests/Constraints/BaseTestCase.php
+
+		-
+			message: '#^Method JsonSchema\\Tests\\Constraints\\BaseTestCase\:\:testValidCasesUsingAssoc\(\) has parameter \$schema with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: tests/Constraints/BaseTestCase.php
+
+		-
+			message: '#^Parameter \#1 \$json of function json_decode expects string, mixed given\.$#'
+			identifier: argument.type
+			count: 8
+			path: tests/Constraints/BaseTestCase.php
+
+		-
+			message: '#^Parameter \#1 \$schema of method JsonSchema\\Tests\\Constraints\\VeryBaseTestCase\:\:getUriRetrieverMock\(\) expects object\|null, mixed given\.$#'
+			identifier: argument.type
+			count: 4
+			path: tests/Constraints/BaseTestCase.php
+
+		-
+			message: '#^Parameter \#1 \$uriRetriever of class JsonSchema\\SchemaStorage constructor expects JsonSchema\\UriRetrieverInterface\|null, object given\.$#'
+			identifier: argument.type
+			count: 4
+			path: tests/Constraints/BaseTestCase.php
+
+		-
+			message: '#^Parameter \#3 \$checkMode of class JsonSchema\\Constraints\\Factory constructor expects int\<0, 511\>, mixed given\.$#'
+			identifier: argument.type
+			count: 4
+			path: tests/Constraints/BaseTestCase.php
+
+		-
+			message: '#^Property JsonSchema\\Tests\\Constraints\\BaseTestCase\:\:\$schemaSpec has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: tests/Constraints/BaseTestCase.php
+
+		-
+			message: '#^Property JsonSchema\\Tests\\Constraints\\BaseTestCase\:\:\$validateSchema has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: tests/Constraints/BaseTestCase.php
+
+		-
+			message: '#^Method JsonSchema\\Tests\\Constraints\\BasicTypesTest\:\:getInvalidTests\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: tests/Constraints/BasicTypesTest.php
+
+		-
+			message: '#^Method JsonSchema\\Tests\\Constraints\\BasicTypesTest\:\:getValidTests\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: tests/Constraints/BasicTypesTest.php
+
+		-
+			message: '#^Property JsonSchema\\Tests\\Constraints\\BasicTypesTest\:\:\$schemaSpec has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: tests/Constraints/BasicTypesTest.php
+
+		-
+			message: '#^Property JsonSchema\\Tests\\Constraints\\BasicTypesTest\:\:\$validateSchema has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: tests/Constraints/BasicTypesTest.php
+
+		-
+			message: '#^Binary operation "\|" between mixed and mixed results in an error\.$#'
+			identifier: binaryOp.invalid
+			count: 1
+			path: tests/Constraints/CoerciveTest.php
+
+		-
+			message: '#^Cannot access an offset on mixed\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: tests/Constraints/CoerciveTest.php
+
+		-
+			message: '#^Cannot call method getConfig\(\) on mixed\.$#'
+			identifier: method.nonObject
+			count: 1
+			path: tests/Constraints/CoerciveTest.php
+
+		-
+			message: '#^Method JsonSchema\\Tests\\Constraints\\CoerciveTest\:\:dataCoerceCases\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: tests/Constraints/CoerciveTest.php
+
+		-
+			message: '#^Method JsonSchema\\Tests\\Constraints\\CoerciveTest\:\:testCoerceCases\(\) has parameter \$assoc with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: tests/Constraints/CoerciveTest.php
+
+		-
+			message: '#^Method JsonSchema\\Tests\\Constraints\\CoerciveTest\:\:testCoerceCases\(\) has parameter \$data with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: tests/Constraints/CoerciveTest.php
+
+		-
+			message: '#^Method JsonSchema\\Tests\\Constraints\\CoerciveTest\:\:testCoerceCases\(\) has parameter \$endType with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: tests/Constraints/CoerciveTest.php
+
+		-
+			message: '#^Method JsonSchema\\Tests\\Constraints\\CoerciveTest\:\:testCoerceCases\(\) has parameter \$endValue with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: tests/Constraints/CoerciveTest.php
+
+		-
+			message: '#^Method JsonSchema\\Tests\\Constraints\\CoerciveTest\:\:testCoerceCases\(\) has parameter \$extraFlags with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: tests/Constraints/CoerciveTest.php
+
+		-
+			message: '#^Method JsonSchema\\Tests\\Constraints\\CoerciveTest\:\:testCoerceCases\(\) has parameter \$schema with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: tests/Constraints/CoerciveTest.php
+
+		-
+			message: '#^Method JsonSchema\\Tests\\Constraints\\CoerciveTest\:\:testCoerceCases\(\) has parameter \$startType with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: tests/Constraints/CoerciveTest.php
+
+		-
+			message: '#^Method JsonSchema\\Tests\\Constraints\\CoerciveTest\:\:testCoerceCases\(\) has parameter \$valid with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: tests/Constraints/CoerciveTest.php
+
+		-
+			message: '#^Method JsonSchema\\Tests\\Constraints\\CoerciveTest\:\:testCoerceCasesUsingAssoc\(\) has parameter \$data with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: tests/Constraints/CoerciveTest.php
+
+		-
+			message: '#^Method JsonSchema\\Tests\\Constraints\\CoerciveTest\:\:testCoerceCasesUsingAssoc\(\) has parameter \$early with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: tests/Constraints/CoerciveTest.php
+
+		-
+			message: '#^Method JsonSchema\\Tests\\Constraints\\CoerciveTest\:\:testCoerceCasesUsingAssoc\(\) has parameter \$endType with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: tests/Constraints/CoerciveTest.php
+
+		-
+			message: '#^Method JsonSchema\\Tests\\Constraints\\CoerciveTest\:\:testCoerceCasesUsingAssoc\(\) has parameter \$endValue with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: tests/Constraints/CoerciveTest.php
+
+		-
+			message: '#^Method JsonSchema\\Tests\\Constraints\\CoerciveTest\:\:testCoerceCasesUsingAssoc\(\) has parameter \$schema with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: tests/Constraints/CoerciveTest.php
+
+		-
+			message: '#^Method JsonSchema\\Tests\\Constraints\\CoerciveTest\:\:testCoerceCasesUsingAssoc\(\) has parameter \$startType with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: tests/Constraints/CoerciveTest.php
+
+		-
+			message: '#^Method JsonSchema\\Tests\\Constraints\\CoerciveTest\:\:testCoerceCasesUsingAssoc\(\) has parameter \$valid with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: tests/Constraints/CoerciveTest.php
+
+		-
+			message: '#^Parameter \#1 \$factory of class JsonSchema\\Validator constructor expects JsonSchema\\Constraints\\Factory\|null, mixed given\.$#'
+			identifier: argument.type
+			count: 1
+			path: tests/Constraints/CoerciveTest.php
+
+		-
+			message: '#^Parameter \#1 \$json of function json_decode expects string, mixed given\.$#'
+			identifier: argument.type
+			count: 2
+			path: tests/Constraints/CoerciveTest.php
+
+		-
+			message: '#^Parameter \#2 \$assoc of function json_decode expects bool\|null, mixed given\.$#'
+			identifier: argument.type
+			count: 1
+			path: tests/Constraints/CoerciveTest.php
+
+		-
+			message: '#^Parameter \#3 \$checkMode of method JsonSchema\\Validator\:\:validate\(\) expects int\<0, 511\>\|null, int given\.$#'
+			identifier: argument.type
+			count: 1
+			path: tests/Constraints/CoerciveTest.php
+
+		-
+			message: '#^Part \$endType \(mixed\) of encapsed string cannot be cast to string\.$#'
+			identifier: encapsedStringPart.nonString
+			count: 1
+			path: tests/Constraints/CoerciveTest.php
+
+		-
+			message: '#^Part \$startType \(mixed\) of encapsed string cannot be cast to string\.$#'
+			identifier: encapsedStringPart.nonString
+			count: 1
+			path: tests/Constraints/CoerciveTest.php
+
+		-
+			message: '#^Property JsonSchema\\Tests\\Constraints\\CoerciveTest\:\:\$factory has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: tests/Constraints/CoerciveTest.php
+
+		-
+			message: '#^Method JsonSchema\\Tests\\Constraints\\ConstTest\:\:getInvalidTests\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: tests/Constraints/ConstTest.php
+
+		-
+			message: '#^Method JsonSchema\\Tests\\Constraints\\ConstTest\:\:getValidTests\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: tests/Constraints/ConstTest.php
+
+		-
+			message: '#^Property JsonSchema\\Tests\\Constraints\\ConstTest\:\:\$schemaSpec has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: tests/Constraints/ConstTest.php
+
+		-
+			message: '#^Property JsonSchema\\Tests\\Constraints\\ConstTest\:\:\$validateSchema has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: tests/Constraints/ConstTest.php
+
+		-
+			message: '#^Binary operation "\|\=" between mixed and 2 results in an error\.$#'
+			identifier: assignOp.invalid
+			count: 1
+			path: tests/Constraints/DefaultPropertiesTest.php
+
+		-
+			message: '#^Binary operation "\|\=" between mixed and 8 results in an error\.$#'
+			identifier: assignOp.invalid
+			count: 1
+			path: tests/Constraints/DefaultPropertiesTest.php
+
+		-
+			message: '#^Cannot access property \$default on mixed\.$#'
+			identifier: property.nonObject
+			count: 1
+			path: tests/Constraints/DefaultPropertiesTest.php
+
+		-
+			message: '#^Cannot access property \$propertyOne on mixed\.$#'
+			identifier: property.nonObject
+			count: 2
+			path: tests/Constraints/DefaultPropertiesTest.php
+
+		-
+			message: '#^Method JsonSchema\\Tests\\Constraints\\DefaultPropertiesTest\:\:getValidTests\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: tests/Constraints/DefaultPropertiesTest.php
+
+		-
+			message: '#^Method JsonSchema\\Tests\\Constraints\\DefaultPropertiesTest\:\:testValidCases\(\) has parameter \$checkMode with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: tests/Constraints/DefaultPropertiesTest.php
+
+		-
+			message: '#^Method JsonSchema\\Tests\\Constraints\\DefaultPropertiesTest\:\:testValidCases\(\) has parameter \$expectOutput with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: tests/Constraints/DefaultPropertiesTest.php
+
+		-
+			message: '#^Method JsonSchema\\Tests\\Constraints\\DefaultPropertiesTest\:\:testValidCases\(\) has parameter \$input with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: tests/Constraints/DefaultPropertiesTest.php
+
+		-
+			message: '#^Method JsonSchema\\Tests\\Constraints\\DefaultPropertiesTest\:\:testValidCases\(\) has parameter \$schema with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: tests/Constraints/DefaultPropertiesTest.php
+
+		-
+			message: '#^Method JsonSchema\\Tests\\Constraints\\DefaultPropertiesTest\:\:testValidCasesUsingAssoc\(\) has parameter \$checkMode with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: tests/Constraints/DefaultPropertiesTest.php
+
+		-
+			message: '#^Method JsonSchema\\Tests\\Constraints\\DefaultPropertiesTest\:\:testValidCasesUsingAssoc\(\) has parameter \$expectOutput with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: tests/Constraints/DefaultPropertiesTest.php
+
+		-
+			message: '#^Method JsonSchema\\Tests\\Constraints\\DefaultPropertiesTest\:\:testValidCasesUsingAssoc\(\) has parameter \$input with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: tests/Constraints/DefaultPropertiesTest.php
+
+		-
+			message: '#^Method JsonSchema\\Tests\\Constraints\\DefaultPropertiesTest\:\:testValidCasesUsingAssoc\(\) has parameter \$schema with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: tests/Constraints/DefaultPropertiesTest.php
+
+		-
+			message: '#^Method JsonSchema\\Tests\\Constraints\\DefaultPropertiesTest\:\:testValidCasesUsingAssocWithoutTypeCast\(\) has parameter \$checkMode with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: tests/Constraints/DefaultPropertiesTest.php
+
+		-
+			message: '#^Method JsonSchema\\Tests\\Constraints\\DefaultPropertiesTest\:\:testValidCasesUsingAssocWithoutTypeCast\(\) has parameter \$expectOutput with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: tests/Constraints/DefaultPropertiesTest.php
+
+		-
+			message: '#^Method JsonSchema\\Tests\\Constraints\\DefaultPropertiesTest\:\:testValidCasesUsingAssocWithoutTypeCast\(\) has parameter \$input with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: tests/Constraints/DefaultPropertiesTest.php
+
+		-
+			message: '#^Method JsonSchema\\Tests\\Constraints\\DefaultPropertiesTest\:\:testValidCasesUsingAssocWithoutTypeCast\(\) has parameter \$schema with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: tests/Constraints/DefaultPropertiesTest.php
+
+		-
+			message: '#^Parameter \#1 \$json of function json_decode expects string, mixed given\.$#'
+			identifier: argument.type
+			count: 3
+			path: tests/Constraints/DefaultPropertiesTest.php
+
+		-
+			message: '#^Parameter \#2 \$schema of method JsonSchema\\SchemaStorage\:\:addSchema\(\) expects object\|null, mixed given\.$#'
+			identifier: argument.type
+			count: 1
+			path: tests/Constraints/DefaultPropertiesTest.php
+
+		-
+			message: '#^Parameter \#3 \$checkMode of method JsonSchema\\Validator\:\:validate\(\) expects int\<0, 511\>\|null, int given\.$#'
+			identifier: argument.type
+			count: 1
+			path: tests/Constraints/DefaultPropertiesTest.php
+
+		-
+			message: '#^Method JsonSchema\\Tests\\Constraints\\DependenciesTest\:\:getInvalidTests\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: tests/Constraints/DependenciesTest.php
+
+		-
+			message: '#^Method JsonSchema\\Tests\\Constraints\\DependenciesTest\:\:getValidTests\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: tests/Constraints/DependenciesTest.php
+
+		-
+			message: '#^Property JsonSchema\\Tests\\Constraints\\DependenciesTest\:\:\$schemaSpec has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: tests/Constraints/DependenciesTest.php
+
+		-
+			message: '#^Property JsonSchema\\Tests\\Constraints\\DependenciesTest\:\:\$validateSchema has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: tests/Constraints/DependenciesTest.php
+
+		-
+			message: '#^Method JsonSchema\\Tests\\Constraints\\DisallowTest\:\:getInvalidTests\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: tests/Constraints/DisallowTest.php
+
+		-
+			message: '#^Method JsonSchema\\Tests\\Constraints\\DisallowTest\:\:getValidTests\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: tests/Constraints/DisallowTest.php
+
+		-
+			message: '#^Property JsonSchema\\Tests\\Constraints\\DisallowTest\:\:\$schemaSpec has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: tests/Constraints/DisallowTest.php
+
+		-
+			message: '#^Property JsonSchema\\Tests\\Constraints\\DisallowTest\:\:\$validateSchema has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: tests/Constraints/DisallowTest.php
+
+		-
+			message: '#^Method JsonSchema\\Tests\\Constraints\\DivisibleByTest\:\:getInvalidTests\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: tests/Constraints/DivisibleByTest.php
+
+		-
+			message: '#^Method JsonSchema\\Tests\\Constraints\\DivisibleByTest\:\:getValidTests\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: tests/Constraints/DivisibleByTest.php
+
+		-
+			message: '#^Property JsonSchema\\Tests\\Constraints\\DivisibleByTest\:\:\$validateSchema has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: tests/Constraints/DivisibleByTest.php
+
+		-
+			message: '#^Method JsonSchema\\Tests\\Constraints\\EnumTest\:\:getInvalidTests\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: tests/Constraints/EnumTest.php
+
+		-
+			message: '#^Method JsonSchema\\Tests\\Constraints\\EnumTest\:\:getValidTests\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: tests/Constraints/EnumTest.php
+
+		-
+			message: '#^Property JsonSchema\\Tests\\Constraints\\EnumTest\:\:\$schemaSpec has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: tests/Constraints/EnumTest.php
+
+		-
+			message: '#^Property JsonSchema\\Tests\\Constraints\\EnumTest\:\:\$validateSchema has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: tests/Constraints/EnumTest.php
+
+		-
+			message: '#^Method JsonSchema\\Tests\\Constraints\\ExtendsTest\:\:getInvalidTests\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: tests/Constraints/ExtendsTest.php
+
+		-
+			message: '#^Method JsonSchema\\Tests\\Constraints\\ExtendsTest\:\:getValidTests\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: tests/Constraints/ExtendsTest.php
+
+		-
+			message: '#^Property JsonSchema\\Tests\\Constraints\\ExtendsTest\:\:\$schemaSpec has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: tests/Constraints/ExtendsTest.php
+
+		-
+			message: '#^Property JsonSchema\\Tests\\Constraints\\ExtendsTest\:\:\$validateSchema has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: tests/Constraints/ExtendsTest.php
+
+		-
+			message: '#^Parameter \#1 \$expected of method PHPUnit\\Framework\\Assert\:\:assertInstanceOf\(\) expects class\-string\<object\>, string given\.$#'
+			identifier: argument.type
+			count: 1
+			path: tests/Constraints/FactoryTest.php
+
+		-
+			message: '#^Method JsonSchema\\Tests\\Constraints\\FormatTest\:\:getInvalidFormats\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: tests/Constraints/FormatTest.php
+
+		-
+			message: '#^Method JsonSchema\\Tests\\Constraints\\FormatTest\:\:getInvalidTests\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: tests/Constraints/FormatTest.php
+
+		-
+			message: '#^Method JsonSchema\\Tests\\Constraints\\FormatTest\:\:getValidFormats\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: tests/Constraints/FormatTest.php
+
+		-
+			message: '#^Method JsonSchema\\Tests\\Constraints\\FormatTest\:\:getValidTests\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: tests/Constraints/FormatTest.php
+
+		-
+			message: '#^Method JsonSchema\\Tests\\Constraints\\FormatTest\:\:testDisabledFormat\(\) has parameter \$format with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: tests/Constraints/FormatTest.php
+
+		-
+			message: '#^Method JsonSchema\\Tests\\Constraints\\FormatTest\:\:testDisabledFormat\(\) has parameter \$string with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: tests/Constraints/FormatTest.php
+
+		-
+			message: '#^Method JsonSchema\\Tests\\Constraints\\FormatTest\:\:testInvalidFormat\(\) has parameter \$format with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: tests/Constraints/FormatTest.php
+
+		-
+			message: '#^Method JsonSchema\\Tests\\Constraints\\FormatTest\:\:testInvalidFormat\(\) has parameter \$string with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: tests/Constraints/FormatTest.php
+
+		-
+			message: '#^Method JsonSchema\\Tests\\Constraints\\FormatTest\:\:testValidFormat\(\) has parameter \$format with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: tests/Constraints/FormatTest.php
+
+		-
+			message: '#^Method JsonSchema\\Tests\\Constraints\\FormatTest\:\:testValidFormat\(\) has parameter \$string with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: tests/Constraints/FormatTest.php
+
+		-
+			message: '#^Property JsonSchema\\Tests\\Constraints\\FormatTest\:\:\$validateSchema has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: tests/Constraints/FormatTest.php
+
+		-
+			message: '#^Parameter \#1 \$json of function json_decode expects string, string\|false given\.$#'
+			identifier: argument.type
+			count: 3
+			path: tests/Constraints/LongArraysTest.php
+
+		-
+			message: '#^Parameter \#1 \$uriRetriever of class JsonSchema\\SchemaStorage constructor expects JsonSchema\\UriRetrieverInterface\|null, object given\.$#'
+			identifier: argument.type
+			count: 3
+			path: tests/Constraints/LongArraysTest.php
+
+		-
+			message: '#^Property JsonSchema\\Tests\\Constraints\\LongArraysTest\:\:\$validateSchema has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: tests/Constraints/LongArraysTest.php
+
+		-
+			message: '#^Method JsonSchema\\Tests\\Constraints\\MinItemsMaxItemsTest\:\:getInvalidTests\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: tests/Constraints/MinItemsMaxItemsTest.php
+
+		-
+			message: '#^Method JsonSchema\\Tests\\Constraints\\MinItemsMaxItemsTest\:\:getValidTests\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: tests/Constraints/MinItemsMaxItemsTest.php
+
+		-
+			message: '#^Property JsonSchema\\Tests\\Constraints\\MinItemsMaxItemsTest\:\:\$validateSchema has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: tests/Constraints/MinItemsMaxItemsTest.php
+
+		-
+			message: '#^Method JsonSchema\\Tests\\Constraints\\MinLengthMaxLengthMultiByteTest\:\:getInvalidTests\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: tests/Constraints/MinLengthMaxLengthMultiByteTest.php
+
+		-
+			message: '#^Method JsonSchema\\Tests\\Constraints\\MinLengthMaxLengthMultiByteTest\:\:getValidTests\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: tests/Constraints/MinLengthMaxLengthMultiByteTest.php
+
+		-
+			message: '#^Property JsonSchema\\Tests\\Constraints\\MinLengthMaxLengthMultiByteTest\:\:\$validateSchema has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: tests/Constraints/MinLengthMaxLengthMultiByteTest.php
+
+		-
+			message: '#^Method JsonSchema\\Tests\\Constraints\\MinLengthMaxLengthTest\:\:getInvalidTests\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: tests/Constraints/MinLengthMaxLengthTest.php
+
+		-
+			message: '#^Method JsonSchema\\Tests\\Constraints\\MinLengthMaxLengthTest\:\:getValidTests\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: tests/Constraints/MinLengthMaxLengthTest.php
+
+		-
+			message: '#^Property JsonSchema\\Tests\\Constraints\\MinLengthMaxLengthTest\:\:\$validateSchema has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: tests/Constraints/MinLengthMaxLengthTest.php
+
+		-
+			message: '#^Method JsonSchema\\Tests\\Constraints\\MinMaxPropertiesTest\:\:getInvalidTests\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: tests/Constraints/MinMaxPropertiesTest.php
+
+		-
+			message: '#^Method JsonSchema\\Tests\\Constraints\\MinMaxPropertiesTest\:\:getValidTests\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: tests/Constraints/MinMaxPropertiesTest.php
+
+		-
+			message: '#^Property JsonSchema\\Tests\\Constraints\\MinMaxPropertiesTest\:\:\$validateSchema has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: tests/Constraints/MinMaxPropertiesTest.php
+
+		-
+			message: '#^Method JsonSchema\\Tests\\Constraints\\MinimumMaximumTest\:\:getInvalidTests\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: tests/Constraints/MinimumMaximumTest.php
+
+		-
+			message: '#^Method JsonSchema\\Tests\\Constraints\\MinimumMaximumTest\:\:getValidTests\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: tests/Constraints/MinimumMaximumTest.php
+
+		-
+			message: '#^Property JsonSchema\\Tests\\Constraints\\MinimumMaximumTest\:\:\$validateSchema has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: tests/Constraints/MinimumMaximumTest.php
+
+		-
+			message: '#^Method JsonSchema\\Tests\\Constraints\\NotTest\:\:getInvalidTests\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: tests/Constraints/NotTest.php
+
+		-
+			message: '#^Method JsonSchema\\Tests\\Constraints\\NotTest\:\:getValidTests\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: tests/Constraints/NotTest.php
+
+		-
+			message: '#^Property JsonSchema\\Tests\\Constraints\\NotTest\:\:\$validateSchema has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: tests/Constraints/NotTest.php
+
+		-
+			message: '#^Method JsonSchema\\Tests\\Constraints\\NumberAndIntegerTypesTest\:\:getInvalidTests\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: tests/Constraints/NumberAndIntegerTypesTest.php
+
+		-
+			message: '#^Method JsonSchema\\Tests\\Constraints\\NumberAndIntegerTypesTest\:\:getValidTests\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: tests/Constraints/NumberAndIntegerTypesTest.php
+
+		-
+			message: '#^Property JsonSchema\\Tests\\Constraints\\NumberAndIntegerTypesTest\:\:\$validateSchema has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: tests/Constraints/NumberAndIntegerTypesTest.php
+
+		-
+			message: '#^Method JsonSchema\\Tests\\Constraints\\OfPropertiesTest\:\:getInvalidTests\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: tests/Constraints/OfPropertiesTest.php
+
+		-
+			message: '#^Method JsonSchema\\Tests\\Constraints\\OfPropertiesTest\:\:getValidTests\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: tests/Constraints/OfPropertiesTest.php
+
+		-
+			message: '#^Property JsonSchema\\Tests\\Constraints\\OfPropertiesTest\:\:\$validateSchema has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: tests/Constraints/OfPropertiesTest.php
+
+		-
+			message: '#^Method JsonSchema\\Tests\\Constraints\\PatternPropertiesTest\:\:getInvalidTests\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: tests/Constraints/PatternPropertiesTest.php
+
+		-
+			message: '#^Method JsonSchema\\Tests\\Constraints\\PatternPropertiesTest\:\:getValidTests\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: tests/Constraints/PatternPropertiesTest.php
+
+		-
+			message: '#^Property JsonSchema\\Tests\\Constraints\\PatternPropertiesTest\:\:\$validateSchema has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: tests/Constraints/PatternPropertiesTest.php
+
+		-
+			message: '#^Method JsonSchema\\Tests\\Constraints\\PatternTest\:\:getInvalidTests\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: tests/Constraints/PatternTest.php
+
+		-
+			message: '#^Method JsonSchema\\Tests\\Constraints\\PatternTest\:\:getValidTests\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: tests/Constraints/PatternTest.php
+
+		-
+			message: '#^Property JsonSchema\\Tests\\Constraints\\PatternTest\:\:\$validateSchema has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: tests/Constraints/PatternTest.php
+
+		-
+			message: '#^Parameter \#1 \$json of function json_decode expects string, string\|false given\.$#'
+			identifier: argument.type
+			count: 2
+			path: tests/Constraints/PointerTest.php
+
+		-
+			message: '#^Property JsonSchema\\Tests\\Constraints\\PointerTest\:\:\$validateSchema has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: tests/Constraints/PointerTest.php
+
+		-
+			message: '#^Method JsonSchema\\Tests\\Constraints\\ReadOnlyTest\:\:getInvalidTests\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: tests/Constraints/ReadOnlyTest.php
+
+		-
+			message: '#^Method JsonSchema\\Tests\\Constraints\\ReadOnlyTest\:\:getValidTests\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: tests/Constraints/ReadOnlyTest.php
+
+		-
+			message: '#^Property JsonSchema\\Tests\\Constraints\\ReadOnlyTest\:\:\$validateSchema has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: tests/Constraints/ReadOnlyTest.php
+
+		-
+			message: '#^Method JsonSchema\\Tests\\Constraints\\RequireTest\:\:getInvalidTests\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: tests/Constraints/RequireTest.php
+
+		-
+			message: '#^Method JsonSchema\\Tests\\Constraints\\RequireTest\:\:getValidTests\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: tests/Constraints/RequireTest.php
+
+		-
+			message: '#^Property JsonSchema\\Tests\\Constraints\\RequireTest\:\:\$validateSchema has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: tests/Constraints/RequireTest.php
+
+		-
+			message: '#^Cannot access offset 0 on mixed\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: tests/Constraints/RequiredPropertyTest.php
+
+		-
+			message: '#^Method JsonSchema\\Tests\\Constraints\\RequiredPropertyTest\:\:assertErrorHasExpectedPropertyValue\(\) has parameter \$error with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: tests/Constraints/RequiredPropertyTest.php
+
+		-
+			message: '#^Method JsonSchema\\Tests\\Constraints\\RequiredPropertyTest\:\:assertErrorHasExpectedPropertyValue\(\) has parameter \$propertyValue with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: tests/Constraints/RequiredPropertyTest.php
+
+		-
+			message: '#^Method JsonSchema\\Tests\\Constraints\\RequiredPropertyTest\:\:getInvalidTests\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: tests/Constraints/RequiredPropertyTest.php
+
+		-
+			message: '#^Method JsonSchema\\Tests\\Constraints\\RequiredPropertyTest\:\:getValidTests\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: tests/Constraints/RequiredPropertyTest.php
+
+		-
+			message: '#^Property JsonSchema\\Tests\\Constraints\\RequiredPropertyTest\:\:\$schemaSpec has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: tests/Constraints/RequiredPropertyTest.php
+
+		-
+			message: '#^Property JsonSchema\\Tests\\Constraints\\RequiredPropertyTest\:\:\$validateSchema has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: tests/Constraints/RequiredPropertyTest.php
+
+		-
+			message: '#^Cannot access offset ''context'' on mixed\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: tests/Constraints/SchemaValidationTest.php
+
+		-
+			message: '#^Method JsonSchema\\Tests\\Constraints\\SchemaValidationTest\:\:getInvalidTests\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: tests/Constraints/SchemaValidationTest.php
+
+		-
+			message: '#^Method JsonSchema\\Tests\\Constraints\\SchemaValidationTest\:\:getValidTests\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: tests/Constraints/SchemaValidationTest.php
+
+		-
+			message: '#^Method JsonSchema\\Tests\\Constraints\\SchemaValidationTest\:\:testInvalidCases\(\) has parameter \$schema with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: tests/Constraints/SchemaValidationTest.php
+
+		-
+			message: '#^Method JsonSchema\\Tests\\Constraints\\SchemaValidationTest\:\:testValidCases\(\) has parameter \$schema with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: tests/Constraints/SchemaValidationTest.php
+
+		-
+			message: '#^Parameter \#1 \$json of function json_decode expects string, mixed given\.$#'
+			identifier: argument.type
+			count: 2
+			path: tests/Constraints/SchemaValidationTest.php
+
+		-
+			message: '#^Property JsonSchema\\Tests\\Constraints\\SchemaValidationTest\:\:\$validateSchema has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: tests/Constraints/SchemaValidationTest.php
+
+		-
+			message: '#^Method JsonSchema\\Tests\\Constraints\\SelfDefinedSchemaTest\:\:getInvalidTests\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: tests/Constraints/SelfDefinedSchemaTest.php
+
+		-
+			message: '#^Method JsonSchema\\Tests\\Constraints\\SelfDefinedSchemaTest\:\:getValidTests\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: tests/Constraints/SelfDefinedSchemaTest.php
+
+		-
+			message: '#^Property JsonSchema\\Tests\\Constraints\\SelfDefinedSchemaTest\:\:\$validateSchema has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: tests/Constraints/SelfDefinedSchemaTest.php
+
+		-
+			message: '#^Method JsonSchema\\Tests\\Constraints\\TupleTypingTest\:\:getInvalidTests\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: tests/Constraints/TupleTypingTest.php
+
+		-
+			message: '#^Method JsonSchema\\Tests\\Constraints\\TupleTypingTest\:\:getValidTests\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: tests/Constraints/TupleTypingTest.php
+
+		-
+			message: '#^Property JsonSchema\\Tests\\Constraints\\TupleTypingTest\:\:\$validateSchema has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: tests/Constraints/TupleTypingTest.php
+
+		-
+			message: '#^Cannot access property \$property on mixed\.$#'
+			identifier: property.nonObject
+			count: 1
+			path: tests/Constraints/TypeTest.php
+
+		-
+			message: '#^Method JsonSchema\\Tests\\Constraints\\TypeTest\:\:provideIndefiniteArticlesForTypes\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: tests/Constraints/TypeTest.php
+
+		-
+			message: '#^Method JsonSchema\\Tests\\Constraints\\TypeTest\:\:testIndefiniteArticleForTypeInTypeCheckErrorMessage\(\) has parameter \$label with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: tests/Constraints/TypeTest.php
+
+		-
+			message: '#^Method JsonSchema\\Tests\\Constraints\\TypeTest\:\:testIndefiniteArticleForTypeInTypeCheckErrorMessage\(\) has parameter \$type with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: tests/Constraints/TypeTest.php
+
+		-
+			message: '#^Method JsonSchema\\Tests\\Constraints\\TypeTest\:\:testIndefiniteArticleForTypeInTypeCheckErrorMessage\(\) has parameter \$value with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: tests/Constraints/TypeTest.php
+
+		-
+			message: '#^Method JsonSchema\\Tests\\Constraints\\TypeTest\:\:testIndefiniteArticleForTypeInTypeCheckErrorMessage\(\) has parameter \$wording with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: tests/Constraints/TypeTest.php
+
+		-
+			message: '#^Method JsonSchema\\Tests\\Constraints\\TypeTest\:\:testValidateTypeNameWording\(\) has parameter \$nameWording with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: tests/Constraints/TypeTest.php
+
+		-
+			message: '#^Method JsonSchema\\Tests\\Constraints\\TypeTest\:\:validNameWordingDataProvider\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: tests/Constraints/TypeTest.php
+
+		-
+			message: '#^Parameter \#1 \$str of function ucwords expects string, mixed given\.$#'
+			identifier: argument.type
+			count: 1
+			path: tests/Constraints/TypeTest.php
+
+		-
+			message: '#^Part \$wording \(mixed\) of encapsed string cannot be cast to string\.$#'
+			identifier: encapsedStringPart.nonString
+			count: 1
+			path: tests/Constraints/TypeTest.php
+
+		-
+			message: '#^Method JsonSchema\\Tests\\Constraints\\UnionTypesTest\:\:getInvalidTests\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: tests/Constraints/UnionTypesTest.php
+
+		-
+			message: '#^Method JsonSchema\\Tests\\Constraints\\UnionTypesTest\:\:getValidTests\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: tests/Constraints/UnionTypesTest.php
+
+		-
+			message: '#^Property JsonSchema\\Tests\\Constraints\\UnionTypesTest\:\:\$validateSchema has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: tests/Constraints/UnionTypesTest.php
+
+		-
+			message: '#^Method JsonSchema\\Tests\\Constraints\\UnionWithNullValueTest\:\:getInvalidTests\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: tests/Constraints/UnionWithNullValueTest.php
+
+		-
+			message: '#^Method JsonSchema\\Tests\\Constraints\\UnionWithNullValueTest\:\:getValidTests\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: tests/Constraints/UnionWithNullValueTest.php
+
+		-
+			message: '#^Property JsonSchema\\Tests\\Constraints\\UnionWithNullValueTest\:\:\$validateSchema has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: tests/Constraints/UnionWithNullValueTest.php
+
+		-
+			message: '#^Method JsonSchema\\Tests\\Constraints\\UniqueItemsTest\:\:getInvalidTests\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: tests/Constraints/UniqueItemsTest.php
+
+		-
+			message: '#^Method JsonSchema\\Tests\\Constraints\\UniqueItemsTest\:\:getValidTests\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: tests/Constraints/UniqueItemsTest.php
+
+		-
+			message: '#^Property JsonSchema\\Tests\\Constraints\\UniqueItemsTest\:\:\$validateSchema has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: tests/Constraints/UniqueItemsTest.php
+
+		-
+			message: '#^Call to an undefined method Prophecy\\Prophecy\\ObjectProphecy\:\:retrieve\(\)\.$#'
+			identifier: method.notFound
+			count: 2
+			path: tests/Constraints/VeryBaseTestCase.php
+
+		-
+			message: '#^Cannot access offset ''path'' on array\{scheme\?\: string, host\?\: string, port\?\: int\<0, 65535\>, user\?\: string, pass\?\: string, path\?\: string, query\?\: string, fragment\?\: string\}\|false\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 2
+			path: tests/Constraints/VeryBaseTestCase.php
+
+		-
+			message: '#^Cannot access offset 0 on mixed\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: tests/Constraints/VeryBaseTestCase.php
+
+		-
+			message: '#^Cannot call method shouldBeCalled\(\) on mixed\.$#'
+			identifier: method.nonObject
+			count: 1
+			path: tests/Constraints/VeryBaseTestCase.php
+
+		-
+			message: '#^Cannot call method will\(\) on mixed\.$#'
+			identifier: method.nonObject
+			count: 1
+			path: tests/Constraints/VeryBaseTestCase.php
+
+		-
+			message: '#^Cannot call method willReturn\(\) on mixed\.$#'
+			identifier: method.nonObject
+			count: 1
+			path: tests/Constraints/VeryBaseTestCase.php
+
+		-
+			message: '#^Negated boolean expression is always false\.$#'
+			identifier: booleanNot.alwaysFalse
+			count: 2
+			path: tests/Constraints/VeryBaseTestCase.php
+
+		-
+			message: '#^Parameter \#1 \$haystack of function strpos expects string, mixed given\.$#'
+			identifier: argument.type
+			count: 2
+			path: tests/Constraints/VeryBaseTestCase.php
+
+		-
+			message: '#^Parameter \#1 \$json of function json_decode expects string, string\|false given\.$#'
+			identifier: argument.type
+			count: 4
+			path: tests/Constraints/VeryBaseTestCase.php
+
+		-
+			message: '#^Parameter \#1 \$url of function parse_url expects string, mixed given\.$#'
+			identifier: argument.type
+			count: 2
+			path: tests/Constraints/VeryBaseTestCase.php
+
+		-
+			message: '#^Property JsonSchema\\Tests\\Constraints\\VeryBaseTestCase\:\:\$jsonSchemaDraft03 \(object\) does not accept mixed\.$#'
+			identifier: assign.propertyType
+			count: 1
+			path: tests/Constraints/VeryBaseTestCase.php
+
+		-
+			message: '#^Property JsonSchema\\Tests\\Constraints\\VeryBaseTestCase\:\:\$jsonSchemaDraft04 \(object\) does not accept mixed\.$#'
+			identifier: assign.propertyType
+			count: 1
+			path: tests/Constraints/VeryBaseTestCase.php
+
+		-
+			message: '#^Method JsonSchema\\Tests\\Constraints\\WrongMessagesFailingTestCaseTest\:\:getInvalidTests\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: tests/Constraints/WrongMessagesFailingTestCaseTest.php
+
+		-
+			message: '#^Method JsonSchema\\Tests\\Constraints\\WrongMessagesFailingTestCaseTest\:\:getValidTests\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: tests/Constraints/WrongMessagesFailingTestCaseTest.php
+
+		-
+			message: '#^Property JsonSchema\\Tests\\Constraints\\WrongMessagesFailingTestCaseTest\:\:\$validateSchema has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: tests/Constraints/WrongMessagesFailingTestCaseTest.php
+
+		-
+			message: '#^Argument of an invalid type list\<string\>\|false supplied for foreach, only iterables are supported\.$#'
+			identifier: foreach.nonIterable
+			count: 1
+			path: tests/Drafts/BaseDraftTestCase.php
+
+		-
+			message: '#^Argument of an invalid type mixed supplied for foreach, only iterables are supported\.$#'
+			identifier: foreach.nonIterable
+			count: 2
+			path: tests/Drafts/BaseDraftTestCase.php
+
+		-
+			message: '#^Cannot access property \$data on mixed\.$#'
+			identifier: property.nonObject
+			count: 1
+			path: tests/Drafts/BaseDraftTestCase.php
+
+		-
+			message: '#^Cannot access property \$description on mixed\.$#'
+			identifier: property.nonObject
+			count: 2
+			path: tests/Drafts/BaseDraftTestCase.php
+
+		-
+			message: '#^Cannot access property \$schema on mixed\.$#'
+			identifier: property.nonObject
+			count: 1
+			path: tests/Drafts/BaseDraftTestCase.php
+
+		-
+			message: '#^Cannot access property \$tests on mixed\.$#'
+			identifier: property.nonObject
+			count: 1
+			path: tests/Drafts/BaseDraftTestCase.php
+
+		-
+			message: '#^Cannot access property \$valid on mixed\.$#'
+			identifier: property.nonObject
+			count: 1
+			path: tests/Drafts/BaseDraftTestCase.php
+
+		-
+			message: '#^Method JsonSchema\\Tests\\Drafts\\BaseDraftTestCase\:\:getInvalidTests\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: tests/Drafts/BaseDraftTestCase.php
+
+		-
+			message: '#^Method JsonSchema\\Tests\\Drafts\\BaseDraftTestCase\:\:getValidTests\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: tests/Drafts/BaseDraftTestCase.php
+
+		-
+			message: '#^Method JsonSchema\\Tests\\Drafts\\BaseDraftTestCase\:\:setUpTests\(\) has parameter \$isValid with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: tests/Drafts/BaseDraftTestCase.php
+
+		-
+			message: '#^Method JsonSchema\\Tests\\Drafts\\BaseDraftTestCase\:\:setUpTests\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: tests/Drafts/BaseDraftTestCase.php
+
+		-
+			message: '#^Parameter \#1 \$json of function json_decode expects string, string\|false given\.$#'
+			identifier: argument.type
+			count: 1
+			path: tests/Drafts/BaseDraftTestCase.php
+
+		-
+			message: '#^Parameter \#2 \$suiteDesc of method JsonSchema\\Tests\\Drafts\\BaseDraftTestCase\:\:createDataSetPath\(\) expects string, mixed given\.$#'
+			identifier: argument.type
+			count: 1
+			path: tests/Drafts/BaseDraftTestCase.php
+
+		-
+			message: '#^Parameter \#3 \$testCaseDesc of method JsonSchema\\Tests\\Drafts\\BaseDraftTestCase\:\:createDataSetPath\(\) expects string, mixed given\.$#'
+			identifier: argument.type
+			count: 1
+			path: tests/Drafts/BaseDraftTestCase.php
+
+		-
+			message: '#^Method JsonSchema\\Tests\\Drafts\\Draft3Test\:\:getFilePaths\(\) should return array\<string\> but returns array\<int, string\|false\>\.$#'
+			identifier: return.type
+			count: 1
+			path: tests/Drafts/Draft3Test.php
+
+		-
+			message: '#^Method JsonSchema\\Tests\\Drafts\\Draft3Test\:\:getInvalidForAssocTests\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: tests/Drafts/Draft3Test.php
+
+		-
+			message: '#^Method JsonSchema\\Tests\\Drafts\\Draft3Test\:\:getValidForAssocTests\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: tests/Drafts/Draft3Test.php
+
+		-
+			message: '#^Property JsonSchema\\Tests\\Drafts\\Draft3Test\:\:\$schemaSpec has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: tests/Drafts/Draft3Test.php
+
+		-
+			message: '#^Property JsonSchema\\Tests\\Drafts\\Draft3Test\:\:\$validateSchema has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: tests/Drafts/Draft3Test.php
+
+		-
+			message: '#^Method JsonSchema\\Tests\\Drafts\\Draft4Test\:\:getFilePaths\(\) should return array\<string\> but returns array\<int, string\|false\>\.$#'
+			identifier: return.type
+			count: 1
+			path: tests/Drafts/Draft4Test.php
+
+		-
+			message: '#^Method JsonSchema\\Tests\\Drafts\\Draft4Test\:\:getInvalidForAssocTests\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: tests/Drafts/Draft4Test.php
+
+		-
+			message: '#^Method JsonSchema\\Tests\\Drafts\\Draft4Test\:\:getValidForAssocTests\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: tests/Drafts/Draft4Test.php
+
+		-
+			message: '#^Property JsonSchema\\Tests\\Drafts\\Draft4Test\:\:\$schemaSpec has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: tests/Drafts/Draft4Test.php
+
+		-
+			message: '#^Property JsonSchema\\Tests\\Drafts\\Draft4Test\:\:\$validateSchema has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: tests/Drafts/Draft4Test.php
+
+		-
+			message: '#^Method JsonSchema\\Tests\\Entity\\JsonPointerTest\:\:testJsonPointer\(\) has parameter \$expectedPropertyPaths with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: tests/Entity/JsonPointerTest.php
+
+		-
+			message: '#^Parameter \#1 \$value of class JsonSchema\\Entity\\JsonPointer constructor expects string, null given\.$#'
+			identifier: argument.type
+			count: 1
+			path: tests/Entity/JsonPointerTest.php
+
+		-
+			message: '#^Method JsonSchema\\Tests\\Exception\\JsonDecodingExceptionTest\:\:testDefaultMessage\(\) has no return type specified\.$#'
+			identifier: missingType.return
+			count: 1
+			path: tests/Exception/JsonDecodingExceptionTest.php
+
+		-
+			message: '#^Method JsonSchema\\Tests\\Exception\\JsonDecodingExceptionTest\:\:testErrorControlCharacterMessage\(\) has no return type specified\.$#'
+			identifier: missingType.return
+			count: 1
+			path: tests/Exception/JsonDecodingExceptionTest.php
+
+		-
+			message: '#^Method JsonSchema\\Tests\\Exception\\JsonDecodingExceptionTest\:\:testErrorDepthMessage\(\) has no return type specified\.$#'
+			identifier: missingType.return
+			count: 1
+			path: tests/Exception/JsonDecodingExceptionTest.php
+
+		-
+			message: '#^Method JsonSchema\\Tests\\Exception\\JsonDecodingExceptionTest\:\:testErrorInfiniteOrNotANumberMessage\(\) has no return type specified\.$#'
+			identifier: missingType.return
+			count: 1
+			path: tests/Exception/JsonDecodingExceptionTest.php
+
+		-
+			message: '#^Method JsonSchema\\Tests\\Exception\\JsonDecodingExceptionTest\:\:testErrorNoneMessage\(\) has no return type specified\.$#'
+			identifier: missingType.return
+			count: 1
+			path: tests/Exception/JsonDecodingExceptionTest.php
+
+		-
+			message: '#^Method JsonSchema\\Tests\\Exception\\JsonDecodingExceptionTest\:\:testErrorRecursionMessage\(\) has no return type specified\.$#'
+			identifier: missingType.return
+			count: 1
+			path: tests/Exception/JsonDecodingExceptionTest.php
+
+		-
+			message: '#^Method JsonSchema\\Tests\\Exception\\JsonDecodingExceptionTest\:\:testErrorStateMismatchMessage\(\) has no return type specified\.$#'
+			identifier: missingType.return
+			count: 1
+			path: tests/Exception/JsonDecodingExceptionTest.php
+
+		-
+			message: '#^Method JsonSchema\\Tests\\Exception\\JsonDecodingExceptionTest\:\:testErrorSyntaxMessage\(\) has no return type specified\.$#'
+			identifier: missingType.return
+			count: 1
+			path: tests/Exception/JsonDecodingExceptionTest.php
+
+		-
+			message: '#^Method JsonSchema\\Tests\\Exception\\JsonDecodingExceptionTest\:\:testErrorUnsupportedTypeMessage\(\) has no return type specified\.$#'
+			identifier: missingType.return
+			count: 1
+			path: tests/Exception/JsonDecodingExceptionTest.php
+
+		-
+			message: '#^Method JsonSchema\\Tests\\Exception\\JsonDecodingExceptionTest\:\:testErrorUtf8Message\(\) has no return type specified\.$#'
+			identifier: missingType.return
+			count: 1
+			path: tests/Exception/JsonDecodingExceptionTest.php
+
+		-
+			message: '#^Cannot access property \$subThree on mixed\.$#'
+			identifier: property.nonObject
+			count: 1
+			path: tests/Iterators/ObjectIteratorTest.php
+
+		-
+			message: '#^Cannot access property \$subTwo on mixed\.$#'
+			identifier: property.nonObject
+			count: 1
+			path: tests/Iterators/ObjectIteratorTest.php
+
+		-
+			message: '#^Parameter \#1 \$obj of function get_object_vars expects object, mixed given\.$#'
+			identifier: argument.type
+			count: 1
+			path: tests/Iterators/ObjectIteratorTest.php
+
+		-
+			message: '#^Parameter \#1 \$object of class JsonSchema\\Iterator\\ObjectIterator constructor expects object, mixed given\.$#'
+			identifier: argument.type
+			count: 6
+			path: tests/Iterators/ObjectIteratorTest.php
+
+		-
+			message: '#^Property JsonSchema\\Tests\\Iterators\\ObjectIteratorTest\:\:\$testObject has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: tests/Iterators/ObjectIteratorTest.php
+
+		-
+			message: '#^Method JsonSchema\\Tests\\RefTest\:\:dataRefIgnoresSiblings\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: tests/RefTest.php
+
+		-
+			message: '#^Method JsonSchema\\Tests\\RefTest\:\:testRefIgnoresSiblings\(\) has parameter \$document with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: tests/RefTest.php
+
+		-
+			message: '#^Method JsonSchema\\Tests\\RefTest\:\:testRefIgnoresSiblings\(\) has parameter \$exception with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: tests/RefTest.php
+
+		-
+			message: '#^Method JsonSchema\\Tests\\RefTest\:\:testRefIgnoresSiblings\(\) has parameter \$isValid with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: tests/RefTest.php
+
+		-
+			message: '#^Method JsonSchema\\Tests\\RefTest\:\:testRefIgnoresSiblings\(\) has parameter \$schema with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: tests/RefTest.php
+
+		-
+			message: '#^Parameter \#1 \$exception of method PHPUnit\\Framework\\TestCase\:\:expectException\(\) expects class\-string\<Throwable\>, mixed given\.$#'
+			identifier: argument.type
+			count: 1
+			path: tests/RefTest.php
+
+		-
+			message: '#^Parameter \#1 \$json of function json_decode expects string, mixed given\.$#'
+			identifier: argument.type
+			count: 2
+			path: tests/RefTest.php
+
+		-
+			message: '#^Access to an undefined property object\:\:\$properties\.$#'
+			identifier: property.notFound
+			count: 3
+			path: tests/SchemaStorageTest.php
+
+		-
+			message: '#^Call to an undefined method JsonSchema\\Uri\\UriRetriever\:\:reveal\(\)\.$#'
+			identifier: method.notFound
+			count: 1
+			path: tests/SchemaStorageTest.php
+
+		-
+			message: '#^Call to an undefined method Prophecy\\Prophecy\\ObjectProphecy\:\:retrieve\(\)\.$#'
+			identifier: method.notFound
+			count: 3
+			path: tests/SchemaStorageTest.php
+
+		-
+			message: '#^Call to an undefined method object\:\:willReturn\(\)\.$#'
+			identifier: method.notFound
+			count: 3
+			path: tests/SchemaStorageTest.php
+
+		-
+			message: '#^Cannot access offset ''test/schema'' on mixed\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: tests/SchemaStorageTest.php
+
+		-
+			message: '#^Cannot access property \$\$ref on mixed\.$#'
+			identifier: property.nonObject
+			count: 2
+			path: tests/SchemaStorageTest.php
+
+		-
+			message: '#^Cannot access property \$format on mixed\.$#'
+			identifier: property.nonObject
+			count: 3
+			path: tests/SchemaStorageTest.php
+
+		-
+			message: '#^Cannot access property \$id on mixed\.$#'
+			identifier: property.nonObject
+			count: 2
+			path: tests/SchemaStorageTest.php
+
+		-
+			message: '#^Cannot call method shouldBeCalled\(\) on mixed\.$#'
+			identifier: method.nonObject
+			count: 6
+			path: tests/SchemaStorageTest.php
+
+		-
+			message: '#^Cannot call method willReturn\(\) on mixed\.$#'
+			identifier: method.nonObject
+			count: 3
+			path: tests/SchemaStorageTest.php
+
+		-
+			message: '#^PHPDoc tag @var with type JsonSchema\\Uri\\UriRetriever is not subtype of native type Prophecy\\Prophecy\\ObjectProphecy\.$#'
+			identifier: varTag.nativeType
+			count: 1
+			path: tests/SchemaStorageTest.php
+
+		-
+			message: '#^Parameter \#1 \$uriRetriever of class JsonSchema\\SchemaStorage constructor expects JsonSchema\\UriRetrieverInterface\|null, mixed given\.$#'
+			identifier: argument.type
+			count: 1
+			path: tests/SchemaStorageTest.php
+
+		-
+			message: '#^Parameter \#1 \$uriRetriever of class JsonSchema\\SchemaStorage constructor expects JsonSchema\\UriRetrieverInterface\|null, object given\.$#'
+			identifier: argument.type
+			count: 3
+			path: tests/SchemaStorageTest.php
+
+		-
+			message: '#^Function JsonSchema\\Uri\\Retrievers\\curl_exec\(\) has no return type specified\.$#'
+			identifier: missingType.return
+			count: 1
+			path: tests/Uri/Retrievers/CurlTest.php
+
+		-
+			message: '#^Function JsonSchema\\Uri\\Retrievers\\curl_exec\(\) has parameter \$curl with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: tests/Uri/Retrievers/CurlTest.php
+
+		-
+			message: '#^Parameter \#1 \$ch of function curl_exec expects resource, mixed given\.$#'
+			identifier: argument.type
+			count: 1
+			path: tests/Uri/Retrievers/CurlTest.php
+
+		-
+			message: '#^Parameter \#1 \$ch of function curl_getinfo expects resource, mixed given\.$#'
+			identifier: argument.type
+			count: 1
+			path: tests/Uri/Retrievers/CurlTest.php
+
+		-
+			message: '#^Parameter \#1 \$expectedFile of static method PHPUnit\\Framework\\Assert\:\:assertStringEqualsFileCanonicalizing\(\) expects string, string\|false given\.$#'
+			identifier: argument.type
+			count: 2
+			path: tests/Uri/Retrievers/CurlTest.php
+
+		-
+			message: '#^Parameter \#1 \$filename of function file_get_contents expects string, string\|false given\.$#'
+			identifier: argument.type
+			count: 1
+			path: tests/Uri/Retrievers/CurlTest.php
+
+		-
+			message: '#^Parameter \#1 \$uri of method JsonSchema\\Uri\\Retrievers\\Curl\:\:retrieve\(\) expects string, string\|false given\.$#'
+			identifier: argument.type
+			count: 1
+			path: tests/Uri/Retrievers/CurlTest.php
+
+		-
+			message: '#^Parameter \#2 \$actualString of static method PHPUnit\\Framework\\Assert\:\:assertStringEqualsFileCanonicalizing\(\) expects string, mixed given\.$#'
+			identifier: argument.type
+			count: 2
+			path: tests/Uri/Retrievers/CurlTest.php
+
+		-
+			message: '#^Cannot call method getContentType\(\) on mixed\.$#'
+			identifier: method.nonObject
+			count: 1
+			path: tests/Uri/Retrievers/PredefinedArrayTest.php
+
+		-
+			message: '#^Cannot call method retrieve\(\) on mixed\.$#'
+			identifier: method.nonObject
+			count: 3
+			path: tests/Uri/Retrievers/PredefinedArrayTest.php
+
+		-
+			message: '#^Property JsonSchema\\Tests\\Uri\\Retrievers\\PredefinedArrayTest\:\:\$retriever has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: tests/Uri/Retrievers/PredefinedArrayTest.php
+
+		-
+			message: '#^Cannot access offset ''extends'' on mixed\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: tests/Uri/UriRetrieverTest.php
+
+		-
+			message: '#^Cannot call method isValid\(\) on mixed\.$#'
+			identifier: method.nonObject
+			count: 4
+			path: tests/Uri/UriRetrieverTest.php
+
+		-
+			message: '#^Cannot call method validate\(\) on mixed\.$#'
+			identifier: method.nonObject
+			count: 4
+			path: tests/Uri/UriRetrieverTest.php
+
+		-
+			message: '#^Method JsonSchema\\Tests\\Uri\\UriRetrieverTest\:\:combinedURITests\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: tests/Uri/UriRetrieverTest.php
+
+		-
+			message: '#^Method JsonSchema\\Tests\\Uri\\UriRetrieverTest\:\:getRetrieverMock\(\) has no return type specified\.$#'
+			identifier: missingType.return
+			count: 1
+			path: tests/Uri/UriRetrieverTest.php
+
+		-
+			message: '#^Method JsonSchema\\Tests\\Uri\\UriRetrieverTest\:\:getRetrieverMock\(\) has parameter \$returnSchema with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: tests/Uri/UriRetrieverTest.php
+
+		-
+			message: '#^Method JsonSchema\\Tests\\Uri\\UriRetrieverTest\:\:jsonProvider\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: tests/Uri/UriRetrieverTest.php
+
+		-
+			message: '#^Method JsonSchema\\Tests\\Uri\\UriRetrieverTest\:\:mockRetriever\(\) has parameter \$schema with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: tests/Uri/UriRetrieverTest.php
+
+		-
+			message: '#^Method JsonSchema\\Tests\\Uri\\UriRetrieverTest\:\:setParentSchemaExtendsValue\(\) has parameter \$parentSchema with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: tests/Uri/UriRetrieverTest.php
+
+		-
+			message: '#^Method JsonSchema\\Tests\\Uri\\UriRetrieverTest\:\:setParentSchemaExtendsValue\(\) has parameter \$value with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: tests/Uri/UriRetrieverTest.php
+
+		-
+			message: '#^Method JsonSchema\\Tests\\Uri\\UriRetrieverTest\:\:testChildExtendsParentInvalidChildTest\(\) has parameter \$childSchema with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: tests/Uri/UriRetrieverTest.php
+
+		-
+			message: '#^Method JsonSchema\\Tests\\Uri\\UriRetrieverTest\:\:testChildExtendsParentInvalidChildTest\(\) has parameter \$parentSchema with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: tests/Uri/UriRetrieverTest.php
+
+		-
+			message: '#^Method JsonSchema\\Tests\\Uri\\UriRetrieverTest\:\:testChildExtendsParentInvalidParentTest\(\) has parameter \$childSchema with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: tests/Uri/UriRetrieverTest.php
+
+		-
+			message: '#^Method JsonSchema\\Tests\\Uri\\UriRetrieverTest\:\:testChildExtendsParentInvalidParentTest\(\) has parameter \$parentSchema with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: tests/Uri/UriRetrieverTest.php
+
+		-
+			message: '#^Method JsonSchema\\Tests\\Uri\\UriRetrieverTest\:\:testChildExtendsParentValidTest\(\) has parameter \$childSchema with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: tests/Uri/UriRetrieverTest.php
+
+		-
+			message: '#^Method JsonSchema\\Tests\\Uri\\UriRetrieverTest\:\:testChildExtendsParentValidTest\(\) has parameter \$parentSchema with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: tests/Uri/UriRetrieverTest.php
+
+		-
+			message: '#^Method JsonSchema\\Tests\\Uri\\UriRetrieverTest\:\:testResolveCombinedURI\(\) has parameter \$baseURI with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: tests/Uri/UriRetrieverTest.php
+
+		-
+			message: '#^Method JsonSchema\\Tests\\Uri\\UriRetrieverTest\:\:testResolveCombinedURI\(\) has parameter \$combinedURI with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: tests/Uri/UriRetrieverTest.php
+
+		-
+			message: '#^Method JsonSchema\\Tests\\Uri\\UriRetrieverTest\:\:testResolveCombinedURI\(\) has parameter \$uri with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: tests/Uri/UriRetrieverTest.php
+
+		-
+			message: '#^Method JsonSchema\\Tests\\Uri\\UriRetrieverTest\:\:testResolveRelativeUri\(\) has parameter \$childSchema with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: tests/Uri/UriRetrieverTest.php
+
+		-
+			message: '#^Method JsonSchema\\Tests\\Uri\\UriRetrieverTest\:\:testResolveRelativeUri\(\) has parameter \$parentSchema with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: tests/Uri/UriRetrieverTest.php
+
+		-
+			message: '#^Parameter \#1 \$json of function json_decode expects string, mixed given\.$#'
+			identifier: argument.type
+			count: 6
+			path: tests/Uri/UriRetrieverTest.php
+
+		-
+			message: '#^Parameter \#1 \$object of method ReflectionProperty\:\:getValue\(\) expects object, mixed given\.$#'
+			identifier: argument.type
+			count: 1
+			path: tests/Uri/UriRetrieverTest.php
+
+		-
+			message: '#^Parameter \#1 \$objectOrValue of method ReflectionProperty\:\:setValue\(\) expects object\|null, mixed given\.$#'
+			identifier: argument.type
+			count: 1
+			path: tests/Uri/UriRetrieverTest.php
+
+		-
+			message: '#^Parameter \#1 \$str of function md5 expects string, string\|false given\.$#'
+			identifier: argument.type
+			count: 1
+			path: tests/Uri/UriRetrieverTest.php
+
+		-
+			message: '#^Parameter \#1 \$uri of method JsonSchema\\Uri\\UriRetriever\:\:resolve\(\) expects string, mixed given\.$#'
+			identifier: argument.type
+			count: 1
+			path: tests/Uri/UriRetrieverTest.php
+
+		-
+			message: '#^Parameter \#2 \$baseUri of method JsonSchema\\Uri\\UriRetriever\:\:resolve\(\) expects string\|null, mixed given\.$#'
+			identifier: argument.type
+			count: 1
+			path: tests/Uri/UriRetrieverTest.php
+
+		-
+			message: '#^Parameter \#2 \$uri of method JsonSchema\\Uri\\UriRetriever\:\:confirmMediaType\(\) expects string, null given\.$#'
+			identifier: argument.type
+			count: 3
+			path: tests/Uri/UriRetrieverTest.php
+
+		-
+			message: '#^Property JsonSchema\\Tests\\Uri\\UriRetrieverTest\:\:\$validator has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: tests/Uri/UriRetrieverTest.php
 

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,10 +1,12 @@
 parameters:
-    level: 8
+    level: max
     paths:
         - ./src/
-    ignoreErrors: []
-    phpVersion: 70200
+        - ./tests/
+    phpVersion:
+        min: 70200
+        max: 80499
 
 includes:
     - phpstan-baseline.neon
-    - vendor/marc-mabe/php-enum-phpstan/extension.neon
+    - tools/vendor/marc-mabe/php-enum-phpstan/extension.neon

--- a/src/JsonSchema/ConstraintError.php
+++ b/src/JsonSchema/ConstraintError.php
@@ -94,7 +94,7 @@ class ConstraintError extends Enum
             self::MINIMUM => 'Must have a minimum value greater than or equal to %d',
             self::MISSING_MAXIMUM => 'Use of exclusiveMaximum requires presence of maximum',
             self::MISSING_MINIMUM => 'Use of exclusiveMinimum requires presence of minimum',
-            /*self::MISSING_ERROR => 'Used for tests; this error is deliberately commented out',*/
+            /* self::MISSING_ERROR => 'Used for tests; this error is deliberately commented out', */
             self::MULTIPLE_OF => 'Must be a multiple of %s',
             self::NOT => 'Matched a schema which it should not',
             self::ONE_OF => 'Failed to match exactly one schema',

--- a/src/JsonSchema/Constraints/BaseConstraint.php
+++ b/src/JsonSchema/Constraints/BaseConstraint.php
@@ -30,6 +30,7 @@ class BaseConstraint
 
     /**
      * @var int All error types which have occurred
+     *
      * @phpstan-var int-mask-of<Validator::ERROR_*>
      */
     protected $errorMask = Validator::ERROR_NONE;

--- a/src/JsonSchema/Constraints/Factory.php
+++ b/src/JsonSchema/Constraints/Factory.php
@@ -35,12 +35,14 @@ class Factory
 
     /**
      * @var int
+     *
      * @phpstan-var int-mask-of<Constraint::CHECK_MODE_*>
      */
     private $checkMode = Constraint::CHECK_MODE_NORMAL;
 
     /**
      * @var array<int, TypeCheck\TypeCheckInterface>
+     *
      * @phpstan-var array<int-mask-of<Constraint::CHECK_MODE_*>, TypeCheck\TypeCheckInterface>
      */
     private $typeCheck = [];
@@ -92,6 +94,7 @@ class Factory
      * Set config values
      *
      * @param int $checkMode Set checkMode options - does not preserve existing flags
+     *
      * @phpstan-param int-mask-of<Constraint::CHECK_MODE_*> $checkMode
      */
     public function setConfig(int $checkMode = Constraint::CHECK_MODE_NORMAL): void
@@ -123,6 +126,7 @@ class Factory
      * Get checkMode option
      *
      * @param int|null $options Options to get, if null then return entire bitmask
+     *
      * @phpstan-param int-mask-of<Constraint::CHECK_MODE_*>|null $options Options to get, if null then return entire bitmask
      *
      * @phpstan-return int-mask-of<Constraint::CHECK_MODE_*>
@@ -180,6 +184,7 @@ class Factory
      * @throws InvalidArgumentException if is not possible create the constraint instance
      *
      * @return ConstraintInterface&BaseConstraint
+     *
      * @phpstan-return ConstraintInterface&BaseConstraint
      */
     public function createInstanceFor($constraintName)

--- a/src/JsonSchema/Constraints/FormatConstraint.php
+++ b/src/JsonSchema/Constraints/FormatConstraint.php
@@ -37,9 +37,9 @@ class FormatConstraint extends Constraint
             case 'date':
                 if (is_string($element) && !$date = $this->validateDateTime($element, 'Y-m-d')) {
                     $this->addError(ConstraintError::FORMAT_DATE(), $path, [
-                            'date' => $element,
-                            'format' => $schema->format
-                        ]
+                        'date' => $element,
+                        'format' => $schema->format
+                    ]
                     );
                 }
                 break;
@@ -47,9 +47,9 @@ class FormatConstraint extends Constraint
             case 'time':
                 if (is_string($element) && !$this->validateDateTime($element, 'H:i:s')) {
                     $this->addError(ConstraintError::FORMAT_TIME(), $path, [
-                            'time' => json_encode($element),
-                            'format' => $schema->format,
-                        ]
+                        'time' => json_encode($element),
+                        'format' => $schema->format,
+                    ]
                     );
                 }
                 break;
@@ -57,9 +57,9 @@ class FormatConstraint extends Constraint
             case 'date-time':
                 if (is_string($element) && null === Rfc3339::createFromString($element)) {
                     $this->addError(ConstraintError::FORMAT_DATE_TIME(), $path, [
-                            'dateTime' => json_encode($element),
-                            'format' => $schema->format
-                        ]
+                        'dateTime' => json_encode($element),
+                        'format' => $schema->format
+                    ]
                     );
                 }
                 break;
@@ -75,9 +75,9 @@ class FormatConstraint extends Constraint
             case 'regex':
                 if (!$this->validateRegex($element)) {
                     $this->addError(ConstraintError::FORMAT_REGEX(), $path, [
-                            'value' => $element,
-                            'format' => $schema->format
-                        ]
+                        'value' => $element,
+                        'format' => $schema->format
+                    ]
                     );
                 }
                 break;

--- a/src/JsonSchema/Constraints/ObjectConstraint.php
+++ b/src/JsonSchema/Constraints/ObjectConstraint.php
@@ -157,7 +157,7 @@ class ObjectConstraint extends Constraint
      */
     protected function &getProperty(&$element, $property, $fallback = null)
     {
-        if (is_array($element) && (isset($element[$property]) || array_key_exists($property, $element)) /*$this->checkMode == self::CHECK_MODE_TYPE_CAST*/) {
+        if (is_array($element) && (isset($element[$property]) || array_key_exists($property, $element)) /* $this->checkMode == self::CHECK_MODE_TYPE_CAST */) {
             return $element[$property];
         } elseif (is_object($element) && property_exists($element, $property)) {
             return $element->$property;

--- a/src/JsonSchema/Constraints/StringConstraint.php
+++ b/src/JsonSchema/Constraints/StringConstraint.php
@@ -34,7 +34,7 @@ class StringConstraint extends Constraint
             ]);
         }
 
-        //verify minLength
+        // verify minLength
         if (isset($schema->minLength) && $this->strlen($element) < $schema->minLength) {
             $this->addError(ConstraintError::LENGTH_MIN(), $path, [
                 'minLength' => $schema->minLength,

--- a/src/JsonSchema/Constraints/TypeCheck/LooseTypeCheck.php
+++ b/src/JsonSchema/Constraints/TypeCheck/LooseTypeCheck.php
@@ -9,15 +9,15 @@ class LooseTypeCheck implements TypeCheckInterface
     public static function isObject($value)
     {
         return
-            is_object($value) ||
-            (is_array($value) && (count($value) == 0 || self::isAssociativeArray($value)));
+            is_object($value)
+            || (is_array($value) && (count($value) == 0 || self::isAssociativeArray($value)));
     }
 
     public static function isArray($value)
     {
         return
-            is_array($value) &&
-            (count($value) == 0 || !self::isAssociativeArray($value));
+            is_array($value)
+            && (count($value) == 0 || !self::isAssociativeArray($value));
     }
 
     public static function propertyGet($value, $property)

--- a/src/JsonSchema/Constraints/TypeConstraint.php
+++ b/src/JsonSchema/Constraints/TypeConstraint.php
@@ -72,8 +72,8 @@ class TypeConstraint extends Constraint
                 $wording[] = self::$wording[$type];
             }
             $this->addError(ConstraintError::TYPE(), $path, [
-                    'found' => gettype($value),
-                    'expected' => $this->implodeWith($wording, ', ', 'or')
+                'found' => gettype($value),
+                'expected' => $this->implodeWith($wording, ', ', 'or')
             ]);
         }
     }
@@ -175,7 +175,7 @@ class TypeConstraint extends Constraint
      */
     protected function validateType(&$value, $type, $coerce = false)
     {
-        //mostly the case for inline schema
+        // mostly the case for inline schema
         if (!$type) {
             return true;
         }

--- a/src/JsonSchema/Constraints/UndefinedConstraint.php
+++ b/src/JsonSchema/Constraints/UndefinedConstraint.php
@@ -72,8 +72,8 @@ class UndefinedConstraint extends Constraint
 
         // check object
         if (LooseTypeCheck::isObject($value)) { // object processing should always be run on assoc arrays,
-                                                // so use LooseTypeCheck here even if CHECK_MODE_TYPE_CAST
-                                                // is not set (i.e. don't use $this->getTypeCheck() here).
+            // so use LooseTypeCheck here even if CHECK_MODE_TYPE_CAST
+            // is not set (i.e. don't use $this->getTypeCheck() here).
             $this->checkObject(
                 $value,
                 $schema,
@@ -232,6 +232,7 @@ class UndefinedConstraint extends Constraint
         if (isset($schema->required) && !is_array($schema->required) && $schema->required) {
             return true;
         }
+
         // default case
         return false;
     }

--- a/src/JsonSchema/Uri/UriResolver.php
+++ b/src/JsonSchema/Uri/UriResolver.php
@@ -80,9 +80,9 @@ class UriResolver implements UriResolverInterface
     {
         // treat non-uri base as local file path
         if (
-            !is_null($baseUri) &&
-            !filter_var($baseUri, \FILTER_VALIDATE_URL) &&
-            !preg_match('|^[^/]+://|u', $baseUri)
+            !is_null($baseUri)
+            && !filter_var($baseUri, \FILTER_VALIDATE_URL)
+            && !preg_match('|^[^/]+://|u', $baseUri)
         ) {
             if (is_file($baseUri)) {
                 $baseUri = 'file://' . realpath($baseUri);

--- a/src/JsonSchema/Uri/UriRetriever.php
+++ b/src/JsonSchema/Uri/UriRetriever.php
@@ -45,7 +45,7 @@ class UriRetriever implements BaseUriRetrieverInterface
     /**
      * @var null|UriRetrieverInterface
      */
-    protected $uriRetriever = null;
+    protected $uriRetriever;
 
     /**
      * @var array|object[]
@@ -168,7 +168,7 @@ class UriRetriever implements BaseUriRetrieverInterface
         $resolver = new UriResolver();
         $resolvedUri = $fetchUri = $resolver->resolve($uri, $baseUri);
 
-        //fetch URL without #fragment
+        // fetch URL without #fragment
         $arParts = $resolver->parse($resolvedUri);
         if (isset($arParts['fragment'])) {
             unset($arParts['fragment']);
@@ -302,7 +302,7 @@ class UriRetriever implements BaseUriRetrieverInterface
         $components = $this->parse($uri);
         $path = $components['path'];
 
-        if ((array_key_exists('scheme', $components)) && ('http' === $components['scheme'])) {
+        if (array_key_exists('scheme', $components) && ('http' === $components['scheme'])) {
             return $uri;
         }
 

--- a/src/JsonSchema/Validator.php
+++ b/src/JsonSchema/Validator.php
@@ -45,6 +45,7 @@ class Validator extends BaseConstraint
      * @return int
      *
      * @phpstan-param int-mask-of<Constraint::CHECK_MODE_*> $checkMode
+     *
      * @phpstan-return int-mask-of<Validator::ERROR_*>
      */
     public function validate(&$value, $schema = null, $checkMode = null)

--- a/tests/Constraints/CoerciveTest.php
+++ b/tests/Constraints/CoerciveTest.php
@@ -16,7 +16,7 @@ use JsonSchema\Validator;
 
 class CoerciveTest extends VeryBaseTestCase
 {
-    protected $factory = null;
+    protected $factory;
 
     public function setUp(): void
     {

--- a/tests/Constraints/FactoryTest.php
+++ b/tests/Constraints/FactoryTest.php
@@ -80,7 +80,7 @@ class FactoryTest extends TestCase
     {
         $factory = new Factory();
 
-        $this->expectException(\JsonSchema\Exception\InvalidArgumentException::class);
+        $this->expectException(InvalidArgumentException::class);
 
         $factory->setConstraintClass('string', 'SomeConstraint');
     }
@@ -89,7 +89,7 @@ class FactoryTest extends TestCase
     {
         $factory = new Factory();
 
-        $this->expectException(\JsonSchema\Exception\InvalidArgumentException::class);
+        $this->expectException(InvalidArgumentException::class);
 
         $factory->setConstraintClass('string', MyBadConstraint::class);
     }

--- a/tests/Constraints/OfPropertiesTest.php
+++ b/tests/Constraints/OfPropertiesTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * This file is part of the JsonSchema package.
  *

--- a/tests/Constraints/PatternPropertiesTest.php
+++ b/tests/Constraints/PatternPropertiesTest.php
@@ -42,46 +42,46 @@ class PatternPropertiesTest extends BaseTestCase
             // Does not match pattern
             [
                 json_encode([
-                        'regex_us' => false,
+                    'regex_us' => false,
                 ]),
                 json_encode([
-                        'type' => 'object',
-                        'patternProperties' => [
-                            '^[a-z]+_(jp|de)$' => [
-                                'type' => ['boolean']
-                            ]
-                        ],
-                        'additionalProperties' => false
+                    'type' => 'object',
+                    'patternProperties' => [
+                        '^[a-z]+_(jp|de)$' => [
+                            'type' => ['boolean']
+                        ]
+                    ],
+                    'additionalProperties' => false
                 ])
             ],
             // Does not match pattern with unicode
             [
                 json_encode([
-                        '猡猡獛' => false,
+                    '猡猡獛' => false,
                 ]),
                 json_encode([
-                        'type' => 'object',
-                        'patternProperties' => [
-                            '^[\\x{0080}-\\x{006FFF}]+$' => [
-                                'type' => ['boolean']
-                            ]
-                        ],
-                        'additionalProperties' => false
+                    'type' => 'object',
+                    'patternProperties' => [
+                        '^[\\x{0080}-\\x{006FFF}]+$' => [
+                            'type' => ['boolean']
+                        ]
+                    ],
+                    'additionalProperties' => false
                 ])
             ],
             // An invalid regular expression pattern
             [
                 json_encode([
-                        'regex_us' => false,
+                    'regex_us' => false,
                 ]),
                 json_encode([
-                        'type' => 'object',
-                        'patternProperties' => [
-                            '^[a-z+_jp|de)$' => [
-                                'type' => ['boolean']
-                            ]
-                        ],
-                        'additionalProperties' => false
+                    'type' => 'object',
+                    'patternProperties' => [
+                        '^[a-z+_jp|de)$' => [
+                            'type' => ['boolean']
+                        ]
+                    ],
+                    'additionalProperties' => false
                 ])
             ],
         ];
@@ -177,21 +177,21 @@ class PatternPropertiesTest extends BaseTestCase
             ],
             [
                 json_encode([
-                        'foobar' => true,
-                        'regex_us' => 'foo',
-                        'regex_de' => 1234
+                    'foobar' => true,
+                    'regex_us' => 'foo',
+                    'regex_de' => 1234
                 ]),
                 json_encode([
-                        'type' => 'object',
-                        'properties' => [
-                            'foobar' => ['type' => 'boolean']
-                        ],
-                        'patternProperties' => [
-                            '^[a-z]+_(us|de)$' => [
-                                'type' => ['string', 'integer']
-                            ]
-                        ],
-                        'additionalProperties' => false
+                    'type' => 'object',
+                    'properties' => [
+                        'foobar' => ['type' => 'boolean']
+                    ],
+                    'patternProperties' => [
+                        '^[a-z]+_(us|de)$' => [
+                            'type' => ['string', 'integer']
+                        ]
+                    ],
+                    'additionalProperties' => false
                 ])
             ],
             // Does match pattern with unicode

--- a/tests/Constraints/ReadOnlyTest.php
+++ b/tests/Constraints/ReadOnlyTest.php
@@ -15,7 +15,7 @@ class ReadOnlyTest extends BaseTestCase
 
     public function getInvalidTests(): array
     {
-        //is readonly really required?
+        // is readonly really required?
         return [
             [
                 '{ "number": [] }',

--- a/tests/Uri/UriResolverTest.php
+++ b/tests/Uri/UriResolverTest.php
@@ -78,7 +78,7 @@ class UriResolverTest extends TestCase
 
     public function testCombineRelativePathWithBasePathNoPath(): void
     {
-        //needed for anchor-only urls
+        // needed for anchor-only urls
         $this->assertEquals(
             '/foo/bar.json',
             UriResolver::combineRelativePathWithBasePath(

--- a/tools/composer.json
+++ b/tools/composer.json
@@ -1,0 +1,7 @@
+{
+    "require": {
+        "friendsofphp/php-cs-fixer": "^3.68.5",
+        "phpstan/phpstan": "^2.1.4",
+        "marc-mabe/php-enum-phpstan": "^3.0"
+    }
+}

--- a/tools/composer.lock
+++ b/tools/composer.lock
@@ -1,0 +1,2727 @@
+{
+    "_readme": [
+        "This file locks the dependencies of your project to a known state",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
+        "This file is @generated automatically"
+    ],
+    "content-hash": "75bad77e78364ddbb224f847da5a0dc9",
+    "packages": [
+        {
+            "name": "clue/ndjson-react",
+            "version": "v1.3.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/clue/reactphp-ndjson.git",
+                "reference": "392dc165fce93b5bb5c637b67e59619223c931b0"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/clue/reactphp-ndjson/zipball/392dc165fce93b5bb5c637b67e59619223c931b0",
+                "reference": "392dc165fce93b5bb5c637b67e59619223c931b0",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3",
+                "react/stream": "^1.2"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.5 || ^5.7 || ^4.8.35",
+                "react/event-loop": "^1.2"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Clue\\React\\NDJson\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Christian Lück",
+                    "email": "christian@clue.engineering"
+                }
+            ],
+            "description": "Streaming newline-delimited JSON (NDJSON) parser and encoder for ReactPHP.",
+            "homepage": "https://github.com/clue/reactphp-ndjson",
+            "keywords": [
+                "NDJSON",
+                "json",
+                "jsonlines",
+                "newline",
+                "reactphp",
+                "streaming"
+            ],
+            "support": {
+                "issues": "https://github.com/clue/reactphp-ndjson/issues",
+                "source": "https://github.com/clue/reactphp-ndjson/tree/v1.3.0"
+            },
+            "funding": [
+                {
+                    "url": "https://clue.engineering/support",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/clue",
+                    "type": "github"
+                }
+            ],
+            "time": "2022-12-23T10:58:28+00:00"
+        },
+        {
+            "name": "composer/pcre",
+            "version": "3.3.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/composer/pcre.git",
+                "reference": "b2bed4734f0cc156ee1fe9c0da2550420d99a21e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/composer/pcre/zipball/b2bed4734f0cc156ee1fe9c0da2550420d99a21e",
+                "reference": "b2bed4734f0cc156ee1fe9c0da2550420d99a21e",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.4 || ^8.0"
+            },
+            "conflict": {
+                "phpstan/phpstan": "<1.11.10"
+            },
+            "require-dev": {
+                "phpstan/phpstan": "^1.12 || ^2",
+                "phpstan/phpstan-strict-rules": "^1 || ^2",
+                "phpunit/phpunit": "^8 || ^9"
+            },
+            "type": "library",
+            "extra": {
+                "phpstan": {
+                    "includes": [
+                        "extension.neon"
+                    ]
+                },
+                "branch-alias": {
+                    "dev-main": "3.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Composer\\Pcre\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Jordi Boggiano",
+                    "email": "j.boggiano@seld.be",
+                    "homepage": "http://seld.be"
+                }
+            ],
+            "description": "PCRE wrapping library that offers type-safe preg_* replacements.",
+            "keywords": [
+                "PCRE",
+                "preg",
+                "regex",
+                "regular expression"
+            ],
+            "support": {
+                "issues": "https://github.com/composer/pcre/issues",
+                "source": "https://github.com/composer/pcre/tree/3.3.2"
+            },
+            "funding": [
+                {
+                    "url": "https://packagist.com",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/composer",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/composer/composer",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2024-11-12T16:29:46+00:00"
+        },
+        {
+            "name": "composer/semver",
+            "version": "3.4.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/composer/semver.git",
+                "reference": "4313d26ada5e0c4edfbd1dc481a92ff7bff91f12"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/composer/semver/zipball/4313d26ada5e0c4edfbd1dc481a92ff7bff91f12",
+                "reference": "4313d26ada5e0c4edfbd1dc481a92ff7bff91f12",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.3.2 || ^7.0 || ^8.0"
+            },
+            "require-dev": {
+                "phpstan/phpstan": "^1.11",
+                "symfony/phpunit-bridge": "^3 || ^7"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "3.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Composer\\Semver\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nils Adermann",
+                    "email": "naderman@naderman.de",
+                    "homepage": "http://www.naderman.de"
+                },
+                {
+                    "name": "Jordi Boggiano",
+                    "email": "j.boggiano@seld.be",
+                    "homepage": "http://seld.be"
+                },
+                {
+                    "name": "Rob Bast",
+                    "email": "rob.bast@gmail.com",
+                    "homepage": "http://robbast.nl"
+                }
+            ],
+            "description": "Semver library that offers utilities, version constraint parsing and validation.",
+            "keywords": [
+                "semantic",
+                "semver",
+                "validation",
+                "versioning"
+            ],
+            "support": {
+                "irc": "ircs://irc.libera.chat:6697/composer",
+                "issues": "https://github.com/composer/semver/issues",
+                "source": "https://github.com/composer/semver/tree/3.4.3"
+            },
+            "funding": [
+                {
+                    "url": "https://packagist.com",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/composer",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/composer/composer",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2024-09-19T14:15:21+00:00"
+        },
+        {
+            "name": "composer/xdebug-handler",
+            "version": "3.0.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/composer/xdebug-handler.git",
+                "reference": "6c1925561632e83d60a44492e0b344cf48ab85ef"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/composer/xdebug-handler/zipball/6c1925561632e83d60a44492e0b344cf48ab85ef",
+                "reference": "6c1925561632e83d60a44492e0b344cf48ab85ef",
+                "shasum": ""
+            },
+            "require": {
+                "composer/pcre": "^1 || ^2 || ^3",
+                "php": "^7.2.5 || ^8.0",
+                "psr/log": "^1 || ^2 || ^3"
+            },
+            "require-dev": {
+                "phpstan/phpstan": "^1.0",
+                "phpstan/phpstan-strict-rules": "^1.1",
+                "phpunit/phpunit": "^8.5 || ^9.6 || ^10.5"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Composer\\XdebugHandler\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "John Stevenson",
+                    "email": "john-stevenson@blueyonder.co.uk"
+                }
+            ],
+            "description": "Restarts a process without Xdebug.",
+            "keywords": [
+                "Xdebug",
+                "performance"
+            ],
+            "support": {
+                "irc": "ircs://irc.libera.chat:6697/composer",
+                "issues": "https://github.com/composer/xdebug-handler/issues",
+                "source": "https://github.com/composer/xdebug-handler/tree/3.0.5"
+            },
+            "funding": [
+                {
+                    "url": "https://packagist.com",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/composer",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/composer/composer",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2024-05-06T16:37:16+00:00"
+        },
+        {
+            "name": "evenement/evenement",
+            "version": "v3.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/igorw/evenement.git",
+                "reference": "0a16b0d71ab13284339abb99d9d2bd813640efbc"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/igorw/evenement/zipball/0a16b0d71ab13284339abb99d9d2bd813640efbc",
+                "reference": "0a16b0d71ab13284339abb99d9d2bd813640efbc",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9 || ^6"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Evenement\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Igor Wiedler",
+                    "email": "igor@wiedler.ch"
+                }
+            ],
+            "description": "Événement is a very simple event dispatching library for PHP",
+            "keywords": [
+                "event-dispatcher",
+                "event-emitter"
+            ],
+            "support": {
+                "issues": "https://github.com/igorw/evenement/issues",
+                "source": "https://github.com/igorw/evenement/tree/v3.0.2"
+            },
+            "time": "2023-08-08T05:53:35+00:00"
+        },
+        {
+            "name": "fidry/cpu-core-counter",
+            "version": "1.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/theofidry/cpu-core-counter.git",
+                "reference": "8520451a140d3f46ac33042715115e290cf5785f"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/theofidry/cpu-core-counter/zipball/8520451a140d3f46ac33042715115e290cf5785f",
+                "reference": "8520451a140d3f46ac33042715115e290cf5785f",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2 || ^8.0"
+            },
+            "require-dev": {
+                "fidry/makefile": "^0.2.0",
+                "fidry/php-cs-fixer-config": "^1.1.2",
+                "phpstan/extension-installer": "^1.2.0",
+                "phpstan/phpstan": "^1.9.2",
+                "phpstan/phpstan-deprecation-rules": "^1.0.0",
+                "phpstan/phpstan-phpunit": "^1.2.2",
+                "phpstan/phpstan-strict-rules": "^1.4.4",
+                "phpunit/phpunit": "^8.5.31 || ^9.5.26",
+                "webmozarts/strict-phpunit": "^7.5"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Fidry\\CpuCoreCounter\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Théo FIDRY",
+                    "email": "theo.fidry@gmail.com"
+                }
+            ],
+            "description": "Tiny utility to get the number of CPU cores.",
+            "keywords": [
+                "CPU",
+                "core"
+            ],
+            "support": {
+                "issues": "https://github.com/theofidry/cpu-core-counter/issues",
+                "source": "https://github.com/theofidry/cpu-core-counter/tree/1.2.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/theofidry",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-08-06T10:04:20+00:00"
+        },
+        {
+            "name": "friendsofphp/php-cs-fixer",
+            "version": "v3.68.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/PHP-CS-Fixer/PHP-CS-Fixer.git",
+                "reference": "7bedb718b633355272428c60736dc97fb96daf27"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/PHP-CS-Fixer/PHP-CS-Fixer/zipball/7bedb718b633355272428c60736dc97fb96daf27",
+                "reference": "7bedb718b633355272428c60736dc97fb96daf27",
+                "shasum": ""
+            },
+            "require": {
+                "clue/ndjson-react": "^1.0",
+                "composer/semver": "^3.4",
+                "composer/xdebug-handler": "^3.0.3",
+                "ext-filter": "*",
+                "ext-json": "*",
+                "ext-tokenizer": "*",
+                "fidry/cpu-core-counter": "^1.2",
+                "php": "^7.4 || ^8.0",
+                "react/child-process": "^0.6.5",
+                "react/event-loop": "^1.0",
+                "react/promise": "^2.0 || ^3.0",
+                "react/socket": "^1.0",
+                "react/stream": "^1.0",
+                "sebastian/diff": "^4.0 || ^5.1 || ^6.0",
+                "symfony/console": "^5.4 || ^6.4 || ^7.0",
+                "symfony/event-dispatcher": "^5.4 || ^6.4 || ^7.0",
+                "symfony/filesystem": "^5.4 || ^6.4 || ^7.0",
+                "symfony/finder": "^5.4 || ^6.4 || ^7.0",
+                "symfony/options-resolver": "^5.4 || ^6.4 || ^7.0",
+                "symfony/polyfill-mbstring": "^1.31",
+                "symfony/polyfill-php80": "^1.31",
+                "symfony/polyfill-php81": "^1.31",
+                "symfony/process": "^5.4 || ^6.4 || ^7.2",
+                "symfony/stopwatch": "^5.4 || ^6.4 || ^7.0"
+            },
+            "require-dev": {
+                "facile-it/paraunit": "^1.3.1 || ^2.4",
+                "infection/infection": "^0.29.8",
+                "justinrainbow/json-schema": "^5.3 || ^6.0",
+                "keradus/cli-executor": "^2.1",
+                "mikey179/vfsstream": "^1.6.12",
+                "php-coveralls/php-coveralls": "^2.7",
+                "php-cs-fixer/accessible-object": "^1.1",
+                "php-cs-fixer/phpunit-constraint-isidenticalstring": "^1.5",
+                "php-cs-fixer/phpunit-constraint-xmlmatchesxsd": "^1.5",
+                "phpunit/phpunit": "^9.6.22 || ^10.5.40 || ^11.5.2",
+                "symfony/var-dumper": "^5.4.48 || ^6.4.15 || ^7.2.0",
+                "symfony/yaml": "^5.4.45 || ^6.4.13 || ^7.2.0"
+            },
+            "suggest": {
+                "ext-dom": "For handling output formats in XML",
+                "ext-mbstring": "For handling non-UTF8 characters."
+            },
+            "bin": [
+                "php-cs-fixer"
+            ],
+            "type": "application",
+            "autoload": {
+                "psr-4": {
+                    "PhpCsFixer\\": "src/"
+                },
+                "exclude-from-classmap": [
+                    "src/Fixer/Internal/*"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Dariusz Rumiński",
+                    "email": "dariusz.ruminski@gmail.com"
+                }
+            ],
+            "description": "A tool to automatically fix PHP code style",
+            "keywords": [
+                "Static code analysis",
+                "fixer",
+                "standards",
+                "static analysis"
+            ],
+            "support": {
+                "issues": "https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/issues",
+                "source": "https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/tree/v3.68.5"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/keradus",
+                    "type": "github"
+                }
+            ],
+            "time": "2025-01-30T17:00:50+00:00"
+        },
+        {
+            "name": "marc-mabe/php-enum",
+            "version": "v4.7.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/marc-mabe/php-enum.git",
+                "reference": "7159809e5cfa041dca28e61f7f7ae58063aae8ed"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/marc-mabe/php-enum/zipball/7159809e5cfa041dca28e61f7f7ae58063aae8ed",
+                "reference": "7159809e5cfa041dca28e61f7f7ae58063aae8ed",
+                "shasum": ""
+            },
+            "require": {
+                "ext-reflection": "*",
+                "php": "^7.1 | ^8.0"
+            },
+            "require-dev": {
+                "phpbench/phpbench": "^0.16.10 || ^1.0.4",
+                "phpstan/phpstan": "^1.3.1",
+                "phpunit/phpunit": "^7.5.20 | ^8.5.22 | ^9.5.11",
+                "vimeo/psalm": "^4.17.0 | ^5.26.1"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-3.x": "3.2-dev",
+                    "dev-master": "4.7-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "MabeEnum\\": "src/"
+                },
+                "classmap": [
+                    "stubs/Stringable.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Marc Bennewitz",
+                    "email": "dev@mabe.berlin",
+                    "homepage": "https://mabe.berlin/",
+                    "role": "Lead"
+                }
+            ],
+            "description": "Simple and fast implementation of enumerations with native PHP",
+            "homepage": "https://github.com/marc-mabe/php-enum",
+            "keywords": [
+                "enum",
+                "enum-map",
+                "enum-set",
+                "enumeration",
+                "enumerator",
+                "enummap",
+                "enumset",
+                "map",
+                "set",
+                "type",
+                "type-hint",
+                "typehint"
+            ],
+            "support": {
+                "issues": "https://github.com/marc-mabe/php-enum/issues",
+                "source": "https://github.com/marc-mabe/php-enum/tree/v4.7.1"
+            },
+            "time": "2024-11-28T04:54:44+00:00"
+        },
+        {
+            "name": "marc-mabe/php-enum-phpstan",
+            "version": "v3.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/marc-mabe/php-enum-phpstan.git",
+                "reference": "9c39239c76cc4dfb8cd33463253568c23c208276"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/marc-mabe/php-enum-phpstan/zipball/9c39239c76cc4dfb8cd33463253568c23c208276",
+                "reference": "9c39239c76cc4dfb8cd33463253568c23c208276",
+                "shasum": ""
+            },
+            "require": {
+                "marc-mabe/php-enum": "^4.0",
+                "php": "^7.4 | ^8.0",
+                "phpstan/phpstan": "^2.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.6"
+            },
+            "type": "phpstan-extension",
+            "extra": {
+                "phpstan": {
+                    "includes": [
+                        "extension.neon"
+                    ]
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "MabeEnumPHPStan\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "description": "Enum class reflection extension for PHPStan",
+            "keywords": [
+                "PHPStan",
+                "enum"
+            ],
+            "support": {
+                "issues": "https://github.com/marc-mabe/php-enum-phpstan/issues",
+                "source": "https://github.com/marc-mabe/php-enum-phpstan/tree/v3.0.0"
+            },
+            "time": "2024-12-10T08:20:38+00:00"
+        },
+        {
+            "name": "phpstan/phpstan",
+            "version": "2.1.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpstan/phpstan.git",
+                "reference": "8f99e18eb775dbaf6460c95fa0b65312da9c746a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/8f99e18eb775dbaf6460c95fa0b65312da9c746a",
+                "reference": "8f99e18eb775dbaf6460c95fa0b65312da9c746a",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.4|^8.0"
+            },
+            "conflict": {
+                "phpstan/phpstan-shim": "*"
+            },
+            "bin": [
+                "phpstan",
+                "phpstan.phar"
+            ],
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "PHPStan - PHP Static Analysis Tool",
+            "keywords": [
+                "dev",
+                "static analysis"
+            ],
+            "support": {
+                "docs": "https://phpstan.org/user-guide/getting-started",
+                "forum": "https://github.com/phpstan/phpstan/discussions",
+                "issues": "https://github.com/phpstan/phpstan/issues",
+                "security": "https://github.com/phpstan/phpstan/security/policy",
+                "source": "https://github.com/phpstan/phpstan-src"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/ondrejmirtes",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/phpstan",
+                    "type": "github"
+                }
+            ],
+            "time": "2025-02-10T08:25:21+00:00"
+        },
+        {
+            "name": "psr/container",
+            "version": "2.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/container.git",
+                "reference": "c71ecc56dfe541dbd90c5360474fbc405f8d5963"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/container/zipball/c71ecc56dfe541dbd90c5360474fbc405f8d5963",
+                "reference": "c71ecc56dfe541dbd90c5360474fbc405f8d5963",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.4.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Container\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "https://www.php-fig.org/"
+                }
+            ],
+            "description": "Common Container Interface (PHP FIG PSR-11)",
+            "homepage": "https://github.com/php-fig/container",
+            "keywords": [
+                "PSR-11",
+                "container",
+                "container-interface",
+                "container-interop",
+                "psr"
+            ],
+            "support": {
+                "issues": "https://github.com/php-fig/container/issues",
+                "source": "https://github.com/php-fig/container/tree/2.0.2"
+            },
+            "time": "2021-11-05T16:47:00+00:00"
+        },
+        {
+            "name": "psr/event-dispatcher",
+            "version": "1.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/event-dispatcher.git",
+                "reference": "dbefd12671e8a14ec7f180cab83036ed26714bb0"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/event-dispatcher/zipball/dbefd12671e8a14ec7f180cab83036ed26714bb0",
+                "reference": "dbefd12671e8a14ec7f180cab83036ed26714bb0",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.2.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\EventDispatcher\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "http://www.php-fig.org/"
+                }
+            ],
+            "description": "Standard interfaces for event handling.",
+            "keywords": [
+                "events",
+                "psr",
+                "psr-14"
+            ],
+            "support": {
+                "issues": "https://github.com/php-fig/event-dispatcher/issues",
+                "source": "https://github.com/php-fig/event-dispatcher/tree/1.0.0"
+            },
+            "time": "2019-01-08T18:20:26+00:00"
+        },
+        {
+            "name": "psr/log",
+            "version": "3.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/log.git",
+                "reference": "f16e1d5863e37f8d8c2a01719f5b34baa2b714d3"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/log/zipball/f16e1d5863e37f8d8c2a01719f5b34baa2b714d3",
+                "reference": "f16e1d5863e37f8d8c2a01719f5b34baa2b714d3",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.0.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Log\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "https://www.php-fig.org/"
+                }
+            ],
+            "description": "Common interface for logging libraries",
+            "homepage": "https://github.com/php-fig/log",
+            "keywords": [
+                "log",
+                "psr",
+                "psr-3"
+            ],
+            "support": {
+                "source": "https://github.com/php-fig/log/tree/3.0.2"
+            },
+            "time": "2024-09-11T13:17:53+00:00"
+        },
+        {
+            "name": "react/cache",
+            "version": "v1.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/reactphp/cache.git",
+                "reference": "d47c472b64aa5608225f47965a484b75c7817d5b"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/reactphp/cache/zipball/d47c472b64aa5608225f47965a484b75c7817d5b",
+                "reference": "d47c472b64aa5608225f47965a484b75c7817d5b",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.0",
+                "react/promise": "^3.0 || ^2.0 || ^1.1"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.5 || ^5.7 || ^4.8.35"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "React\\Cache\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Christian Lück",
+                    "email": "christian@clue.engineering",
+                    "homepage": "https://clue.engineering/"
+                },
+                {
+                    "name": "Cees-Jan Kiewiet",
+                    "email": "reactphp@ceesjankiewiet.nl",
+                    "homepage": "https://wyrihaximus.net/"
+                },
+                {
+                    "name": "Jan Sorgalla",
+                    "email": "jsorgalla@gmail.com",
+                    "homepage": "https://sorgalla.com/"
+                },
+                {
+                    "name": "Chris Boden",
+                    "email": "cboden@gmail.com",
+                    "homepage": "https://cboden.dev/"
+                }
+            ],
+            "description": "Async, Promise-based cache interface for ReactPHP",
+            "keywords": [
+                "cache",
+                "caching",
+                "promise",
+                "reactphp"
+            ],
+            "support": {
+                "issues": "https://github.com/reactphp/cache/issues",
+                "source": "https://github.com/reactphp/cache/tree/v1.2.0"
+            },
+            "funding": [
+                {
+                    "url": "https://opencollective.com/reactphp",
+                    "type": "open_collective"
+                }
+            ],
+            "time": "2022-11-30T15:59:55+00:00"
+        },
+        {
+            "name": "react/child-process",
+            "version": "v0.6.6",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/reactphp/child-process.git",
+                "reference": "1721e2b93d89b745664353b9cfc8f155ba8a6159"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/reactphp/child-process/zipball/1721e2b93d89b745664353b9cfc8f155ba8a6159",
+                "reference": "1721e2b93d89b745664353b9cfc8f155ba8a6159",
+                "shasum": ""
+            },
+            "require": {
+                "evenement/evenement": "^3.0 || ^2.0 || ^1.0",
+                "php": ">=5.3.0",
+                "react/event-loop": "^1.2",
+                "react/stream": "^1.4"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.6 || ^5.7 || ^4.8.36",
+                "react/socket": "^1.16",
+                "sebastian/environment": "^5.0 || ^3.0 || ^2.0 || ^1.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "React\\ChildProcess\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Christian Lück",
+                    "email": "christian@clue.engineering",
+                    "homepage": "https://clue.engineering/"
+                },
+                {
+                    "name": "Cees-Jan Kiewiet",
+                    "email": "reactphp@ceesjankiewiet.nl",
+                    "homepage": "https://wyrihaximus.net/"
+                },
+                {
+                    "name": "Jan Sorgalla",
+                    "email": "jsorgalla@gmail.com",
+                    "homepage": "https://sorgalla.com/"
+                },
+                {
+                    "name": "Chris Boden",
+                    "email": "cboden@gmail.com",
+                    "homepage": "https://cboden.dev/"
+                }
+            ],
+            "description": "Event-driven library for executing child processes with ReactPHP.",
+            "keywords": [
+                "event-driven",
+                "process",
+                "reactphp"
+            ],
+            "support": {
+                "issues": "https://github.com/reactphp/child-process/issues",
+                "source": "https://github.com/reactphp/child-process/tree/v0.6.6"
+            },
+            "funding": [
+                {
+                    "url": "https://opencollective.com/reactphp",
+                    "type": "open_collective"
+                }
+            ],
+            "time": "2025-01-01T16:37:48+00:00"
+        },
+        {
+            "name": "react/dns",
+            "version": "v1.13.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/reactphp/dns.git",
+                "reference": "eb8ae001b5a455665c89c1df97f6fb682f8fb0f5"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/reactphp/dns/zipball/eb8ae001b5a455665c89c1df97f6fb682f8fb0f5",
+                "reference": "eb8ae001b5a455665c89c1df97f6fb682f8fb0f5",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.0",
+                "react/cache": "^1.0 || ^0.6 || ^0.5",
+                "react/event-loop": "^1.2",
+                "react/promise": "^3.2 || ^2.7 || ^1.2.1"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.6 || ^5.7 || ^4.8.36",
+                "react/async": "^4.3 || ^3 || ^2",
+                "react/promise-timer": "^1.11"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "React\\Dns\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Christian Lück",
+                    "email": "christian@clue.engineering",
+                    "homepage": "https://clue.engineering/"
+                },
+                {
+                    "name": "Cees-Jan Kiewiet",
+                    "email": "reactphp@ceesjankiewiet.nl",
+                    "homepage": "https://wyrihaximus.net/"
+                },
+                {
+                    "name": "Jan Sorgalla",
+                    "email": "jsorgalla@gmail.com",
+                    "homepage": "https://sorgalla.com/"
+                },
+                {
+                    "name": "Chris Boden",
+                    "email": "cboden@gmail.com",
+                    "homepage": "https://cboden.dev/"
+                }
+            ],
+            "description": "Async DNS resolver for ReactPHP",
+            "keywords": [
+                "async",
+                "dns",
+                "dns-resolver",
+                "reactphp"
+            ],
+            "support": {
+                "issues": "https://github.com/reactphp/dns/issues",
+                "source": "https://github.com/reactphp/dns/tree/v1.13.0"
+            },
+            "funding": [
+                {
+                    "url": "https://opencollective.com/reactphp",
+                    "type": "open_collective"
+                }
+            ],
+            "time": "2024-06-13T14:18:03+00:00"
+        },
+        {
+            "name": "react/event-loop",
+            "version": "v1.5.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/reactphp/event-loop.git",
+                "reference": "bbe0bd8c51ffc05ee43f1729087ed3bdf7d53354"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/reactphp/event-loop/zipball/bbe0bd8c51ffc05ee43f1729087ed3bdf7d53354",
+                "reference": "bbe0bd8c51ffc05ee43f1729087ed3bdf7d53354",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.6 || ^5.7 || ^4.8.36"
+            },
+            "suggest": {
+                "ext-pcntl": "For signal handling support when using the StreamSelectLoop"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "React\\EventLoop\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Christian Lück",
+                    "email": "christian@clue.engineering",
+                    "homepage": "https://clue.engineering/"
+                },
+                {
+                    "name": "Cees-Jan Kiewiet",
+                    "email": "reactphp@ceesjankiewiet.nl",
+                    "homepage": "https://wyrihaximus.net/"
+                },
+                {
+                    "name": "Jan Sorgalla",
+                    "email": "jsorgalla@gmail.com",
+                    "homepage": "https://sorgalla.com/"
+                },
+                {
+                    "name": "Chris Boden",
+                    "email": "cboden@gmail.com",
+                    "homepage": "https://cboden.dev/"
+                }
+            ],
+            "description": "ReactPHP's core reactor event loop that libraries can use for evented I/O.",
+            "keywords": [
+                "asynchronous",
+                "event-loop"
+            ],
+            "support": {
+                "issues": "https://github.com/reactphp/event-loop/issues",
+                "source": "https://github.com/reactphp/event-loop/tree/v1.5.0"
+            },
+            "funding": [
+                {
+                    "url": "https://opencollective.com/reactphp",
+                    "type": "open_collective"
+                }
+            ],
+            "time": "2023-11-13T13:48:05+00:00"
+        },
+        {
+            "name": "react/promise",
+            "version": "v3.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/reactphp/promise.git",
+                "reference": "8a164643313c71354582dc850b42b33fa12a4b63"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/reactphp/promise/zipball/8a164643313c71354582dc850b42b33fa12a4b63",
+                "reference": "8a164643313c71354582dc850b42b33fa12a4b63",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.1.0"
+            },
+            "require-dev": {
+                "phpstan/phpstan": "1.10.39 || 1.4.10",
+                "phpunit/phpunit": "^9.6 || ^7.5"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "src/functions_include.php"
+                ],
+                "psr-4": {
+                    "React\\Promise\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Jan Sorgalla",
+                    "email": "jsorgalla@gmail.com",
+                    "homepage": "https://sorgalla.com/"
+                },
+                {
+                    "name": "Christian Lück",
+                    "email": "christian@clue.engineering",
+                    "homepage": "https://clue.engineering/"
+                },
+                {
+                    "name": "Cees-Jan Kiewiet",
+                    "email": "reactphp@ceesjankiewiet.nl",
+                    "homepage": "https://wyrihaximus.net/"
+                },
+                {
+                    "name": "Chris Boden",
+                    "email": "cboden@gmail.com",
+                    "homepage": "https://cboden.dev/"
+                }
+            ],
+            "description": "A lightweight implementation of CommonJS Promises/A for PHP",
+            "keywords": [
+                "promise",
+                "promises"
+            ],
+            "support": {
+                "issues": "https://github.com/reactphp/promise/issues",
+                "source": "https://github.com/reactphp/promise/tree/v3.2.0"
+            },
+            "funding": [
+                {
+                    "url": "https://opencollective.com/reactphp",
+                    "type": "open_collective"
+                }
+            ],
+            "time": "2024-05-24T10:39:05+00:00"
+        },
+        {
+            "name": "react/socket",
+            "version": "v1.16.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/reactphp/socket.git",
+                "reference": "23e4ff33ea3e160d2d1f59a0e6050e4b0fb0eac1"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/reactphp/socket/zipball/23e4ff33ea3e160d2d1f59a0e6050e4b0fb0eac1",
+                "reference": "23e4ff33ea3e160d2d1f59a0e6050e4b0fb0eac1",
+                "shasum": ""
+            },
+            "require": {
+                "evenement/evenement": "^3.0 || ^2.0 || ^1.0",
+                "php": ">=5.3.0",
+                "react/dns": "^1.13",
+                "react/event-loop": "^1.2",
+                "react/promise": "^3.2 || ^2.6 || ^1.2.1",
+                "react/stream": "^1.4"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.6 || ^5.7 || ^4.8.36",
+                "react/async": "^4.3 || ^3.3 || ^2",
+                "react/promise-stream": "^1.4",
+                "react/promise-timer": "^1.11"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "React\\Socket\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Christian Lück",
+                    "email": "christian@clue.engineering",
+                    "homepage": "https://clue.engineering/"
+                },
+                {
+                    "name": "Cees-Jan Kiewiet",
+                    "email": "reactphp@ceesjankiewiet.nl",
+                    "homepage": "https://wyrihaximus.net/"
+                },
+                {
+                    "name": "Jan Sorgalla",
+                    "email": "jsorgalla@gmail.com",
+                    "homepage": "https://sorgalla.com/"
+                },
+                {
+                    "name": "Chris Boden",
+                    "email": "cboden@gmail.com",
+                    "homepage": "https://cboden.dev/"
+                }
+            ],
+            "description": "Async, streaming plaintext TCP/IP and secure TLS socket server and client connections for ReactPHP",
+            "keywords": [
+                "Connection",
+                "Socket",
+                "async",
+                "reactphp",
+                "stream"
+            ],
+            "support": {
+                "issues": "https://github.com/reactphp/socket/issues",
+                "source": "https://github.com/reactphp/socket/tree/v1.16.0"
+            },
+            "funding": [
+                {
+                    "url": "https://opencollective.com/reactphp",
+                    "type": "open_collective"
+                }
+            ],
+            "time": "2024-07-26T10:38:09+00:00"
+        },
+        {
+            "name": "react/stream",
+            "version": "v1.4.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/reactphp/stream.git",
+                "reference": "1e5b0acb8fe55143b5b426817155190eb6f5b18d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/reactphp/stream/zipball/1e5b0acb8fe55143b5b426817155190eb6f5b18d",
+                "reference": "1e5b0acb8fe55143b5b426817155190eb6f5b18d",
+                "shasum": ""
+            },
+            "require": {
+                "evenement/evenement": "^3.0 || ^2.0 || ^1.0",
+                "php": ">=5.3.8",
+                "react/event-loop": "^1.2"
+            },
+            "require-dev": {
+                "clue/stream-filter": "~1.2",
+                "phpunit/phpunit": "^9.6 || ^5.7 || ^4.8.36"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "React\\Stream\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Christian Lück",
+                    "email": "christian@clue.engineering",
+                    "homepage": "https://clue.engineering/"
+                },
+                {
+                    "name": "Cees-Jan Kiewiet",
+                    "email": "reactphp@ceesjankiewiet.nl",
+                    "homepage": "https://wyrihaximus.net/"
+                },
+                {
+                    "name": "Jan Sorgalla",
+                    "email": "jsorgalla@gmail.com",
+                    "homepage": "https://sorgalla.com/"
+                },
+                {
+                    "name": "Chris Boden",
+                    "email": "cboden@gmail.com",
+                    "homepage": "https://cboden.dev/"
+                }
+            ],
+            "description": "Event-driven readable and writable streams for non-blocking I/O in ReactPHP",
+            "keywords": [
+                "event-driven",
+                "io",
+                "non-blocking",
+                "pipe",
+                "reactphp",
+                "readable",
+                "stream",
+                "writable"
+            ],
+            "support": {
+                "issues": "https://github.com/reactphp/stream/issues",
+                "source": "https://github.com/reactphp/stream/tree/v1.4.0"
+            },
+            "funding": [
+                {
+                    "url": "https://opencollective.com/reactphp",
+                    "type": "open_collective"
+                }
+            ],
+            "time": "2024-06-11T12:45:25+00:00"
+        },
+        {
+            "name": "sebastian/diff",
+            "version": "6.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/diff.git",
+                "reference": "b4ccd857127db5d41a5b676f24b51371d76d8544"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/b4ccd857127db5d41a5b676f24b51371d76d8544",
+                "reference": "b4ccd857127db5d41a5b676f24b51371d76d8544",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^11.0",
+                "symfony/process": "^4.2 || ^5"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "6.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                },
+                {
+                    "name": "Kore Nordmann",
+                    "email": "mail@kore-nordmann.de"
+                }
+            ],
+            "description": "Diff implementation",
+            "homepage": "https://github.com/sebastianbergmann/diff",
+            "keywords": [
+                "diff",
+                "udiff",
+                "unidiff",
+                "unified diff"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/diff/issues",
+                "security": "https://github.com/sebastianbergmann/diff/security/policy",
+                "source": "https://github.com/sebastianbergmann/diff/tree/6.0.2"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-07-03T04:53:05+00:00"
+        },
+        {
+            "name": "symfony/console",
+            "version": "v7.2.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/console.git",
+                "reference": "fefcc18c0f5d0efe3ab3152f15857298868dc2c3"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/console/zipball/fefcc18c0f5d0efe3ab3152f15857298868dc2c3",
+                "reference": "fefcc18c0f5d0efe3ab3152f15857298868dc2c3",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2",
+                "symfony/polyfill-mbstring": "~1.0",
+                "symfony/service-contracts": "^2.5|^3",
+                "symfony/string": "^6.4|^7.0"
+            },
+            "conflict": {
+                "symfony/dependency-injection": "<6.4",
+                "symfony/dotenv": "<6.4",
+                "symfony/event-dispatcher": "<6.4",
+                "symfony/lock": "<6.4",
+                "symfony/process": "<6.4"
+            },
+            "provide": {
+                "psr/log-implementation": "1.0|2.0|3.0"
+            },
+            "require-dev": {
+                "psr/log": "^1|^2|^3",
+                "symfony/config": "^6.4|^7.0",
+                "symfony/dependency-injection": "^6.4|^7.0",
+                "symfony/event-dispatcher": "^6.4|^7.0",
+                "symfony/http-foundation": "^6.4|^7.0",
+                "symfony/http-kernel": "^6.4|^7.0",
+                "symfony/lock": "^6.4|^7.0",
+                "symfony/messenger": "^6.4|^7.0",
+                "symfony/process": "^6.4|^7.0",
+                "symfony/stopwatch": "^6.4|^7.0",
+                "symfony/var-dumper": "^6.4|^7.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Console\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Eases the creation of beautiful and testable command line interfaces",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "cli",
+                "command-line",
+                "console",
+                "terminal"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/console/tree/v7.2.1"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2024-12-11T03:49:26+00:00"
+        },
+        {
+            "name": "symfony/deprecation-contracts",
+            "version": "v3.5.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/deprecation-contracts.git",
+                "reference": "74c71c939a79f7d5bf3c1ce9f5ea37ba0114c6f6"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/deprecation-contracts/zipball/74c71c939a79f7d5bf3c1ce9f5ea37ba0114c6f6",
+                "reference": "74c71c939a79f7d5bf3c1ce9f5ea37ba0114c6f6",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1"
+            },
+            "type": "library",
+            "extra": {
+                "thanks": {
+                    "url": "https://github.com/symfony/contracts",
+                    "name": "symfony/contracts"
+                },
+                "branch-alias": {
+                    "dev-main": "3.5-dev"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "function.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "A generic function and convention to trigger deprecation notices",
+            "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/deprecation-contracts/tree/v3.5.1"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2024-09-25T14:20:29+00:00"
+        },
+        {
+            "name": "symfony/event-dispatcher",
+            "version": "v7.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/event-dispatcher.git",
+                "reference": "910c5db85a5356d0fea57680defec4e99eb9c8c1"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/event-dispatcher/zipball/910c5db85a5356d0fea57680defec4e99eb9c8c1",
+                "reference": "910c5db85a5356d0fea57680defec4e99eb9c8c1",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2",
+                "symfony/event-dispatcher-contracts": "^2.5|^3"
+            },
+            "conflict": {
+                "symfony/dependency-injection": "<6.4",
+                "symfony/service-contracts": "<2.5"
+            },
+            "provide": {
+                "psr/event-dispatcher-implementation": "1.0",
+                "symfony/event-dispatcher-implementation": "2.0|3.0"
+            },
+            "require-dev": {
+                "psr/log": "^1|^2|^3",
+                "symfony/config": "^6.4|^7.0",
+                "symfony/dependency-injection": "^6.4|^7.0",
+                "symfony/error-handler": "^6.4|^7.0",
+                "symfony/expression-language": "^6.4|^7.0",
+                "symfony/http-foundation": "^6.4|^7.0",
+                "symfony/service-contracts": "^2.5|^3",
+                "symfony/stopwatch": "^6.4|^7.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\EventDispatcher\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Provides tools that allow your application components to communicate with each other by dispatching events and listening to them",
+            "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/event-dispatcher/tree/v7.2.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2024-09-25T14:21:43+00:00"
+        },
+        {
+            "name": "symfony/event-dispatcher-contracts",
+            "version": "v3.5.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/event-dispatcher-contracts.git",
+                "reference": "7642f5e970b672283b7823222ae8ef8bbc160b9f"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/event-dispatcher-contracts/zipball/7642f5e970b672283b7823222ae8ef8bbc160b9f",
+                "reference": "7642f5e970b672283b7823222ae8ef8bbc160b9f",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1",
+                "psr/event-dispatcher": "^1"
+            },
+            "type": "library",
+            "extra": {
+                "thanks": {
+                    "url": "https://github.com/symfony/contracts",
+                    "name": "symfony/contracts"
+                },
+                "branch-alias": {
+                    "dev-main": "3.5-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Contracts\\EventDispatcher\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Generic abstractions related to dispatching event",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "abstractions",
+                "contracts",
+                "decoupling",
+                "interfaces",
+                "interoperability",
+                "standards"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/event-dispatcher-contracts/tree/v3.5.1"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2024-09-25T14:20:29+00:00"
+        },
+        {
+            "name": "symfony/filesystem",
+            "version": "v7.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/filesystem.git",
+                "reference": "b8dce482de9d7c9fe2891155035a7248ab5c7fdb"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/filesystem/zipball/b8dce482de9d7c9fe2891155035a7248ab5c7fdb",
+                "reference": "b8dce482de9d7c9fe2891155035a7248ab5c7fdb",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2",
+                "symfony/polyfill-ctype": "~1.8",
+                "symfony/polyfill-mbstring": "~1.8"
+            },
+            "require-dev": {
+                "symfony/process": "^6.4|^7.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Filesystem\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Provides basic utilities for the filesystem",
+            "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/filesystem/tree/v7.2.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2024-10-25T15:15:23+00:00"
+        },
+        {
+            "name": "symfony/finder",
+            "version": "v7.2.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/finder.git",
+                "reference": "87a71856f2f56e4100373e92529eed3171695cfb"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/finder/zipball/87a71856f2f56e4100373e92529eed3171695cfb",
+                "reference": "87a71856f2f56e4100373e92529eed3171695cfb",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2"
+            },
+            "require-dev": {
+                "symfony/filesystem": "^6.4|^7.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Finder\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Finds files and directories via an intuitive fluent interface",
+            "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/finder/tree/v7.2.2"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2024-12-30T19:00:17+00:00"
+        },
+        {
+            "name": "symfony/options-resolver",
+            "version": "v7.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/options-resolver.git",
+                "reference": "7da8fbac9dcfef75ffc212235d76b2754ce0cf50"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/options-resolver/zipball/7da8fbac9dcfef75ffc212235d76b2754ce0cf50",
+                "reference": "7da8fbac9dcfef75ffc212235d76b2754ce0cf50",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2",
+                "symfony/deprecation-contracts": "^2.5|^3"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\OptionsResolver\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Provides an improved replacement for the array_replace PHP function",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "config",
+                "configuration",
+                "options"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/options-resolver/tree/v7.2.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2024-11-20T11:17:29+00:00"
+        },
+        {
+            "name": "symfony/polyfill-ctype",
+            "version": "v1.31.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-ctype.git",
+                "reference": "a3cc8b044a6ea513310cbd48ef7333b384945638"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/a3cc8b044a6ea513310cbd48ef7333b384945638",
+                "reference": "a3cc8b044a6ea513310cbd48ef7333b384945638",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.2"
+            },
+            "provide": {
+                "ext-ctype": "*"
+            },
+            "suggest": {
+                "ext-ctype": "For best performance"
+            },
+            "type": "library",
+            "extra": {
+                "thanks": {
+                    "url": "https://github.com/symfony/polyfill",
+                    "name": "symfony/polyfill"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ],
+                "psr-4": {
+                    "Symfony\\Polyfill\\Ctype\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Gert de Pagter",
+                    "email": "BackEndTea@gmail.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill for ctype functions",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "ctype",
+                "polyfill",
+                "portable"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/polyfill-ctype/tree/v1.31.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2024-09-09T11:45:10+00:00"
+        },
+        {
+            "name": "symfony/polyfill-intl-grapheme",
+            "version": "v1.31.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-intl-grapheme.git",
+                "reference": "b9123926e3b7bc2f98c02ad54f6a4b02b91a8abe"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-intl-grapheme/zipball/b9123926e3b7bc2f98c02ad54f6a4b02b91a8abe",
+                "reference": "b9123926e3b7bc2f98c02ad54f6a4b02b91a8abe",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.2"
+            },
+            "suggest": {
+                "ext-intl": "For best performance"
+            },
+            "type": "library",
+            "extra": {
+                "thanks": {
+                    "url": "https://github.com/symfony/polyfill",
+                    "name": "symfony/polyfill"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ],
+                "psr-4": {
+                    "Symfony\\Polyfill\\Intl\\Grapheme\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill for intl's grapheme_* functions",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "grapheme",
+                "intl",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/polyfill-intl-grapheme/tree/v1.31.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2024-09-09T11:45:10+00:00"
+        },
+        {
+            "name": "symfony/polyfill-intl-normalizer",
+            "version": "v1.31.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-intl-normalizer.git",
+                "reference": "3833d7255cc303546435cb650316bff708a1c75c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-intl-normalizer/zipball/3833d7255cc303546435cb650316bff708a1c75c",
+                "reference": "3833d7255cc303546435cb650316bff708a1c75c",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.2"
+            },
+            "suggest": {
+                "ext-intl": "For best performance"
+            },
+            "type": "library",
+            "extra": {
+                "thanks": {
+                    "url": "https://github.com/symfony/polyfill",
+                    "name": "symfony/polyfill"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ],
+                "psr-4": {
+                    "Symfony\\Polyfill\\Intl\\Normalizer\\": ""
+                },
+                "classmap": [
+                    "Resources/stubs"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill for intl's Normalizer class and related functions",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "intl",
+                "normalizer",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/polyfill-intl-normalizer/tree/v1.31.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2024-09-09T11:45:10+00:00"
+        },
+        {
+            "name": "symfony/polyfill-mbstring",
+            "version": "v1.31.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-mbstring.git",
+                "reference": "85181ba99b2345b0ef10ce42ecac37612d9fd341"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/85181ba99b2345b0ef10ce42ecac37612d9fd341",
+                "reference": "85181ba99b2345b0ef10ce42ecac37612d9fd341",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.2"
+            },
+            "provide": {
+                "ext-mbstring": "*"
+            },
+            "suggest": {
+                "ext-mbstring": "For best performance"
+            },
+            "type": "library",
+            "extra": {
+                "thanks": {
+                    "url": "https://github.com/symfony/polyfill",
+                    "name": "symfony/polyfill"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ],
+                "psr-4": {
+                    "Symfony\\Polyfill\\Mbstring\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill for the Mbstring extension",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "mbstring",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/polyfill-mbstring/tree/v1.31.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2024-09-09T11:45:10+00:00"
+        },
+        {
+            "name": "symfony/polyfill-php80",
+            "version": "v1.31.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-php80.git",
+                "reference": "60328e362d4c2c802a54fcbf04f9d3fb892b4cf8"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-php80/zipball/60328e362d4c2c802a54fcbf04f9d3fb892b4cf8",
+                "reference": "60328e362d4c2c802a54fcbf04f9d3fb892b4cf8",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.2"
+            },
+            "type": "library",
+            "extra": {
+                "thanks": {
+                    "url": "https://github.com/symfony/polyfill",
+                    "name": "symfony/polyfill"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ],
+                "psr-4": {
+                    "Symfony\\Polyfill\\Php80\\": ""
+                },
+                "classmap": [
+                    "Resources/stubs"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Ion Bazan",
+                    "email": "ion.bazan@gmail.com"
+                },
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill backporting some PHP 8.0+ features to lower PHP versions",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/polyfill-php80/tree/v1.31.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2024-09-09T11:45:10+00:00"
+        },
+        {
+            "name": "symfony/polyfill-php81",
+            "version": "v1.31.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-php81.git",
+                "reference": "4a4cfc2d253c21a5ad0e53071df248ed48c6ce5c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-php81/zipball/4a4cfc2d253c21a5ad0e53071df248ed48c6ce5c",
+                "reference": "4a4cfc2d253c21a5ad0e53071df248ed48c6ce5c",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.2"
+            },
+            "type": "library",
+            "extra": {
+                "thanks": {
+                    "url": "https://github.com/symfony/polyfill",
+                    "name": "symfony/polyfill"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ],
+                "psr-4": {
+                    "Symfony\\Polyfill\\Php81\\": ""
+                },
+                "classmap": [
+                    "Resources/stubs"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill backporting some PHP 8.1+ features to lower PHP versions",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/polyfill-php81/tree/v1.31.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2024-09-09T11:45:10+00:00"
+        },
+        {
+            "name": "symfony/process",
+            "version": "v7.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/process.git",
+                "reference": "d34b22ba9390ec19d2dd966c40aa9e8462f27a7e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/process/zipball/d34b22ba9390ec19d2dd966c40aa9e8462f27a7e",
+                "reference": "d34b22ba9390ec19d2dd966c40aa9e8462f27a7e",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Process\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Executes commands in sub-processes",
+            "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/process/tree/v7.2.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2024-11-06T14:24:19+00:00"
+        },
+        {
+            "name": "symfony/service-contracts",
+            "version": "v3.5.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/service-contracts.git",
+                "reference": "e53260aabf78fb3d63f8d79d69ece59f80d5eda0"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/service-contracts/zipball/e53260aabf78fb3d63f8d79d69ece59f80d5eda0",
+                "reference": "e53260aabf78fb3d63f8d79d69ece59f80d5eda0",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1",
+                "psr/container": "^1.1|^2.0",
+                "symfony/deprecation-contracts": "^2.5|^3"
+            },
+            "conflict": {
+                "ext-psr": "<1.1|>=2"
+            },
+            "type": "library",
+            "extra": {
+                "thanks": {
+                    "url": "https://github.com/symfony/contracts",
+                    "name": "symfony/contracts"
+                },
+                "branch-alias": {
+                    "dev-main": "3.5-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Contracts\\Service\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Test/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Generic abstractions related to writing services",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "abstractions",
+                "contracts",
+                "decoupling",
+                "interfaces",
+                "interoperability",
+                "standards"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/service-contracts/tree/v3.5.1"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2024-09-25T14:20:29+00:00"
+        },
+        {
+            "name": "symfony/stopwatch",
+            "version": "v7.2.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/stopwatch.git",
+                "reference": "e46690d5b9d7164a6d061cab1e8d46141b9f49df"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/stopwatch/zipball/e46690d5b9d7164a6d061cab1e8d46141b9f49df",
+                "reference": "e46690d5b9d7164a6d061cab1e8d46141b9f49df",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2",
+                "symfony/service-contracts": "^2.5|^3"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Stopwatch\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Provides a way to profile code",
+            "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/stopwatch/tree/v7.2.2"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2024-12-18T14:28:33+00:00"
+        },
+        {
+            "name": "symfony/string",
+            "version": "v7.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/string.git",
+                "reference": "446e0d146f991dde3e73f45f2c97a9faad773c82"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/string/zipball/446e0d146f991dde3e73f45f2c97a9faad773c82",
+                "reference": "446e0d146f991dde3e73f45f2c97a9faad773c82",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2",
+                "symfony/polyfill-ctype": "~1.8",
+                "symfony/polyfill-intl-grapheme": "~1.0",
+                "symfony/polyfill-intl-normalizer": "~1.0",
+                "symfony/polyfill-mbstring": "~1.0"
+            },
+            "conflict": {
+                "symfony/translation-contracts": "<2.5"
+            },
+            "require-dev": {
+                "symfony/emoji": "^7.1",
+                "symfony/error-handler": "^6.4|^7.0",
+                "symfony/http-client": "^6.4|^7.0",
+                "symfony/intl": "^6.4|^7.0",
+                "symfony/translation-contracts": "^2.5|^3.0",
+                "symfony/var-exporter": "^6.4|^7.0"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "Resources/functions.php"
+                ],
+                "psr-4": {
+                    "Symfony\\Component\\String\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Provides an object-oriented API to strings and deals with bytes, UTF-8 code points and grapheme clusters in a unified way",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "grapheme",
+                "i18n",
+                "string",
+                "unicode",
+                "utf-8",
+                "utf8"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/string/tree/v7.2.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2024-11-13T13:31:26+00:00"
+        }
+    ],
+    "packages-dev": [],
+    "aliases": [],
+    "minimum-stability": "stable",
+    "stability-flags": {},
+    "prefer-stable": false,
+    "prefer-lowest": false,
+    "platform": {},
+    "platform-dev": {},
+    "plugin-api-version": "2.6.0"
+}


### PR DESCRIPTION
Moved dev tools to their own composer.json, so that we can get the newest versions while still supporting PHP 7.2 for the main composer.json.

Styling changes are due to updated php-cs-fixer, no rules were changed.