### PR TITLE
fix: Create deep copy before checking each sub schema in oneOf

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Add required permissions for welcome action ([#789](https://github.com/jsonrainbow/json-schema/pull/789))
 - Upgrade php cs fixer to latest ([#783](https://github.com/jsonrainbow/json-schema/pull/783))
+- Create deep copy before checking each sub schema in oneOf ([#791](https://github.com/jsonrainbow/json-schema/pull/791))
 
 ### Changed
 - Used PHPStan's int-mask-of<T> type where applicable ([#779](https://github.com/jsonrainbow/json-schema/pull/779))

--- a/src/JsonSchema/Constraints/UndefinedConstraint.php
+++ b/src/JsonSchema/Constraints/UndefinedConstraint.php
@@ -15,6 +15,7 @@ use JsonSchema\ConstraintError;
 use JsonSchema\Constraints\TypeCheck\LooseTypeCheck;
 use JsonSchema\Entity\JsonPointer;
 use JsonSchema\Exception\ValidationException;
+use JsonSchema\Tool\DeepCopy;
 use JsonSchema\Uri\UriResolver;
 
 /**
@@ -352,14 +353,17 @@ class UndefinedConstraint extends Constraint
 
         if (isset($schema->oneOf)) {
             $allErrors = [];
-            $matchedSchemas = 0;
+            $matchedSchemas = [];
             $startErrors = $this->getErrors();
+
             foreach ($schema->oneOf as $oneOf) {
                 try {
                     $this->errors = [];
-                    $this->checkUndefined($value, $oneOf, $path, $i);
-                    if (count($this->getErrors()) == 0) {
-                        $matchedSchemas++;
+
+                    $valueDeepCopy = DeepCopy::copyOf($value);
+                    $this->checkUndefined($valueDeepCopy, $oneOf, $path, $i);
+                    if (count($this->getErrors()) === 0) {
+                        $matchedSchemas[] = ['schema' => $oneOf, 'value' => $valueDeepCopy];
                     }
                     $allErrors = array_merge($allErrors, array_values($this->getErrors()));
                 } catch (ValidationException $e) {
@@ -367,11 +371,12 @@ class UndefinedConstraint extends Constraint
                     // other schema options in the OneOf field.
                 }
             }
-            if ($matchedSchemas !== 1) {
+            if (count($matchedSchemas) !== 1) {
                 $this->addErrors(array_merge($allErrors, $startErrors));
                 $this->addError(ConstraintError::ONE_OF(), $path);
             } else {
                 $this->errors = $startErrors;
+                $value = $matchedSchemas[0]['value'];
             }
         }
     }

--- a/src/JsonSchema/Constraints/UndefinedConstraint.php
+++ b/src/JsonSchema/Constraints/UndefinedConstraint.php
@@ -355,14 +355,16 @@ class UndefinedConstraint extends Constraint
             $allErrors = [];
             $matchedSchemas = [];
             $startErrors = $this->getErrors();
+            $coerce = $this->factory->getConfig(self::CHECK_MODE_COERCE_TYPES);
+
             foreach ($schema->oneOf as $oneOf) {
                 try {
                     $this->errors = [];
 
-                    $valueDeepCopy = DeepCopy::copyOf($value);
-                    $this->checkUndefined($valueDeepCopy, $oneOf, $path, $i);
+                    $oneOfValue = $coerce ? DeepCopy::copyOf($value) : $value;
+                    $this->checkUndefined($oneOfValue, $oneOf, $path, $i);
                     if (count($this->getErrors()) === 0) {
-                        $matchedSchemas[] = ['schema' => $oneOf, 'value' => $valueDeepCopy];
+                        $matchedSchemas[] = ['schema' => $oneOf, 'value' => $oneOfValue];
                     }
                     $allErrors = array_merge($allErrors, array_values($this->getErrors()));
                 } catch (ValidationException $e) {

--- a/src/JsonSchema/Constraints/UndefinedConstraint.php
+++ b/src/JsonSchema/Constraints/UndefinedConstraint.php
@@ -355,7 +355,6 @@ class UndefinedConstraint extends Constraint
             $allErrors = [];
             $matchedSchemas = [];
             $startErrors = $this->getErrors();
-
             foreach ($schema->oneOf as $oneOf) {
                 try {
                     $this->errors = [];

--- a/src/JsonSchema/Tool/DeepCopy.php
+++ b/src/JsonSchema/Tool/DeepCopy.php
@@ -11,6 +11,7 @@ class DeepCopy
 {
     /**
      * @param mixed $input
+     *
      * @return mixed
      */
     public static function copyOf($input)

--- a/src/JsonSchema/Tool/DeepCopy.php
+++ b/src/JsonSchema/Tool/DeepCopy.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JsonSchema\Tool;
+
+use JsonSchema\Exception\JsonDecodingException;
+use JsonSchema\Exception\RuntimeException;
+
+class DeepCopy
+{
+    /**
+     * @param mixed $input
+     * @return mixed
+     */
+    public static function copyOf($input)
+    {
+        $json = json_encode($input);
+        if (JSON_ERROR_NONE < $error = json_last_error()) {
+            throw new JsonDecodingException($error);
+        }
+
+        if ($json === false) {
+            throw new RuntimeException('Failed to encode input to JSON: ' . json_last_error_msg());
+        }
+
+        return json_decode($json, self::isAssociativeArray($input));
+    }
+
+    /**
+     * @param mixed $input
+     */
+    private static function isAssociativeArray($input): bool
+    {
+        return is_array($input) && array_keys($input) !== range(0, count($input) - 1);
+    }
+}

--- a/tests/Constraints/UndefinedConstraintTest.php
+++ b/tests/Constraints/UndefinedConstraintTest.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JsonSchema\Tests\Constraints;
+
+use JsonSchema\Constraints\Constraint;
+
+class UndefinedConstraintTest extends BaseTestCase
+{
+    /**
+     * @return array{}
+     */
+    public function getInvalidTests(): array
+    {
+        return [];
+    }
+
+    /**
+     * @return array<string, array{input: string, schema: string, checkMode?: int}>
+     */
+    public function getValidTests(): array
+    {
+        return [
+            'oneOf with type coercion should not affect value passed to each sub schema (#790)' => [
+                'input' => <<<JSON
+                    {
+                        "id": "LOC1",
+                        "related_locations": [
+                            {
+                                "latitude": "51.047598",
+                                "longitude": "3.729943"
+                            }
+                        ]
+                    }
+JSON,
+                'schema' => <<<JSON
+                    {
+                        "title": "Location",
+                        "type": "object",
+                        "properties": {
+                            "id": {
+                                "type": "string"
+                            },
+                            "related_locations": {
+                                "oneOf": [
+                                    {
+                                        "type": "null"
+                                    },
+                                    {
+                                        "type": "array",
+                                        "items": {
+                                            "type": "object",
+                                            "properties": {
+                                                "latitude": {
+                                                    "type": "string"
+                                                },
+                                                "longitude": {
+                                                    "type": "string"
+                                                }
+                                            }
+                                        }
+                                    }
+                                ]
+                            }
+                        }
+                    }
+JSON,
+                'checkMode' => Constraint::CHECK_MODE_COERCE_TYPES
+            ]
+        ];
+    }
+}

--- a/tests/Constraints/UndefinedConstraintTest.php
+++ b/tests/Constraints/UndefinedConstraintTest.php
@@ -33,7 +33,8 @@ class UndefinedConstraintTest extends BaseTestCase
                             }
                         ]
                     }
-JSON,
+JSON
+                ,
                 'schema' => <<<JSON
                     {
                         "title": "Location",
@@ -65,7 +66,8 @@ JSON,
                             }
                         }
                     }
-JSON,
+JSON
+                ,
                 'checkMode' => Constraint::CHECK_MODE_COERCE_TYPES
             ]
         ];

--- a/tests/Tool/DeepCopyTest.php
+++ b/tests/Tool/DeepCopyTest.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JsonSchema\Tests\Tool;
+
+use JsonSchema\Tool\DeepCopy;
+use PHPUnit\Framework\TestCase;
+
+class DeepCopyTest extends TestCase
+{
+    public function testCanDeepCopyObject(): void
+    {
+        $input = (object) ['foo' => 'bar'];
+
+        $result = DeepCopy::copyOf($input);
+
+        self::assertEquals($input, $result);
+        self::assertNotSame($input, $result);
+    }
+
+    public function testCanDeepCopyObjectWithChildObject(): void
+    {
+        $child = (object) ['bar' => 'baz'];
+        $input = (object) ['foo' => $child];
+
+        $result = DeepCopy::copyOf($input);
+
+        self::assertEquals($input, $result);
+        self::assertNotSame($input, $result);
+        self::assertEquals($input->foo, $result->foo);
+        self::assertNotSame($input->foo, $result->foo);
+    }
+
+    public function testCanDeepCopyArray(): void
+    {
+        $input = ['foo' => 'bar'];
+
+        $result = DeepCopy::copyOf($input);
+
+        self::assertEquals($input, $result);
+    }
+
+    public function testCanDeepCopyArrayWithNestedArray(): void
+    {
+        $nested = ['bar' => 'baz'];
+        $input = ['foo' => $nested];
+
+        $result = DeepCopy::copyOf($input);
+
+        self::assertEquals($input, $result);
+    }
+}


### PR DESCRIPTION
This PR creates a deep copy of the value before passing it by reference for validating sub schemas of a `oneOf` with type coercion enabled.

Fixes #790 