### PR TITLE
refactor: cleanup redundant checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Used PHPStan's int-mask-of<T> type where applicable ([#779](https://github.com/jsonrainbow/json-schema/pull/779))
 - Fixed some PHPStan errors ([#781](https://github.com/jsonrainbow/json-schema/pull/781))
+- Cleanup redundant checks ([#796](https://github.com/jsonrainbow/json-schema/pull/796))
 
 ## [6.1.0] - 2025-02-04
 ### Added

--- a/tests/ValidatorTest.php
+++ b/tests/ValidatorTest.php
@@ -4,6 +4,7 @@ namespace JsonSchema\Tests;
 
 use JsonSchema\Validator;
 use PHPUnit\Framework\TestCase;
+use JsonSchema\Exception\InvalidArgumentException;
 
 class ValidatorTest extends TestCase
 {
@@ -31,18 +32,12 @@ class ValidatorTest extends TestCase
 
     public function testBadAssocSchemaInput(): void
     {
-        if (version_compare(phpversion(), '5.5.0', '<')) {
-            $this->markTestSkipped('PHP versions < 5.5.0 trigger an error on json_encode issues');
-        }
-        if (defined('HHVM_VERSION')) {
-            $this->markTestSkipped('HHVM has no problem with encoding resources');
-        }
-        $schema = ['propertyOne' => fopen('php://stdout', 'w')];
+        $schema = ['propertyOne' => fopen('php://stdout', 'wb')];
         $data = json_decode('{"propertyOne":[42]}', true);
 
         $validator = new Validator();
 
-        $this->expectException('\JsonSchema\Exception\InvalidArgumentException');
+        $this->expectException(InvalidArgumentException::class);
         $validator->validate($data, $schema);
     }
 

--- a/tests/ValidatorTest.php
+++ b/tests/ValidatorTest.php
@@ -2,9 +2,9 @@
 
 namespace JsonSchema\Tests;
 
+use JsonSchema\Exception\InvalidArgumentException;
 use JsonSchema\Validator;
 use PHPUnit\Framework\TestCase;
-use JsonSchema\Exception\InvalidArgumentException;
 
 class ValidatorTest extends TestCase
 {


### PR DESCRIPTION
Fixes #793 removing PHP 5.5 and HHVM checks