### PR TITLE
fix: replace filter_var for uri and uri-reference to userland code to be RFC 3986 compliant

### DIFF
--- a/src/JsonSchema/Tool/Validator/RelativeReferenceValidator.php
+++ b/src/JsonSchema/Tool/Validator/RelativeReferenceValidator.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JsonSchema\Tool\Validator;
+
+class RelativeReferenceValidator
+{
+    public static function isValid(string $ref): bool
+    {
+        // Relative reference pattern as per RFC 3986, Section 4.1
+        $pattern = '/^(([^\/?#]+):)?(\/\/([^\/?#]*))?([^?#]*)(\?([^#]*))?(#(.*))?$/';
+
+        if (preg_match($pattern, $ref) !== 1) {
+            return false;
+        }
+
+        // Additional checks for invalid cases
+        if (preg_match('/^(http|https):\/\//', $ref)) {
+            return false; // Absolute URI
+        }
+
+        if (preg_match('/^:\/\//', $ref)) {
+            return false; // Missing scheme in authority
+        }
+
+        if (preg_match('/^:\//', $ref)) {
+            return false; // Invalid scheme separator
+        }
+
+        if (preg_match('/^\/\/$/', $ref)) {
+            return false; // Empty authority
+        }
+
+        if (preg_match('/^\/\/\/[^\/]/', $ref)) {
+            return false; // Invalid authority with three slashes
+        }
+
+        if (preg_match('/\s/', $ref)) {
+            return false; // Spaces are not allowed in URIs
+        }
+
+        if (preg_match('/^\?#|^#$/', $ref)) {
+            return false; // Missing path but having query and fragment
+        }
+
+        if ($ref === '#' || $ref === '?') {
+            return false; // Missing path and having only fragment or query
+        }
+
+        return true;
+    }
+}

--- a/src/JsonSchema/Tool/Validator/UriValidator.php
+++ b/src/JsonSchema/Tool/Validator/UriValidator.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JsonSchema\Tool\Validator;
+
+class UriValidator
+{
+    public static function isValid(string $uri): bool
+    {
+        // RFC 3986: Hierarchical URIs (http, https, ftp, etc.)
+        $hierarchicalPattern = '/^
+            ([a-z][a-z0-9+\-.]*):\/\/                # Scheme (http, https, ftp, etc.)
+            (?:([^:@\/?#]+)(?::([^@\/?#]*))?@)?      # Optional userinfo (user:pass@)
+            ([a-z0-9.-]+|\[[a-f0-9:.]+\])            # Hostname or IPv6 in brackets
+            (?::(\d{1,5}))?                          # Optional port
+            (\/[a-zA-Z0-9._~!$&\'()*+,;=:@\/%-]*)*   # Path (valid characters only)
+            (\?([^#]*))?                             # Optional query
+            (\#(.*))?                                # Optional fragment
+        $/ix';
+
+        // RFC 3986: Non-Hierarchical URIs (mailto, data, urn)
+        $nonHierarchicalPattern = '/^
+            (mailto|data|urn):                        # Only allow known non-hierarchical schemes
+            (.+)                                      # Must contain at least one character after scheme
+        $/ix';
+
+        // RFC 5322-compliant email validation for `mailto:` URIs
+        $emailPattern = '/^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$/';
+
+        // First, check if it's a valid hierarchical URI
+        if (preg_match($hierarchicalPattern, $uri, $matches) === 1) {
+            // Validate domain name (no double dots like example..com)
+            if (!empty($matches[4]) && preg_match('/\.\./', $matches[4])) {
+                return false;
+            }
+
+            // Validate port (should be between 1 and 65535 if specified)
+            if (!empty($matches[5]) && ($matches[5] < 1 || $matches[5] > 65535)) {
+                return false;
+            }
+
+            // Validate path (reject illegal characters: < > { } | \ ^ `)
+            if (!empty($matches[6]) && preg_match('/[<>{}|\\\^`]/', $matches[6])) {
+                return false;
+            }
+
+            return true;
+        }
+
+        // If not hierarchical, check non-hierarchical URIs
+        if (preg_match($nonHierarchicalPattern, $uri, $matches) === 1) {
+            $scheme = strtolower($matches[1]); // Extract the scheme
+
+            // Special case: `mailto:` must contain a **valid email address**
+            if ($scheme === 'mailto') {
+                return preg_match($emailPattern, $matches[2]) === 1;
+            }
+
+            return true; // Valid non-hierarchical URI
+        }
+
+        return false;
+    }
+}

--- a/tests/Tool/Validator/RelativeReferenceValidatorTest.php
+++ b/tests/Tool/Validator/RelativeReferenceValidatorTest.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tool\Validator;
+
+use JsonSchema\Tool\Validator\RelativeReferenceValidator;
+use PHPUnit\Framework\TestCase;
+
+class RelativeReferenceValidatorTest extends TestCase
+{
+    /** @dataProvider validRelativeReferenceDataProvider */
+    public function testValidRelativeReferencesAreValidatedAsSuch(string $ref): void
+    {
+        self::assertTrue(RelativeReferenceValidator::isValid($ref));
+    }
+
+    /** @dataProvider invalidRelativeReferenceDataProvider */
+    public function testInvalidRelativeReferencesAreValidatedAsSuch(string $ref): void
+    {
+        self::assertFalse(RelativeReferenceValidator::isValid($ref));
+    }
+
+    public function validRelativeReferenceDataProvider(): \Generator
+    {
+        yield 'Relative path from root' => ['ref' => '/relative/path'];
+        yield 'Relative path up one level' => ['ref' => '../up-one-level'];
+        yield 'Relative path from current' => ['ref' => 'foo/bar'];
+    }
+
+    public function invalidRelativeReferenceDataProvider(): \Generator
+    {
+        yield 'Absolute URI' => ['ref' => 'http://example.com'];
+        yield 'Three slashes' => ['ref' => '///three/slashes'];
+        yield 'Path with spaces' => ['ref' => '/path with spaces'];
+        yield 'No path having query and fragment' => ['ref' => '?#invalid'];
+        yield 'Missing path having fragment' => ['ref' => '#'];
+        yield 'Missing path having query' => ['ref' => '?'];
+    }
+}

--- a/tests/Tool/Validator/UriValidatorTest.php
+++ b/tests/Tool/Validator/UriValidatorTest.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tool\Validator;
+
+use JsonSchema\Tool\Validator\UriValidator;
+use PHPUnit\Framework\TestCase;
+
+class UriValidatorTest extends TestCase
+{
+    /** @dataProvider validUriDataProvider */
+    public function testValidUrisAreValidatedAsSuch(string $uri): void
+    {
+        self::assertTrue(UriValidator::isValid($uri));
+    }
+
+    /** @dataProvider invalidUriDataProvider */
+    public function testInvalidUrisAreValidatedAsSuch(string $uri): void
+    {
+        self::assertFalse(UriValidator::isValid($uri));
+    }
+
+    public function validUriDataProvider(): \Generator
+    {
+        yield 'Simple HTTP URI' => ['uri' => 'https://example.com'];
+        yield 'Subdomain HTTP URI' => ['uri' => 'https://sub.domain.example.com'];
+        yield 'Full HTTP URI' => ['uri' => 'https://example.com:8080/path/to/resource?query=string#fragment'];
+        yield 'Full FTP URI' => ['uri' => 'ftp://user:pass@ftp.example.com:21/path'];
+        yield 'IPV6 HTTP URI' => ['uri' => 'http://[2001:db8::ff00:42:8329]'];
+        yield 'Mailto URI' => ['uri' => 'mailto:user@example.com'];
+        yield 'Data URI' => ['uri' => 'data:text/plain;charset=utf-8,Hello%20World!'];
+        yield 'ISBN URN URI' => ['uri' => 'urn:isbn:0451450523'];
+        yield 'OASIS URN URI' => ['uri' => 'urn:oasis:names:specification:docbook:dtd:xml:4.1.2'];
+    }
+
+    public function invalidUriDataProvider(): \Generator
+    {
+        yield 'Invalid schema' => ['uri' => 'ht!tp://example.com'];
+        yield 'Missing schema' => ['uri' => '://example.com'];
+        yield 'Double dot in domain' => ['uri' => 'https://example..com'];
+        yield 'To high of a port number' => ['uri' => 'https://example.com:65536'];
+        yield 'Invalid path characters with "<>"' => ['uri' => 'http://example.com/<>'];
+        yield 'Invalid path characters with "{}"' => ['uri' => 'http://example.com/{bad}'];
+        yield 'Invalid path characters with "^"' => ['uri' => 'http://example.com/^invalid'];
+        yield 'Only mailto:' => ['uri' => 'mailto:'];
+        yield 'Invalid email used in mailto:' => ['uri' => 'mailto:user@.com'];
+    }
+}


### PR DESCRIPTION
This pull request introduces new validators for URI and relative references and integrates them into the `FormatConstraint` class. The changes also include corresponding unit tests to ensure the validators work as expected.

### New Validators:
* [`src/JsonSchema/Tool/Validator/UriValidator.php`](diffhunk://#diff-2019f410f3ef4cdf8478ffa71444226beb8a118d60b3337c40eaaec8d3aef7a3R1-R65): Added a new class `UriValidator` to validate URIs according to RFC 3986 and RFC 5322 for `mailto:` URIs.
* [`src/JsonSchema/Tool/Validator/RelativeReferenceValidator.php`](diffhunk://#diff-0bfeeb9c38593a2d65cc2e8c49fe873c78765eac81c00cf0a398bd754ca9c7a8R1-R53): Added a new class `RelativeReferenceValidator` to validate relative references according to RFC 3986.

### Integration into `FormatConstraint`:
* [`src/JsonSchema/Constraints/FormatConstraint.php`](diffhunk://#diff-44020f0c0690a2a4c1c446e97185986c31b19374b4a99f4b0970c5df36279067L104-R114): Integrated the new `UriValidator` and `RelativeReferenceValidator` into the `check` method to replace the previous inline validation logic for `uri` and `uri-reference` formats.

### Unit Tests:
* [`tests/Tool/Validator/UriValidatorTest.php`](diffhunk://#diff-6b107cb8679795fb59c070ba500d0646f6d357e4c03a585f4a0c67181e4101fcR1-R49): Added unit tests for `UriValidator` to ensure it correctly validates valid and invalid URIs.
* [`tests/Tool/Validator/RelativeReferenceValidatorTest.php`](diffhunk://#diff-97a7acc2a16f7653d307a16e356c7545b0a0bc26156ce60f7ca13332a6656729R1-R40): Added unit tests for `RelativeReferenceValidator` to ensure it correctly validates valid and invalid relative references.

# Closing keywords
fixes https://github.com/jsonrainbow/json-schema/issues/685