### PR TITLE
refactor: replace icecave/parity with custom deep comparator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - only check minProperties or maxProperties on objects ([#802](https://github.com/jsonrainbow/json-schema/pull/802))
 - replace filter_var for uri and uri-reference to userland code to be RFC 3986 compliant ([#800](https://github.com/jsonrainbow/json-schema/pull/800))
 
+## Changed
+- replace icecave/parity with custom deep comparator ([#803](https://github.com/jsonrainbow/json-schema/pull/803))
+- 
 ## [6.2.1] - 2025-03-06
 ### Fixed
 - allow items: true to pass validation ([#801](https://github.com/jsonrainbow/json-schema/pull/801))

--- a/composer.json
+++ b/composer.json
@@ -29,8 +29,7 @@
     "require": {
         "php": "^7.2 || ^8.0",
         "ext-json": "*",
-        "marc-mabe/php-enum":"^4.0",
-        "icecave/parity": "^3.0"
+        "marc-mabe/php-enum":"^4.0"
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "3.3.0",

--- a/src/JsonSchema/Constraints/ConstConstraint.php
+++ b/src/JsonSchema/Constraints/ConstConstraint.php
@@ -11,9 +11,9 @@ declare(strict_types=1);
 
 namespace JsonSchema\Constraints;
 
-use Icecave\Parity\Parity;
 use JsonSchema\ConstraintError;
 use JsonSchema\Entity\JsonPointer;
+use JsonSchema\Tool\DeepComparer;
 
 /**
  * The ConstConstraint Constraints, validates an element against a constant value
@@ -36,13 +36,13 @@ class ConstConstraint extends Constraint
         $type = gettype($element);
         $constType = gettype($const);
 
-        if ($this->factory->getConfig(self::CHECK_MODE_TYPE_CAST) && $type == 'array' && $constType == 'object') {
-            if (Parity::isEqualTo((object) $element, $const)) {
+        if ($this->factory->getConfig(self::CHECK_MODE_TYPE_CAST) && $type === 'array' && $constType === 'object') {
+            if (DeepComparer::isEqual((object) $element, $const)) {
                 return;
             }
         }
 
-        if (Parity::isEqualTo($element, $const)) {
+        if (DeepComparer::isEqual($element, $const)) {
             return;
         }
 

--- a/src/JsonSchema/Constraints/EnumConstraint.php
+++ b/src/JsonSchema/Constraints/EnumConstraint.php
@@ -11,9 +11,9 @@ declare(strict_types=1);
 
 namespace JsonSchema\Constraints;
 
-use Icecave\Parity\Parity;
 use JsonSchema\ConstraintError;
 use JsonSchema\Entity\JsonPointer;
+use JsonSchema\Tool\DeepComparer;
 
 /**
  * The EnumConstraint Constraints, validates an element against a given set of possibilities
@@ -36,14 +36,15 @@ class EnumConstraint extends Constraint
 
         foreach ($schema->enum as $enum) {
             $enumType = gettype($enum);
-            if ($this->factory->getConfig(self::CHECK_MODE_TYPE_CAST) && $type == 'array' && $enumType == 'object') {
-                if (Parity::isEqualTo((object) $element, $enum)) {
+
+            if ($this->factory->getConfig(self::CHECK_MODE_TYPE_CAST) && $type === 'array' && $enumType === 'object') {
+                if (DeepComparer::isEqual((object) $element, $enum)) {
                     return;
                 }
             }
 
             if ($type === gettype($enum)) {
-                if (Parity::isEqualTo($element, $enum)) {
+                if (DeepComparer::isEqual($element, $enum)) {
                     return;
                 }
             }

--- a/src/JsonSchema/Tool/DeepComparer.php
+++ b/src/JsonSchema/Tool/DeepComparer.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JsonSchema\Tool;
+
+use phpDocumentor\Reflection\Types\True_;
+
+class DeepComparer
+{
+    public static function isEqual($left, $right): bool
+    {
+        $isLeftScalar = is_scalar($left);
+        $isRightScalar = is_scalar($right);
+
+        if ($isLeftScalar && $isRightScalar) {
+            return $left === $right;
+        }
+
+        if ($isLeftScalar !== $isRightScalar) {
+            return false;
+        }
+
+        if (is_array($left) && is_array($right)) {
+            return self::isArrayEqual($left, $right);
+        }
+
+        if ($left instanceof \stdClass && $right instanceof \stdClass) {
+            return self::isArrayEqual((array) $left, (array) $right);
+        }
+
+        return false;
+    }
+
+    private static function isArrayEqual(array $left, array $right): bool
+    {
+        if (count($left) !== count($right)) {
+            return false;
+        }
+        foreach ($left as $key => $value) {
+            if (!array_key_exists($key, $right)) {
+                return false;
+            }
+
+            if (!self::isEqual($value, $right[$key])) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+}

--- a/src/JsonSchema/Tool/DeepComparer.php
+++ b/src/JsonSchema/Tool/DeepComparer.php
@@ -4,10 +4,12 @@ declare(strict_types=1);
 
 namespace JsonSchema\Tool;
 
-use phpDocumentor\Reflection\Types\True_;
-
 class DeepComparer
 {
+    /**
+     * @param mixed $left
+     * @param mixed $right
+     */
     public static function isEqual($left, $right): bool
     {
         $isLeftScalar = is_scalar($left);
@@ -32,6 +34,10 @@ class DeepComparer
         return false;
     }
 
+    /**
+     * @param array<string|int, mixed> $left
+     * @param array<string|int, mixed> $right
+     */
     private static function isArrayEqual(array $left, array $right): bool
     {
         if (count($left) !== count($right)) {
@@ -49,5 +55,4 @@ class DeepComparer
 
         return true;
     }
-
 }

--- a/tests/Tool/DeepComparerTest.php
+++ b/tests/Tool/DeepComparerTest.php
@@ -91,5 +91,4 @@ class DeepComparerTest extends TestCase
             }
         }
     }
-
 }

--- a/tests/Tool/DeepComparerTest.php
+++ b/tests/Tool/DeepComparerTest.php
@@ -1,0 +1,95 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JsonSchema\Tests\Tool;
+
+use JsonSchema\Tool\DeepComparer;
+use PHPUnit\Framework\TestCase;
+
+class DeepComparerTest extends TestCase
+{
+    /**
+     * @dataProvider equalDataProvider
+     */
+    public function testComparesDeepEqualForEqualLeftAndRight($left, $right): void
+    {
+        self::assertTrue(DeepComparer::isEqual($left, $right));
+    }
+
+    /**
+     * @dataProvider notEqualDataProvider
+     */
+    public function testComparesDeepEqualForNotEqualLeftAndRight($left, $right): void
+    {
+        self::assertFalse(DeepComparer::isEqual($left, $right));
+    }
+
+    public function equalDataProvider(): \Generator
+    {
+        yield 'Boolean true' => [true, true];
+        yield 'Boolean false' => [false, false];
+
+        yield 'Integer one' => [1, 1];
+        yield 'Integer INT MIN' => [PHP_INT_MIN, PHP_INT_MIN];
+        yield 'Integer INT MAX' => [PHP_INT_MAX, PHP_INT_MAX];
+
+        yield 'Float PI' => [M_PI, M_PI];
+
+        yield 'String' => ['hello world!', 'hello world!'];
+
+        yield 'array of integer' => [[1, 2, 3], [1, 2, 3]];
+        yield 'object of integer' => [(object) [1, 2, 3], (object) [1, 2, 3]];
+
+        yield 'nested objects of integers' => [
+            (object) [1 => (object) range(1, 10), 2 => (object) range(50, 60)],
+            (object) [1 => (object) range(1, 10), 2 => (object) range(50, 60)],
+        ];
+    }
+
+    public function notEqualDataProvider(): \Generator
+    {
+        yield 'Boolean true/false' => [true, false];
+
+        yield 'Integer one/two' => [1, 2];
+        yield 'Integer INT MIN/MAX' => [PHP_INT_MIN, PHP_INT_MAX];
+
+        yield 'Float PI/' => [M_PI, M_E];
+
+        yield 'String' => ['hello world!', 'hell0 w0rld!'];
+
+        yield 'array of integer with smaller left side' => [[1, 3], [1, 2, 3]];
+        yield 'array of integer with smaller right side' => [[1, 2, 3], [1, 3]];
+        yield 'object of integer with smaller left side' => [(object) [1, 3], (object) [1, 2, 3]];
+        yield 'object of integer with smaller right side' => [(object) [1, 2, 3], (object) [1, 3]];
+
+        yield 'nested objects of integers with different left hand side' => [
+            (object) [1 => (object) range(1, 10), 2 => (object) range(50, 60, 2)],
+            (object) [1 => (object) range(1, 10), 2 => (object) range(50, 60)],
+        ];
+        yield 'nested objects of integers with different right hand side' => [
+            (object) [1 => (object) range(1, 10), 2 => (object) range(50, 60)],
+            (object) [1 => (object) range(1, 10), 2 => (object) range(50, 60, 2)],
+        ];
+
+        $options = [
+            'boolean' => true,
+            'integer' => 42,
+            'float' => M_PI,
+            'string' => 'hello world!',
+            'array' => [1, 2, 3],
+            'object' => (object) [1, 2, 3],
+        ];
+
+        foreach ($options as $leftType => $leftValue) {
+            foreach ($options as $rightType => $rightValue) {
+                if ($leftType === $rightType) {
+                    continue;
+                }
+
+                yield sprintf('%s vs. %s', $leftType, $rightType) => [$leftValue, $rightValue];
+            }
+        }
+    }
+
+}


### PR DESCRIPTION
After considering the options and rethinking the problem we are trying to solve I came top the conclusion we don't need a external library which can handle PHP class equality. Since we are working with JSON we only have scalar types (boolean, float, integer and string) and two collections types array and `stdClass`.
This made it simple to write our own deep comparison.

Fixes https://github.com/jsonrainbow/json-schema/issues/753