### PR TITLE
Run PHPStan using the lowest and highest php version

### DIFF
--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -12,10 +12,16 @@ env:
   COMPOSER_FLAGS: "--ansi --no-interaction --no-progress --prefer-dist"
 
 jobs:
-  tests:
+  phpstan:
     name: "PHPStan"
 
     runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        php-version:
+          - "7.2"
+          - "latest"
 
     steps:
       - name: "Checkout"
@@ -24,10 +30,10 @@ jobs:
       - name: "Install PHP"
         uses: "shivammathur/setup-php@v2"
         with:
-          coverage: "none"
+          php-version: "${{ matrix.php-version }}"
           extensions: "intl, zip"
           ini-values: "memory_limit=-1"
-          php-version: "7.2"
+          coverage: "none"
 
       - name: "Update dependencies"
         run: "composer update ${{ env.COMPOSER_FLAGS }}"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Run PHPStan using the lowest and highest php version ([#811](https://github.com/jsonrainbow/json-schema/pull/811))
 
 ## [6.3.1] - 2025-03-18
 ### Fixed


### PR DESCRIPTION
This pull request makes changes to the GitHub Actions workflow configuration for running PHPStan, a PHP static analysis tool. The most important changes include renaming the job, adding a matrix strategy for different PHP versions, and updating the PHP installation step.

Improvements to the GitHub Actions workflow:

* [`.github/workflows/phpstan.yml`](diffhunk://#diff-73a1d6ddd0eabb7e1349cdb83b76ff10f29f9e4fe316c0cd29495174181f4546L15-R36): Renamed the job from `tests` to `phpstan` to better reflect its purpose.
* [`.github/workflows/phpstan.yml`](diffhunk://#diff-73a1d6ddd0eabb7e1349cdb83b76ff10f29f9e4fe316c0cd29495174181f4546L15-R36): Added a matrix strategy to run PHPStan on multiple PHP versions (7.2 and 8.4).
* [`.github/workflows/phpstan.yml`](diffhunk://#diff-73a1d6ddd0eabb7e1349cdb83b76ff10f29f9e4fe316c0cd29495174181f4546L15-R36): Updated the PHP installation step to use the matrix's PHP version instead of a hardcoded version.