### PR TITLE
Use parallel-lint and cs2pr for improved feedback on linting errors

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -35,4 +35,4 @@ jobs:
 
       - name: "Lint PHP files"
         run: |
-          parallel-lint . --checkstyle | cs2pr
+          parallel-lint . --checkstyle --exclude vendor --show-deprecated | cs2pr

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -9,7 +9,7 @@ on:
       - master
 
 jobs:
-  tests:
+  lint:
     name: "Lint"
 
     runs-on: ubuntu-latest
@@ -27,10 +27,12 @@ jobs:
       - name: "Install PHP"
         uses: "shivammathur/setup-php@v2"
         with:
-          coverage: "none"
+          php-version: "${{ matrix.php-version }}"
           extensions: "intl"
           ini-values: "memory_limit=-1, error_reporting=E_ALL, display_errors=On"
-          php-version: "${{ matrix.php-version }}"
+          coverage: "none"
+          tools: parallel-lint, cs2pr
 
       - name: "Lint PHP files"
-        run: "find src/ -type f -name '*.php' -print0 | xargs -0 -L1 -P4 -- php -l -f"
+        run: |
+          parallel-lint . --checkstyle | cs2pr

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Added
 - Run PHPStan using the lowest and highest php version ([#811](https://github.com/jsonrainbow/json-schema/pull/811))
+### Fixed
+- Use parallel-lint and cs2pr for improved feedback on linting errors ([#812](https://github.com/jsonrainbow/json-schema/pull/812))
 
 ## [6.3.1] - 2025-03-18
 ### Fixed


### PR DESCRIPTION
This pull request includes changes to the `.github/workflows/lint.yml` file to improve the linting process for the project. The most important changes include renaming the job from "tests" to "lint", updating the PHP setup configuration, and modifying the linting command.

Improvements to linting workflow:

* [`.github/workflows/lint.yml`](diffhunk://#diff-107e910e9f2ebfb9a741fa10b2aa7100cc1fc4f5f3aca2dfe78b905cbd73c0d2L12-R12): Renamed the job from "tests" to "lint" to better reflect its purpose.
* [`.github/workflows/lint.yml`](diffhunk://#diff-107e910e9f2ebfb9a741fa10b2aa7100cc1fc4f5f3aca2dfe78b905cbd73c0d2L30-R38): Updated the PHP setup configuration to include `parallel-lint` and `cs2pr` tools, and reordered the `php-version` and `coverage` parameters for clarity.
* [`.github/workflows/lint.yml`](diffhunk://#diff-107e910e9f2ebfb9a741fa10b2aa7100cc1fc4f5f3aca2dfe78b905cbd73c0d2L30-R38): Modified the linting command to use `parallel-lint` with `cs2pr` for better parallel processing and reporting.