### PR TITLE
fix: Array with number values with mathematical equality are considered valid

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,9 +10,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Run PHPStan using the lowest and highest php version ([#811](https://github.com/jsonrainbow/json-schema/pull/811))
 ### Fixed
 - Use parallel-lint and cs2pr for improved feedback on linting errors ([#812](https://github.com/jsonrainbow/json-schema/pull/812))
+- Array with number values with mathematical equality are considered valid ([#813](https://github.com/jsonrainbow/json-schema/pull/813))
 ## Changed
 - Correct PHPStan findings in validator ([#808](https://github.com/jsonrainbow/json-schema/pull/808))
-
 
 ## [6.3.1] - 2025-03-18
 ### Fixed

--- a/src/JsonSchema/Tool/DeepComparer.php
+++ b/src/JsonSchema/Tool/DeepComparer.php
@@ -22,9 +22,9 @@ class DeepComparer
         $isRightNumber = is_int($right) || is_float($right);
 
         if ($isLeftScalar && $isRightScalar) {
-            /**
+            /*
              * In Json-Schema mathematically equal numbers are compared equal
-             **/
+             */
             if ($isLeftNumber && $isRightNumber && (float) $left === (float) $right) {
                 return true;
             }

--- a/src/JsonSchema/Tool/DeepComparer.php
+++ b/src/JsonSchema/Tool/DeepComparer.php
@@ -17,9 +17,18 @@ class DeepComparer
         }
 
         $isLeftScalar = is_scalar($left);
+        $isLeftNumber = is_int($left) || is_float($left);
         $isRightScalar = is_scalar($right);
+        $isRightNumber = is_int($right) || is_float($right);
 
         if ($isLeftScalar && $isRightScalar) {
+            /**
+             * In Json-Schema mathematically equal numbers are compared equal
+             **/
+            if ($isLeftNumber && $isRightNumber && (float) $left === (float) $right) {
+                return true;
+            }
+
             return $left === $right;
         }
 

--- a/tests/Constraints/ConstTest.php
+++ b/tests/Constraints/ConstTest.php
@@ -17,7 +17,7 @@ class ConstTest extends BaseTestCase
     public function getInvalidTests(): array
     {
         return [
-            [
+            'Object with inner string value' => [
                 '{"value":"foo"}',
                 '{
                   "type":"object",
@@ -27,7 +27,7 @@ class ConstTest extends BaseTestCase
                   "additionalProperties":false
                 }'
             ],
-            [
+            'Object with inner integer value' => [
                 '{"value":5}',
                 '{
                   "type":"object",
@@ -37,7 +37,7 @@ class ConstTest extends BaseTestCase
                   "additionalProperties":false
                 }'
             ],
-            [
+            'Object with inner boolean value' => [
                 '{"value":false}',
                 '{
                   "type":"object",
@@ -47,7 +47,7 @@ class ConstTest extends BaseTestCase
                   "additionalProperties":false
                 }'
             ],
-            [
+            'Object with inner numerical string value' => [
                 '{
                     "value": {
                         "foo": "12"
@@ -71,7 +71,7 @@ class ConstTest extends BaseTestCase
     public function getValidTests(): array
     {
         return [
-            [
+            'String value' => [
                 '{"value":"bar"}',
                 '{
                   "type":"object",
@@ -81,7 +81,7 @@ class ConstTest extends BaseTestCase
                   "additionalProperties":false
                 }'
             ],
-            [
+            'Boolean(false) value' => [
                 '{"value":false}',
                 '{
                   "type":"object",
@@ -91,7 +91,7 @@ class ConstTest extends BaseTestCase
                   "additionalProperties":false
                 }'
             ],
-            [
+            'Boolean(true) value' => [
                 '{"value":true}',
                 '{
                   "type":"object",
@@ -101,7 +101,7 @@ class ConstTest extends BaseTestCase
                   "additionalProperties":false
                 }'
             ],
-            [
+            'Integer value' => [
                 '{"value":5}',
                 '{
                   "type":"object",
@@ -111,7 +111,7 @@ class ConstTest extends BaseTestCase
                   "additionalProperties":false
                 }'
             ],
-            [
+            'Object with inner integer value' => [
                 '{
                     "value": {
                         "foo": 12

--- a/tests/Constraints/EnumTest.php
+++ b/tests/Constraints/EnumTest.php
@@ -176,7 +176,7 @@ class EnumTest extends BaseTestCase
                     }
                 }'
             ],
-            'Numeric values with mathematical equality are considered valid' => [
+            'Number values with mathematical equality are considered valid' => [
                 'data' => '12',
                 'schema' => '{
                     "type": "any",
@@ -184,6 +184,14 @@ class EnumTest extends BaseTestCase
                         12.0
                     ]
                 }'
+            ],
+            'Array with number values with mathematical equality are considered valid' => [
+                'input' => '[ 0.0 ]',
+                'schema' => '{
+                    "enum": [
+                        [ 0 ]
+                    ]
+                }',
             ]
         ];
     }


### PR DESCRIPTION
Our Bowtie [report](https://bowtie.report/#/dialects/draft4?language=php) pointed out we are not correctly validating an enum type with an array holding a number type 