### PR TITLE
ci: Add cs2pr handling for php-cs-fixer; avoid doing composer install

### DIFF
--- a/.github/workflows/style-check.yml
+++ b/.github/workflows/style-check.yml
@@ -8,11 +8,8 @@ on:
     branches:
       - master
 
-env:
-  COMPOSER_FLAGS: "--ansi --no-interaction --no-progress --prefer-dist"
-
 jobs:
-  tests:
+  style-check:
     name: "Style Check"
 
     runs-on: ubuntu-latest
@@ -28,10 +25,8 @@ jobs:
           extensions: "intl, zip"
           ini-values: "memory_limit=-1, phar.readonly=0, error_reporting=E_ALL, display_errors=On"
           php-version: "7.4"
-          tools: composer
-
-      - name: "Update dependencies"
-        run: "composer update ${{ env.COMPOSER_FLAGS }}"
+          tools: cs2pr, php-cs-fixer:3.3
 
       - name: "Run style-check"
-        run: "composer style-check"
+        run: |
+          composer style-check -- --format=checkstyle src | cs2pr

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Use parallel-lint and cs2pr for improved feedback on linting errors ([#812](https://github.com/jsonrainbow/json-schema/pull/812))
 - Array with number values with mathematical equality are considered valid ([#813](https://github.com/jsonrainbow/json-schema/pull/813))
-## Changed
+### Changed
 - Correct PHPStan findings in validator ([#808](https://github.com/jsonrainbow/json-schema/pull/808))
+- Add cs2pr handling for php-cs-fixer; avoid doing composer install ([#814](https://github.com/jsonrainbow/json-schema/pull/814))
 
 ## [6.3.1] - 2025-03-18
 ### Fixed


### PR DESCRIPTION
This PR uses the tools available from the [setup-php ](https://github.com/marketplace/actions/setup-php-action) action to improve the feedback to better readable for humans using [cs2pr](https://github.com/staabm/annotate-pull-request-from-checkstyle) and avoids running `composer install` during the flow.