### PR TITLE
Update constraint class to PHP 7.2 language level

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - Added extra breaking change to UPDATE-6.0.md regarding BaseConstraint::addError signature change ([#823](https://github.com/jsonrainbow/json-schema/pull/823)
+- Update constraint class to PHP 7.2 language level ([#824](https://github.com/jsonrainbow/json-schema/pull/824)
+
 
 ## [6.4.1] - 2025-04-04
 ### Fixed

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -41,21 +41,6 @@ parameters:
 			path: src/JsonSchema/Constraints/CollectionConstraint.php
 
 		-
-			message: "#^Method JsonSchema\\\\Constraints\\\\Constraint\\:\\:checkObject\\(\\) has parameter \\$appliedDefaults with no type specified\\.$#"
-			count: 1
-			path: src/JsonSchema/Constraints/Constraint.php
-
-		-
-			message: "#^Method JsonSchema\\\\Constraints\\\\Constraint\\:\\:checkUndefined\\(\\) has parameter \\$fromDefault with no type specified\\.$#"
-			count: 1
-			path: src/JsonSchema/Constraints/Constraint.php
-
-		-
-			message: "#^Property JsonSchema\\\\Constraints\\\\Constraint\\:\\:\\$inlineSchemaProperty has no type specified\\.$#"
-			count: 1
-			path: src/JsonSchema/Constraints/Constraint.php
-
-		-
 			message: "#^Method JsonSchema\\\\Constraints\\\\ConstraintInterface\\:\\:addError\\(\\) has parameter \\$more with no value type specified in iterable type array\\.$#"
 			count: 1
 			path: src/JsonSchema/Constraints/ConstraintInterface.php
@@ -206,11 +191,6 @@ parameters:
 			path: src/JsonSchema/Constraints/ObjectConstraint.php
 
 		-
-			message: "#^Method JsonSchema\\\\Constraints\\\\ObjectConstraint\\:\\:check\\(\\) has parameter \\$appliedDefaults with no type specified\\.$#"
-			count: 1
-			path: src/JsonSchema/Constraints/ObjectConstraint.php
-
-		-
 			message: "#^Method JsonSchema\\\\Constraints\\\\ObjectConstraint\\:\\:check\\(\\) has parameter \\$patternProperties with no type specified\\.$#"
 			count: 1
 			path: src/JsonSchema/Constraints/ObjectConstraint.php
@@ -252,11 +232,6 @@ parameters:
 
 		-
 			message: "#^Parameter \\#2 \\$objectDefinition of method JsonSchema\\\\Constraints\\\\ObjectConstraint\\:\\:validateMinMaxConstraint\\(\\) expects stdClass, stdClass\\|null given\\.$#"
-			count: 1
-			path: src/JsonSchema/Constraints/ObjectConstraint.php
-
-		-
-			message: "#^Property JsonSchema\\\\Constraints\\\\ObjectConstraint\\:\\:\\$appliedDefaults type has no value type specified in iterable type array\\.$#"
 			count: 1
 			path: src/JsonSchema/Constraints/ObjectConstraint.php
 
@@ -566,11 +541,6 @@ parameters:
 			path: src/JsonSchema/Constraints/TypeConstraint.php
 
 		-
-			message: "#^Method JsonSchema\\\\Constraints\\\\UndefinedConstraint\\:\\:check\\(\\) has parameter \\$fromDefault with no type specified\\.$#"
-			count: 1
-			path: src/JsonSchema/Constraints/UndefinedConstraint.php
-
-		-
 			message: "#^Method JsonSchema\\\\Constraints\\\\UndefinedConstraint\\:\\:shouldApplyDefaultValue\\(\\) has parameter \\$name with no type specified\\.$#"
 			count: 1
 			path: src/JsonSchema/Constraints/UndefinedConstraint.php
@@ -611,17 +581,7 @@ parameters:
 			path: src/JsonSchema/Constraints/UndefinedConstraint.php
 
 		-
-			message: "#^Property JsonSchema\\\\Constraints\\\\UndefinedConstraint\\:\\:\\$appliedDefaults type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/JsonSchema/Constraints/UndefinedConstraint.php
-
-		-
 			message: "#^Method JsonSchema\\\\Entity\\\\JsonPointer\\:\\:encodePropertyPaths\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/JsonSchema/Entity/JsonPointer.php
-
-		-
-			message: "#^Method JsonSchema\\\\Entity\\\\JsonPointer\\:\\:setFromDefault\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: src/JsonSchema/Entity/JsonPointer.php
 

--- a/src/JsonSchema/Constraints/Constraint.php
+++ b/src/JsonSchema/Constraints/Constraint.php
@@ -8,7 +8,7 @@ use JsonSchema\Entity\JsonPointer;
 
 abstract class Constraint extends BaseConstraint implements ConstraintInterface
 {
-    /** @var string  */
+    /** @var string */
     protected $inlineSchemaProperty = '$schema';
 
     public const CHECK_MODE_NONE =             0x00000000;
@@ -62,11 +62,11 @@ abstract class Constraint extends BaseConstraint implements ConstraintInterface
     /**
      * Validates an object
      *
-     * @param mixed $value
-     * @param mixed $schema
-     * @param mixed $properties
-     * @param mixed $additionalProperties
-     * @param mixed $patternProperties
+     * @param mixed         $value
+     * @param mixed         $schema
+     * @param mixed         $properties
+     * @param mixed         $additionalProperties
+     * @param mixed         $patternProperties
      * @param array<string> $appliedDefaults
      */
     protected function checkObject(

--- a/src/JsonSchema/Constraints/Constraint.php
+++ b/src/JsonSchema/Constraints/Constraint.php
@@ -86,7 +86,7 @@ abstract class Constraint extends BaseConstraint implements ConstraintInterface
     }
 
     /**
-     * Validates the type of the property
+     * Validates the type of the value
      *
      * @param mixed $value
      * @param mixed $schema

--- a/src/JsonSchema/Constraints/Constraint.php
+++ b/src/JsonSchema/Constraints/Constraint.php
@@ -21,6 +21,7 @@ use JsonSchema\Entity\JsonPointer;
  */
 abstract class Constraint extends BaseConstraint implements ConstraintInterface
 {
+    /** @var string  */
     protected $inlineSchemaProperty = '$schema';
 
     public const CHECK_MODE_NONE =             0x00000000;
@@ -48,14 +49,12 @@ abstract class Constraint extends BaseConstraint implements ConstraintInterface
             return $path;
         }
 
-        $path = $path->withPropertyPaths(
+        return $path->withPropertyPaths(
             array_merge(
                 $path->getPropertyPaths(),
                 [$i]
             )
         );
-
-        return $path;
     }
 
     /**
@@ -81,10 +80,17 @@ abstract class Constraint extends BaseConstraint implements ConstraintInterface
      * @param mixed $properties
      * @param mixed $additionalProperties
      * @param mixed $patternProperties
+     * @param array<string> $appliedDefaults
      */
-    protected function checkObject(&$value, $schema = null, ?JsonPointer $path = null, $properties = null,
-        $additionalProperties = null, $patternProperties = null, $appliedDefaults = []): void
-    {
+    protected function checkObject(
+        &$value,
+        $schema = null,
+        ?JsonPointer $path = null,
+        $properties = null,
+        $additionalProperties = null,
+        $patternProperties = null,
+        array $appliedDefaults = []
+    ): void {
         /** @var ObjectConstraint $validator */
         $validator = $this->factory->createInstanceFor('object');
         $validator->check($value, $schema, $path, $properties, $additionalProperties, $patternProperties, $appliedDefaults);
@@ -93,7 +99,7 @@ abstract class Constraint extends BaseConstraint implements ConstraintInterface
     }
 
     /**
-     * Validates the type of a property
+     * Validates the type of the property
      *
      * @param mixed $value
      * @param mixed $schema
@@ -114,7 +120,7 @@ abstract class Constraint extends BaseConstraint implements ConstraintInterface
      * @param mixed $schema
      * @param mixed $i
      */
-    protected function checkUndefined(&$value, $schema = null, ?JsonPointer $path = null, $i = null, $fromDefault = false): void
+    protected function checkUndefined(&$value, $schema = null, ?JsonPointer $path = null, $i = null, bool $fromDefault = false): void
     {
         /** @var UndefinedConstraint $validator */
         $validator = $this->factory->createInstanceFor('undefined');

--- a/src/JsonSchema/Constraints/Constraint.php
+++ b/src/JsonSchema/Constraints/Constraint.php
@@ -2,23 +2,10 @@
 
 declare(strict_types=1);
 
-/*
- * This file is part of the JsonSchema package.
- *
- * For the full copyright and license information, please view the LICENSE
- * file that was distributed with this source code.
- */
-
 namespace JsonSchema\Constraints;
 
 use JsonSchema\Entity\JsonPointer;
 
-/**
- * The Base Constraints, all Validators should extend this class
- *
- * @author Robert Schönthal <seroscho@googlemail.com>
- * @author Bruno Prieto Reis <bruno.p.reis@gmail.com>
- */
 abstract class Constraint extends BaseConstraint implements ConstraintInterface
 {
     /** @var string  */

--- a/src/JsonSchema/Constraints/ObjectConstraint.php
+++ b/src/JsonSchema/Constraints/ObjectConstraint.php
@@ -2,24 +2,11 @@
 
 declare(strict_types=1);
 
-/*
- * This file is part of the JsonSchema package.
- *
- * For the full copyright and license information, please view the LICENSE
- * file that was distributed with this source code.
- */
-
 namespace JsonSchema\Constraints;
 
 use JsonSchema\ConstraintError;
 use JsonSchema\Entity\JsonPointer;
 
-/**
- * The ObjectConstraint Constraints, validates an object against a given schema
- *
- * @author Robert Schönthal <seroscho@googlemail.com>
- * @author Bruno Prieto Reis <bruno.p.reis@gmail.com>
- */
 class ObjectConstraint extends Constraint
 {
     /**

--- a/src/JsonSchema/Constraints/ObjectConstraint.php
+++ b/src/JsonSchema/Constraints/ObjectConstraint.php
@@ -30,9 +30,15 @@ class ObjectConstraint extends Constraint
     /**
      * {@inheritdoc}
      */
-    public function check(&$element, $schema = null, ?JsonPointer $path = null, $properties = null,
-        $additionalProp = null, $patternProperties = null, $appliedDefaults = []): void
-    {
+    public function check(
+        &$element,
+        $schema = null,
+        ?JsonPointer $path = null,
+        $properties = null,
+        $additionalProp = null,
+        $patternProperties = null,
+        $appliedDefaults = []
+    ): void {
         if ($element instanceof UndefinedConstraint) {
             return;
         }

--- a/src/JsonSchema/Constraints/ObjectConstraint.php
+++ b/src/JsonSchema/Constraints/ObjectConstraint.php
@@ -10,12 +10,14 @@ use JsonSchema\Entity\JsonPointer;
 class ObjectConstraint extends Constraint
 {
     /**
-     * @var array List of properties to which a default value has been applied
+     * @var list<string> List of properties to which a default value has been applied
      */
     protected $appliedDefaults = [];
 
     /**
      * {@inheritdoc}
+     *
+     * @param list<string> $appliedDefaults
      */
     public function check(
         &$element,

--- a/src/JsonSchema/Constraints/UndefinedConstraint.php
+++ b/src/JsonSchema/Constraints/UndefinedConstraint.php
@@ -2,13 +2,6 @@
 
 declare(strict_types=1);
 
-/*
- * This file is part of the JsonSchema package.
- *
- * For the full copyright and license information, please view the LICENSE
- * file that was distributed with this source code.
- */
-
 namespace JsonSchema\Constraints;
 
 use JsonSchema\ConstraintError;
@@ -18,12 +11,6 @@ use JsonSchema\Exception\ValidationException;
 use JsonSchema\Tool\DeepCopy;
 use JsonSchema\Uri\UriResolver;
 
-/**
- * The UndefinedConstraint Constraints
- *
- * @author Robert Schönthal <seroscho@googlemail.com>
- * @author Bruno Prieto Reis <bruno.p.reis@gmail.com>
- */
 #[\AllowDynamicProperties]
 class UndefinedConstraint extends Constraint
 {

--- a/src/JsonSchema/Constraints/UndefinedConstraint.php
+++ b/src/JsonSchema/Constraints/UndefinedConstraint.php
@@ -21,8 +21,8 @@ class UndefinedConstraint extends Constraint
 
     /**
      * {@inheritdoc}
-     */
-    public function check(&$value, $schema = null, ?JsonPointer $path = null, $i = null, $fromDefault = false): void
+     * */
+    public function check(&$value, $schema = null, ?JsonPointer $path = null, $i = null, bool $fromDefault = false): void
     {
         if (is_null($schema) || !is_object($schema)) {
             return;

--- a/src/JsonSchema/Constraints/UndefinedConstraint.php
+++ b/src/JsonSchema/Constraints/UndefinedConstraint.php
@@ -28,7 +28,7 @@ use JsonSchema\Uri\UriResolver;
 class UndefinedConstraint extends Constraint
 {
     /**
-     * @var array List of properties to which a default value has been applied
+     * @var list<string> List of properties to which a default value has been applied
      */
     protected $appliedDefaults = [];
 
@@ -72,9 +72,10 @@ class UndefinedConstraint extends Constraint
         }
 
         // check object
-        if (LooseTypeCheck::isObject($value)) { // object processing should always be run on assoc arrays,
-                                                // so use LooseTypeCheck here even if CHECK_MODE_TYPE_CAST
-                                                // is not set (i.e. don't use $this->getTypeCheck() here).
+        if (LooseTypeCheck::isObject($value)) {
+            // object processing should always be run on assoc arrays,
+            // so use LooseTypeCheck here even if CHECK_MODE_TYPE_CAST
+            // is not set (i.e. don't use $this->getTypeCheck() here).
             $this->checkObject(
                 $value,
                 $schema,

--- a/src/JsonSchema/Entity/JsonPointer.php
+++ b/src/JsonSchema/Entity/JsonPointer.php
@@ -146,7 +146,7 @@ class JsonPointer
     /**
      * Mark the value at this path as being set from a schema default
      */
-    public function setFromDefault()
+    public function setFromDefault(): void
     {
         $this->fromDefault = true;
     }


### PR DESCRIPTION
This brings the `Constraint` class to PHP 7.2 language level and does some cleanup along the way.