### PR TITLE
ci: add 32-bits ci workflow

### DIFF
--- a/.github/workflows/continuous-integration-32-bit.yml
+++ b/.github/workflows/continuous-integration-32-bit.yml
@@ -1,0 +1,50 @@
+name: "Continuous Integration - 32-bits"
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+
+env:
+  COMPOSER_FLAGS: "--ansi --no-interaction --no-progress --prefer-dist"
+
+jobs:
+  tests:
+    name: "PHP 8.4 - 32-bits"
+
+    runs-on: ubuntu-latest
+    container: shivammathur/node:latest-i386
+
+    steps:
+      - name: "Checkout"
+        uses: "actions/checkout@v4"
+
+      - name: "Install PHP"
+        uses: "shivammathur/setup-php@v2"
+        with:
+          coverage: "none"
+          extensions: "intl, zip"
+          ini-values: "memory_limit=-1, phar.readonly=0, error_reporting=E_ALL, display_errors=On"
+          php-version: "8.4"
+          tools: composer
+
+      - name: Check PHP_INT_MAX
+        run: |
+          MAX=$(php -r "echo PHP_INT_MAX;")
+          if [ "$MAX" -ne 2147483647 ]; then
+            echo "Error: PHP is not 32-bit (PHP_INT_MAX is $MAX)"
+            exit 1
+          fi
+        env:
+          MAX: ""
+
+      - name: Install dependencies
+        run: |
+          git config --global --add safe.directory $(pwd)
+          composer install
+
+      - name: Run tests
+        run: "composer test"

--- a/.github/workflows/continuous-integration-32-bits.yml
+++ b/.github/workflows/continuous-integration-32-bits.yml
@@ -35,7 +35,7 @@ jobs:
         run: |
           MAX=$(php -r "echo PHP_INT_MAX;")
           if [ "$MAX" -ne 2147483647 ]; then
-            echo "Error: PHP is not 32-bit (PHP_INT_MAX is $MAX)"
+            echo "Error: PHP is not 32-bits (PHP_INT_MAX is $MAX)"
             exit 1
           fi
         env:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,11 +10,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix objects are non-unique despite key order ([#819](https://github.com/jsonrainbow/json-schema/pull/819))
 
 ### Changed
-- Added extra breaking change to UPDATE-6.0.md regarding BaseConstraint::addError signature change ([#823](https://github.com/jsonrainbow/json-schema/pull/823)
-- Update constraint class to PHP 7.2 language level ([#824](https://github.com/jsonrainbow/json-schema/pull/824)
+- Added extra breaking change to UPDATE-6.0.md regarding BaseConstraint::addError signature change ([#823](https://github.com/jsonrainbow/json-schema/pull/823))
+- Update constraint class to PHP 7.2 language level ([#824](https://github.com/jsonrainbow/json-schema/pull/824))
 
 ### Added
-- Introduce 32 bits CI workflow on latest php version ([#825](https://github.com/jsonrainbow/json-schema/pull/825)
+- Introduce 32 bits CI workflow on latest php version ([#825](https://github.com/jsonrainbow/json-schema/pull/825))
 
 ## [6.4.1] - 2025-04-04
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added extra breaking change to UPDATE-6.0.md regarding BaseConstraint::addError signature change ([#823](https://github.com/jsonrainbow/json-schema/pull/823)
 - Update constraint class to PHP 7.2 language level ([#824](https://github.com/jsonrainbow/json-schema/pull/824)
 
+### Added
+- Introduce 32 bits CI workflow on latest php version ([#825](https://github.com/jsonrainbow/json-schema/pull/825)
 
 ## [6.4.1] - 2025-04-04
 ### Fixed


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow for continuous integration on a 32-bit system. The workflow is configured to run tests using PHP 8.4 and includes steps for environment setup and test execution.

### New Continuous Integration Workflow:

* [`.github/workflows/continuous-integration-32-bit.yml`](diffhunk://#diff-913f89970936b1231274367aff0161dfd9c5ca768783bdf9d1e1961b59aad86eR1-R38): Added a new workflow named "Continuous Integration" that triggers on `push` and `pull_request` events targeting the `master` branch. It runs on `ubuntu-latest` using a 32-bit container (`shivammathur/node:latest-i386`) and sets up PHP 8.4 with specific extensions, tools, and configuration before executing tests via `composer test`.

Fixes #818 