### PR TITLE
Fix #827

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Fixed
 - Fix objects are non-unique despite key order ([#819](https://github.com/jsonrainbow/json-schema/pull/819))
+- Id's not being resolved and id property affects sibling ref which it should not do ([#828](https://github.com/jsonrainbow/json-schema/pull/828)) 
 
 ### Changed
 - Added extra breaking change to UPDATE-6.0.md regarding BaseConstraint::addError signature change ([#823](https://github.com/jsonrainbow/json-schema/pull/823))

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -646,22 +646,17 @@ parameters:
 			path: src/JsonSchema/SchemaStorage.php
 
 		-
+			message: "#^Argument of an invalid type array\\|stdClass supplied for foreach, only iterables are supported\\.$#"
+			count: 1
+			path: src/JsonSchema/SchemaStorage.php
+
+		-
 			message: "#^Argument of an invalid type object supplied for foreach, only iterables are supported\\.$#"
 			count: 1
 			path: src/JsonSchema/SchemaStorage.php
 
 		-
 			message: "#^Call to function is_array\\(\\) with object will always evaluate to false\\.$#"
-			count: 1
-			path: src/JsonSchema/SchemaStorage.php
-
-		-
-			message: "#^Method JsonSchema\\\\SchemaStorage\\:\\:addSchema\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/JsonSchema/SchemaStorage.php
-
-		-
-			message: "#^Method JsonSchema\\\\SchemaStorage\\:\\:expandRefs\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: src/JsonSchema/SchemaStorage.php
 
@@ -694,11 +689,6 @@ parameters:
 			message: "#^Result of && is always false\\.$#"
 			count: 1
 			path: src/JsonSchema/SchemaStorage.php
-
-		-
-			message: "#^Method JsonSchema\\\\SchemaStorageInterface\\:\\:addSchema\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/JsonSchema/SchemaStorageInterface.php
 
 		-
 			message: "#^Method JsonSchema\\\\Uri\\\\Retrievers\\\\Curl\\:\\:fetchMessageBody\\(\\) has no return type specified\\.$#"

--- a/src/JsonSchema/SchemaStorage.php
+++ b/src/JsonSchema/SchemaStorage.php
@@ -45,7 +45,7 @@ class SchemaStorage implements SchemaStorageInterface
     /**
      * {@inheritdoc}
      */
-    public function addSchema($id, $schema = null): void
+    public function addSchema(string $id, $schema = null): void
     {
         if (is_null($schema) && $id !== self::INTERNAL_PROVIDED_SCHEMA_URI) {
             // if the schema was user-provided to Validator and is still null, then assume this is
@@ -177,9 +177,12 @@ class SchemaStorage implements SchemaStorageInterface
         return $refSchema;
     }
 
+    /**
+     * @param mixed $schema
+     */
     private function addSubschemas($schema, string $parentId): void
     {
-        if (!is_object($schema) && !is_array($schema)) {
+        if (! $schema instanceof \stdClass  && !is_array($schema)) {
             return;
         }
 

--- a/src/JsonSchema/SchemaStorage.php
+++ b/src/JsonSchema/SchemaStorage.php
@@ -70,6 +70,8 @@ class SchemaStorage implements SchemaStorageInterface
             }
         }
 
+        $this->addSubschemas($schema, $id);
+
         // resolve references
         $this->expandRefs($schema, $id);
 
@@ -173,5 +175,25 @@ class SchemaStorage implements SchemaStorageInterface
         }
 
         return $refSchema;
+    }
+
+    private function addSubschemas($schema, string $parentId): void
+    {
+        if (!is_object($schema) && !is_array($schema)) {
+            return;
+        }
+
+        foreach ($schema as $potentialSubSchema) {
+            if (!is_object($potentialSubSchema)) {
+                continue;
+            }
+
+            // Found sub schema
+            if (property_exists($potentialSubSchema, 'id') && is_string($potentialSubSchema->id) && property_exists($potentialSubSchema, 'type')) {
+                $this->addSchema($parentId . $potentialSubSchema->id, $potentialSubSchema);
+            }
+
+            $this->addSubschemas($potentialSubSchema, $parentId);
+        }
     }
 }

--- a/src/JsonSchema/SchemaStorage.php
+++ b/src/JsonSchema/SchemaStorage.php
@@ -81,9 +81,9 @@ class SchemaStorage implements SchemaStorageInterface
     /**
      * Recursively resolve all references against the provided base
      *
-     * @param mixed  $schema
+     * @param mixed $schema
      */
-    private function expandRefs(&$schema, string $parentId = null): void
+    private function expandRefs(&$schema, ?string $parentId = null): void
     {
         if (!is_object($schema)) {
             if (is_array($schema)) {
@@ -182,7 +182,7 @@ class SchemaStorage implements SchemaStorageInterface
      */
     private function addSubschemas($schema, string $parentId): void
     {
-        if (! $schema instanceof \stdClass  && !is_array($schema)) {
+        if (!$schema instanceof \stdClass  && !is_array($schema)) {
             return;
         }
 

--- a/src/JsonSchema/SchemaStorage.php
+++ b/src/JsonSchema/SchemaStorage.php
@@ -45,7 +45,7 @@ class SchemaStorage implements SchemaStorageInterface
     /**
      * {@inheritdoc}
      */
-    public function addSchema($id, $schema = null)
+    public function addSchema($id, $schema = null): void
     {
         if (is_null($schema) && $id !== self::INTERNAL_PROVIDED_SCHEMA_URI) {
             // if the schema was user-provided to Validator and is still null, then assume this is
@@ -62,9 +62,9 @@ class SchemaStorage implements SchemaStorageInterface
         // workaround for bug in draft-03 & draft-04 meta-schemas (id & $ref defined with incorrect format)
         // see https://github.com/json-schema-org/JSON-Schema-Test-Suite/issues/177#issuecomment-293051367
         if (is_object($schema) && property_exists($schema, 'id')) {
-            if ($schema->id == 'http://json-schema.org/draft-04/schema#') {
+            if ($schema->id === 'http://json-schema.org/draft-04/schema#') {
                 $schema->properties->id->format = 'uri-reference';
-            } elseif ($schema->id == 'http://json-schema.org/draft-03/schema#') {
+            } elseif ($schema->id === 'http://json-schema.org/draft-03/schema#') {
                 $schema->properties->id->format = 'uri-reference';
                 $schema->properties->{'$ref'}->format = 'uri-reference';
             }
@@ -113,7 +113,7 @@ class SchemaStorage implements SchemaStorageInterface
     /**
      * {@inheritdoc}
      */
-    public function getSchema($id)
+    public function getSchema(string $id)
     {
         if (!array_key_exists($id, $this->schemas)) {
             $this->addSchema($id);
@@ -125,7 +125,7 @@ class SchemaStorage implements SchemaStorageInterface
     /**
      * {@inheritdoc}
      */
-    public function resolveRef($ref, $resolveStack = [])
+    public function resolveRef(string $ref, $resolveStack = [])
     {
         $jsonPointer = new JsonPointer($ref);
 

--- a/src/JsonSchema/SchemaStorageInterface.php
+++ b/src/JsonSchema/SchemaStorageInterface.php
@@ -9,28 +9,23 @@ interface SchemaStorageInterface
     /**
      * Adds schema with given identifier
      *
-     * @param string $id
      * @param object $schema
      */
-    public function addSchema($id, $schema = null);
+    public function addSchema(string $id, $schema = null): void;
 
     /**
      * Returns schema for given identifier, or null if it does not exist
      *
-     * @param string $id
-     *
      * @return object
      */
-    public function getSchema($id);
+    public function getSchema(string $id);
 
     /**
      * Returns schema for given reference with all sub-references resolved
      *
-     * @param string $ref
-     *
      * @return object
      */
-    public function resolveRef($ref);
+    public function resolveRef(string $ref);
 
     /**
      * Returns schema referenced by '$ref' property


### PR DESCRIPTION
This PR will:
- Scan schemas that are being added for `id` properties and register them if valid schemas
- Avoid altering the `id` for sibling `ref` properties
- Don't register schema or expand refs when found in enum or const

This will fix #827 