### PR TITLE
Upgrade test suite to use generators

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Changed
 - Update test case to current (PHP) standards ([#831](https://github.com/jsonrainbow/json-schema/pull/831))
+- Upgrade test suite to use generators ([#834](https://github.com/jsonrainbow/json-schema/pull/834))
 
 ## [6.4.2] - 2025-06-03
 ### Fixed

--- a/tests/ConstraintErrorTest.php
+++ b/tests/ConstraintErrorTest.php
@@ -2,12 +2,6 @@
 
 declare(strict_types=1);
 
-/*
- * This file is part of the JsonSchema package.
- *
- * For the full copyright and license information, please view the LICENSE
- * file that was distributed with this source code.
- */
 namespace JsonSchema\Tests;
 
 use JsonSchema\ConstraintError;

--- a/tests/ConstraintErrorTest.php
+++ b/tests/ConstraintErrorTest.php
@@ -1,12 +1,13 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * This file is part of the JsonSchema package.
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  */
-
 namespace JsonSchema\Tests;
 
 use JsonSchema\ConstraintError;

--- a/tests/ConstraintErrorTest.php
+++ b/tests/ConstraintErrorTest.php
@@ -19,7 +19,7 @@ class ConstraintErrorTest extends TestCase
     {
         $e = ConstraintError::MISSING_ERROR();
 
-        $this->expectException('\JsonSchema\Exception\InvalidArgumentException');
+        $this->expectException(\JsonSchema\Exception\InvalidArgumentException::class);
         $this->expectExceptionMessage('Missing error message for missingError');
 
         $e->getMessage();

--- a/tests/Constraints/AdditionalPropertiesTest.php
+++ b/tests/Constraints/AdditionalPropertiesTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace JsonSchema\Tests\Constraints;
 
 use JsonSchema\Validator;

--- a/tests/Constraints/ArraysTest.php
+++ b/tests/Constraints/ArraysTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace JsonSchema\Tests\Constraints;
 
 class ArraysTest extends BaseTestCase

--- a/tests/Constraints/ArraysTest.php
+++ b/tests/Constraints/ArraysTest.php
@@ -9,7 +9,7 @@ class ArraysTest extends BaseTestCase
 
     public function getInvalidTests(): \Generator
     {
-            yield [
+        yield [
                 '{
                   "array":[1,2,"a"]
                 }',

--- a/tests/Constraints/BaseTestCase.php
+++ b/tests/Constraints/BaseTestCase.php
@@ -1,12 +1,13 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * This file is part of the JsonSchema package.
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  */
-
 namespace JsonSchema\Tests\Constraints;
 
 use Generator;

--- a/tests/Constraints/BaseTestCase.php
+++ b/tests/Constraints/BaseTestCase.php
@@ -52,7 +52,7 @@ abstract class BaseTestCase extends VeryBaseTestCase
      */
     public function testInvalidCasesUsingAssoc($input, $schema, $checkMode = Constraint::CHECK_MODE_TYPE_CAST, $errors = []): void
     {
-        $checkMode = $checkMode === null ? Constraint::CHECK_MODE_TYPE_CAST : $checkMode;
+        $checkMode = $checkMode ?? Constraint::CHECK_MODE_TYPE_CAST;
         if ($this->validateSchema) {
             $checkMode |= Constraint::CHECK_MODE_VALIDATE_SCHEMA;
         }

--- a/tests/Constraints/BaseTestCase.php
+++ b/tests/Constraints/BaseTestCase.php
@@ -2,12 +2,6 @@
 
 declare(strict_types=1);
 
-/*
- * This file is part of the JsonSchema package.
- *
- * For the full copyright and license information, please view the LICENSE
- * file that was distributed with this source code.
- */
 namespace JsonSchema\Tests\Constraints;
 
 use Generator;

--- a/tests/Constraints/BaseTestCase.php
+++ b/tests/Constraints/BaseTestCase.php
@@ -87,14 +87,14 @@ abstract class BaseTestCase extends VeryBaseTestCase
         if ($this->validateSchema) {
             $checkMode |= Constraint::CHECK_MODE_VALIDATE_SCHEMA;
         }
-        $schemaStorage = new SchemaStorage($this->getUriRetrieverMock(json_decode($schema)));
+        $schemaStorage = new SchemaStorage($this->getUriRetrieverMock(json_decode($schema, false)));
         $schema = $schemaStorage->getSchema('http://www.my-domain.com/schema.json');
         if (is_object($schema) && !isset($schema->{'$schema'})) {
             $schema->{'$schema'} = $this->schemaSpec;
         }
 
         $validator = new Validator(new Factory($schemaStorage, null, $checkMode));
-        $checkValue = json_decode($input);
+        $checkValue = json_decode($input, false);
         $errorMask = $validator->validate($checkValue, $schema);
         $this->assertEquals(0, $errorMask);
 

--- a/tests/Constraints/BasicTypesTest.php
+++ b/tests/Constraints/BasicTypesTest.php
@@ -4,14 +4,13 @@ namespace JsonSchema\Tests\Constraints;
 
 class BasicTypesTest extends BaseTestCase
 {
-    /** @var string  */
+    /** @var string */
     protected $schemaSpec = 'http://json-schema.org/draft-03/schema#';
-    /** @var bool  */
+    /** @var bool */
     protected $validateSchema = true;
 
     public function getInvalidTests(): \Generator
     {
-
         yield [
             '{
               "string":null

--- a/tests/Constraints/BasicTypesTest.php
+++ b/tests/Constraints/BasicTypesTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace JsonSchema\Tests\Constraints;
 
 class BasicTypesTest extends BaseTestCase

--- a/tests/Constraints/CoerciveTest.php
+++ b/tests/Constraints/CoerciveTest.php
@@ -1,12 +1,13 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * This file is part of the JsonSchema package.
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  */
-
 namespace JsonSchema\Tests\Constraints;
 
 use JsonSchema\Constraints\Constraint;

--- a/tests/Constraints/CoerciveTest.php
+++ b/tests/Constraints/CoerciveTest.php
@@ -2,12 +2,6 @@
 
 declare(strict_types=1);
 
-/*
- * This file is part of the JsonSchema package.
- *
- * For the full copyright and license information, please view the LICENSE
- * file that was distributed with this source code.
- */
 namespace JsonSchema\Tests\Constraints;
 
 use JsonSchema\Constraints\Constraint;

--- a/tests/Constraints/ConstTest.php
+++ b/tests/Constraints/ConstTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace JsonSchema\Tests\Constraints;
 
 class ConstTest extends BaseTestCase

--- a/tests/Constraints/ConstTest.php
+++ b/tests/Constraints/ConstTest.php
@@ -4,9 +4,9 @@ namespace JsonSchema\Tests\Constraints;
 
 class ConstTest extends BaseTestCase
 {
-    /** @var string  */
+    /** @var string */
     protected $schemaSpec = 'http://json-schema.org/draft-06/schema#';
-    /** @var bool  */
+    /** @var bool */
     protected $validateSchema = true;
 
     public function getInvalidTests(): \Generator

--- a/tests/Constraints/DefaultPropertiesTest.php
+++ b/tests/Constraints/DefaultPropertiesTest.php
@@ -1,12 +1,13 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * This file is part of the JsonSchema package.
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  */
-
 namespace JsonSchema\Tests\Constraints;
 
 use JsonSchema\Constraints\Constraint;

--- a/tests/Constraints/DefaultPropertiesTest.php
+++ b/tests/Constraints/DefaultPropertiesTest.php
@@ -2,12 +2,6 @@
 
 declare(strict_types=1);
 
-/*
- * This file is part of the JsonSchema package.
- *
- * For the full copyright and license information, please view the LICENSE
- * file that was distributed with this source code.
- */
 namespace JsonSchema\Tests\Constraints;
 
 use JsonSchema\Constraints\Constraint;

--- a/tests/Constraints/DependenciesTest.php
+++ b/tests/Constraints/DependenciesTest.php
@@ -4,9 +4,9 @@ namespace JsonSchema\Tests\Constraints;
 
 class DependenciesTest extends BaseTestCase
 {
-    /** @var string  */
+    /** @var string */
     protected $schemaSpec = 'http://json-schema.org/draft-03/schema#';
-    /** @var bool  */
+    /** @var bool */
     protected $validateSchema = true;
 
     public function getInvalidTests(): \Generator

--- a/tests/Constraints/DependenciesTest.php
+++ b/tests/Constraints/DependenciesTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace JsonSchema\Tests\Constraints;
 
 class DependenciesTest extends BaseTestCase

--- a/tests/Constraints/DisallowTest.php
+++ b/tests/Constraints/DisallowTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace JsonSchema\Tests\Constraints;
 
 /**

--- a/tests/Constraints/DivisibleByTest.php
+++ b/tests/Constraints/DivisibleByTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace JsonSchema\Tests\Constraints;
 
 class DivisibleByTest extends BaseTestCase

--- a/tests/Constraints/EnumTest.php
+++ b/tests/Constraints/EnumTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace JsonSchema\Tests\Constraints;
 
 class EnumTest extends BaseTestCase

--- a/tests/Constraints/EnumTest.php
+++ b/tests/Constraints/EnumTest.php
@@ -4,9 +4,9 @@ namespace JsonSchema\Tests\Constraints;
 
 class EnumTest extends BaseTestCase
 {
-    /** @var string  */
+    /** @var string */
     protected $schemaSpec = 'http://json-schema.org/draft-03/schema#';
-    /** @var bool  */
+    /** @var bool */
     protected $validateSchema = true;
 
     public function getInvalidTests(): \Generator

--- a/tests/Constraints/ExtendsTest.php
+++ b/tests/Constraints/ExtendsTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace JsonSchema\Tests\Constraints;
 
 class ExtendsTest extends BaseTestCase

--- a/tests/Constraints/FactoryTest.php
+++ b/tests/Constraints/FactoryTest.php
@@ -1,12 +1,5 @@
 <?php
 
-/*
- * This file is part of the JsonSchema package.
- *
- * For the full copyright and license information, please view the LICENSE
- * file that was distributed with this source code.
- */
-
 declare(strict_types=1);
 
 namespace JsonSchema\Tests\Constraints;

--- a/tests/Constraints/FormatTest.php
+++ b/tests/Constraints/FormatTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace JsonSchema\Tests\Constraints;
 
 use JsonSchema\Constraints\Constraint;

--- a/tests/Constraints/FormatTest.php
+++ b/tests/Constraints/FormatTest.php
@@ -1,6 +1,5 @@
 <?php
 
-
 namespace JsonSchema\Tests\Constraints;
 
 use JsonSchema\Constraints\Constraint;
@@ -9,7 +8,7 @@ use JsonSchema\Constraints\FormatConstraint;
 
 class FormatTest extends BaseTestCase
 {
-    /** @var bool  */
+    /** @var bool */
     protected $validateSchema = true;
 
     public function setUp(): void

--- a/tests/Constraints/LongArraysTest.php
+++ b/tests/Constraints/LongArraysTest.php
@@ -55,7 +55,7 @@ class LongArraysTest extends VeryBaseTestCase
 
         $tmp = new \stdClass();
         $tmp->p_array = array_map(function ($i) {
-            return rand(1, 1000) / 1000.0;
+            return random_int(1, 1000) / 1000.0;
         }, range(1, 100000));
         $input = json_encode($tmp);
 

--- a/tests/Constraints/LongArraysTest.php
+++ b/tests/Constraints/LongArraysTest.php
@@ -2,12 +2,6 @@
 
 declare(strict_types=1);
 
-/*
- * This file is part of the JsonSchema package.
- *
- * For the full copyright and license information, please view the LICENSE
- * file that was distributed with this source code.
- */
 namespace JsonSchema\Tests\Constraints;
 
 use JsonSchema\Constraints\Factory;

--- a/tests/Constraints/LongArraysTest.php
+++ b/tests/Constraints/LongArraysTest.php
@@ -1,12 +1,13 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * This file is part of the JsonSchema package.
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  */
-
 namespace JsonSchema\Tests\Constraints;
 
 use JsonSchema\Constraints\Factory;

--- a/tests/Constraints/MinItemsMaxItemsTest.php
+++ b/tests/Constraints/MinItemsMaxItemsTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace JsonSchema\Tests\Constraints;
 
 use JsonSchema\Constraints\Constraint;

--- a/tests/Constraints/MinLengthMaxLengthMultiByteTest.php
+++ b/tests/Constraints/MinLengthMaxLengthMultiByteTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace JsonSchema\Tests\Constraints;
 
 class MinLengthMaxLengthMultiByteTest extends BaseTestCase

--- a/tests/Constraints/MinLengthMaxLengthTest.php
+++ b/tests/Constraints/MinLengthMaxLengthTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace JsonSchema\Tests\Constraints;
 
 class MinLengthMaxLengthTest extends BaseTestCase

--- a/tests/Constraints/MinMaxPropertiesTest.php
+++ b/tests/Constraints/MinMaxPropertiesTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace JsonSchema\Tests\Constraints;
 
 use JsonSchema\Constraints\Constraint;

--- a/tests/Constraints/MinimumMaximumTest.php
+++ b/tests/Constraints/MinimumMaximumTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace JsonSchema\Tests\Constraints;
 
 class MinimumMaximumTest extends BaseTestCase

--- a/tests/Constraints/NotTest.php
+++ b/tests/Constraints/NotTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace JsonSchema\Tests\Constraints;
 
 class NotTest extends BaseTestCase

--- a/tests/Constraints/NotTest.php
+++ b/tests/Constraints/NotTest.php
@@ -4,6 +4,7 @@ namespace JsonSchema\Tests\Constraints;
 
 class NotTest extends BaseTestCase
 {
+    /** @var bool */
     protected $validateSchema = true;
 
     public function getInvalidTests(): \Generator

--- a/tests/Constraints/NotTest.php
+++ b/tests/Constraints/NotTest.php
@@ -1,12 +1,5 @@
 <?php
 
-/*
- * This file is part of the JsonSchema package.
- *
- * For the full copyright and license information, please view the LICENSE
- * file that was distributed with this source code.
- */
-
 namespace JsonSchema\Tests\Constraints;
 
 class NotTest extends BaseTestCase

--- a/tests/Constraints/NumberAndIntegerTypesTest.php
+++ b/tests/Constraints/NumberAndIntegerTypesTest.php
@@ -1,6 +1,5 @@
 <?php
 
-
 namespace JsonSchema\Tests\Constraints;
 
 class NumberAndIntegerTypesTest extends BaseTestCase

--- a/tests/Constraints/NumberAndIntegerTypesTest.php
+++ b/tests/Constraints/NumberAndIntegerTypesTest.php
@@ -13,106 +13,102 @@ class NumberAndIntegerTypesTest extends BaseTestCase
 {
     protected $validateSchema = true;
 
-    public function getInvalidTests(): array
+    public function getInvalidTests(): \Generator
     {
-        return [
-            [
-                '{
-                  "integer": 1.4
-                }',
-                '{
-                  "type":"object",
-                  "properties":{
-                    "integer":{"type":"integer"}
-                  }
-                }'
-            ],
-            [
-                '{"integer": 1.001}',
-                '{
-                    "type": "object",
-                    "properties": {
-                        "integer": {"type": "integer"}
-                    }
-                }'
-            ],
-            [
-                '{"integer": true}',
-                '{
-                    "type": "object",
-                    "properties": {
-                        "integer": {"type": "integer"}
-                    }
-                }'
-            ],
-            [
-                '{"number": "x"}',
-                '{
-                    "type": "object",
-                    "properties": {
-                        "number": {"type": "number"}
-                    }
-                }'
-            ]
+        yield [
+            '{
+              "integer": 1.4
+            }',
+            '{
+              "type":"object",
+              "properties":{
+                "integer":{"type":"integer"}
+              }
+            }'
+        ];
+        yield [
+            '{"integer": 1.001}',
+            '{
+                "type": "object",
+                "properties": {
+                    "integer": {"type": "integer"}
+                }
+            }'
+        ];
+        yield [
+            '{"integer": true}',
+            '{
+                "type": "object",
+                "properties": {
+                    "integer": {"type": "integer"}
+                }
+            }'
+        ];
+        yield [
+            '{"number": "x"}',
+            '{
+                "type": "object",
+                "properties": {
+                    "number": {"type": "number"}
+                }
+            }'
         ];
     }
 
-    public function getValidTests(): array
+    public function getValidTests(): \Generator
     {
-        return [
-            [
-                '{
-                  "integer": 1
-                }',
-                '{
-                  "type":"object",
-                  "properties":{
-                    "integer":{"type":"integer"}
-                  }
-                }'
-            ],
-            [
-                '{
-                  "number": 1.4
-                }',
-                '{
-                  "type":"object",
-                  "properties":{
-                    "number":{"type":"number"}
-                  }
-                }'
-            ],
-            [
-                '{"number": 1e5}',
-                '{
-                    "type": "object",
-                    "properties": {
-                        "number": {"type": "number"}
-                    }
-                }'
-            ],
-            [
-                '{"number": 1}',
-                '{
-                    "type": "object",
-                    "properties": {
-                        "number": {"type": "number"}
+        yield [
+            '{
+              "integer": 1
+            }',
+            '{
+              "type":"object",
+              "properties":{
+                "integer":{"type":"integer"}
+              }
+            }'
+        ];
+        yield [
+            '{
+              "number": 1.4
+            }',
+            '{
+              "type":"object",
+              "properties":{
+                "number":{"type":"number"}
+              }
+            }'
+        ];
+        yield [
+            '{"number": 1e5}',
+            '{
+                "type": "object",
+                "properties": {
+                    "number": {"type": "number"}
+                }
+            }'
+        ];
+        yield [
+            '{"number": 1}',
+            '{
+                "type": "object",
+                "properties": {
+                    "number": {"type": "number"}
 
+                }
+            }'
+        ];
+        yield [
+            '{"number": -49.89}',
+            '{
+                "type": "object",
+                "properties": {
+                    "number": {
+                      "type": "number",
+                      "multipleOf": 0.01
                     }
-                }'
-            ],
-            [
-                '{"number": -49.89}',
-                '{
-                    "type": "object",
-                    "properties": {
-                        "number": {
-                          "type": "number",
-                          "multipleOf": 0.01
-                        }
-                    }
-                }'
-            ]
+                }
+            }'
         ];
     }
 }

--- a/tests/Constraints/NumberAndIntegerTypesTest.php
+++ b/tests/Constraints/NumberAndIntegerTypesTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace JsonSchema\Tests\Constraints;
 
 class NumberAndIntegerTypesTest extends BaseTestCase

--- a/tests/Constraints/NumberAndIntegerTypesTest.php
+++ b/tests/Constraints/NumberAndIntegerTypesTest.php
@@ -1,11 +1,5 @@
 <?php
 
-/*
- * This file is part of the JsonSchema package.
- *
- * For the full copyright and license information, please view the LICENSE
- * file that was distributed with this source code.
- */
 
 namespace JsonSchema\Tests\Constraints;
 

--- a/tests/Constraints/NumberAndIntegerTypesTest.php
+++ b/tests/Constraints/NumberAndIntegerTypesTest.php
@@ -5,6 +5,7 @@ namespace JsonSchema\Tests\Constraints;
 
 class NumberAndIntegerTypesTest extends BaseTestCase
 {
+    /** @var bool */
     protected $validateSchema = true;
 
     public function getInvalidTests(): \Generator

--- a/tests/Constraints/OfPropertiesTest.php
+++ b/tests/Constraints/OfPropertiesTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace JsonSchema\Tests\Constraints;
 
 use JsonSchema\Constraints\Constraint;

--- a/tests/Constraints/OfPropertiesTest.php
+++ b/tests/Constraints/OfPropertiesTest.php
@@ -139,7 +139,7 @@ class OfPropertiesTest extends BaseTestCase
               }
             }'
         ];
-        yield[
+        yield [
             '{"prop1": [1,2]}',
             '{
               "type": "object",
@@ -158,7 +158,7 @@ class OfPropertiesTest extends BaseTestCase
               }
             }'
         ];
-        yield[
+        yield [
             '{"prop1": [1,2]}',
             '{
               "type": "object",
@@ -177,7 +177,7 @@ class OfPropertiesTest extends BaseTestCase
               }
             }'
         ];
-        yield[
+        yield [
             '{"prop1": [1,2]}',
             '{
               "type": "object",

--- a/tests/Constraints/OfPropertiesTest.php
+++ b/tests/Constraints/OfPropertiesTest.php
@@ -5,9 +5,6 @@ namespace JsonSchema\Tests\Constraints;
 use JsonSchema\Constraints\Constraint;
 use JsonSchema\Validator;
 
-/**
- * Class OfPropertiesTest
- */
 class OfPropertiesTest extends BaseTestCase
 {
     protected $validateSchema = true;

--- a/tests/Constraints/OfPropertiesTest.php
+++ b/tests/Constraints/OfPropertiesTest.php
@@ -18,217 +18,213 @@ class OfPropertiesTest extends BaseTestCase
 {
     protected $validateSchema = true;
 
-    public function getValidTests(): array
+    public function getValidTests(): \Generator
     {
-        return [
-            [
-                '{"prop1": "abc"}',
-                '{
-                  "type": "object",
-                  "properties": {
-                    "prop1": {"type": "string"},
-                    "prop2": {
-                      "oneOf": [
-                        {"type": "number"},
-                        {"type": "string"}
-                      ]
-                    }
-                  },
-                  "required": ["prop1"]
-                }'
-            ],
-            [
-                '{"prop1": "abc", "prop2": 23}',
-                '{
-                  "type": "object",
-                  "properties": {
-                    "prop1": {"type": "string"},
-                    "prop2": {
-                      "oneOf": [
-                        {"type": "number"},
-                        {"type": "string"}
-                      ]
-                    }
-                  },
-                  "required": ["prop1"]
-                }'
-            ],
+        yield [
+            '{"prop1": "abc"}',
+            '{
+              "type": "object",
+              "properties": {
+                "prop1": {"type": "string"},
+                "prop2": {
+                  "oneOf": [
+                    {"type": "number"},
+                    {"type": "string"}
+                  ]
+                }
+              },
+              "required": ["prop1"]
+            }'
+        ];
+        yield [
+            '{"prop1": "abc", "prop2": 23}',
+            '{
+              "type": "object",
+              "properties": {
+                "prop1": {"type": "string"},
+                "prop2": {
+                  "oneOf": [
+                    {"type": "number"},
+                    {"type": "string"}
+                  ]
+                }
+              },
+              "required": ["prop1"]
+            }'
         ];
     }
 
-    public function getInvalidTests(): array
+    public function getInvalidTests(): \Generator
     {
-        return [
+        yield [
+            '{"prop1": "abc", "prop2": []}',
+            '{
+              "type": "object",
+              "properties": {
+                "prop1": {"type": "string"},
+                "prop2": {
+                  "oneOf": [
+                    {"type": "number"},
+                    {"type": "string"}
+                  ]
+                }
+              },
+              "required": ["prop1"]
+            }',
+            null,
             [
-                '{"prop1": "abc", "prop2": []}',
-                '{
-                  "type": "object",
-                  "properties": {
-                    "prop1": {"type": "string"},
-                    "prop2": {
-                      "oneOf": [
-                        {"type": "number"},
-                        {"type": "string"}
-                      ]
-                    }
-                  },
-                  "required": ["prop1"]
-                }',
-                null,
                 [
-                    [
-                        'property'   => 'prop2',
-                        'pointer'    => '/prop2',
-                        'message'    => 'Array value found, but a string is required',
-                        'constraint' => [
-                            'name' => 'type',
-                            'params' => [
-                                'expected'   => 'a string',
-                                'found'      => 'array'
-                            ]
-                        ],
-                        'context'    => Validator::ERROR_DOCUMENT_VALIDATION
+                    'property'   => 'prop2',
+                    'pointer'    => '/prop2',
+                    'message'    => 'Array value found, but a string is required',
+                    'constraint' => [
+                        'name' => 'type',
+                        'params' => [
+                            'expected'   => 'a string',
+                            'found'      => 'array'
+                        ]
                     ],
-                    [
-                        'property'   => 'prop2',
-                        'pointer'    => '/prop2',
-                        'message'    => 'Array value found, but a number is required',
-                        'constraint' => [
-                            'name' => 'type',
-                            'params' => [
-                                'expected'   => 'a number',
-                                'found'      => 'array'
-                            ]
-                        ],
-                        'context'    => Validator::ERROR_DOCUMENT_VALIDATION
+                    'context'    => Validator::ERROR_DOCUMENT_VALIDATION
+                ],
+                [
+                    'property'   => 'prop2',
+                    'pointer'    => '/prop2',
+                    'message'    => 'Array value found, but a number is required',
+                    'constraint' => [
+                        'name' => 'type',
+                        'params' => [
+                            'expected'   => 'a number',
+                            'found'      => 'array'
+                        ]
                     ],
-                    [
-                        'property'   => 'prop2',
-                        'pointer'    => '/prop2',
-                        'message'    => 'Failed to match exactly one schema',
-                        'constraint' => [
-                            'name' => 'oneOf',
-                            'params' => []
-                        ],
-                        'context'    => Validator::ERROR_DOCUMENT_VALIDATION
+                    'context'    => Validator::ERROR_DOCUMENT_VALIDATION
+                ],
+                [
+                    'property'   => 'prop2',
+                    'pointer'    => '/prop2',
+                    'message'    => 'Failed to match exactly one schema',
+                    'constraint' => [
+                        'name' => 'oneOf',
+                        'params' => []
                     ],
+                    'context'    => Validator::ERROR_DOCUMENT_VALIDATION
                 ],
             ],
-            [
-                '{"prop1": [1,2]}',
-                '{
-                  "type": "object",
-                  "properties": {
-                    "prop1": {
-                      "oneOf": [
-                        {
-                          "type": "string",
-                          "pattern": "^[a-z]*$"
-                        },
-                        {
-                          "type": "string",
-                          "pattern": "^[A-Z]*$"
-                        }
-                      ]
+        ];
+        yield [
+            '{"prop1": [1,2]}',
+            '{
+              "type": "object",
+              "properties": {
+                "prop1": {
+                  "oneOf": [
+                    {
+                      "type": "string",
+                      "pattern": "^[a-z]*$"
+                    },
+                    {
+                      "type": "string",
+                      "pattern": "^[A-Z]*$"
                     }
-                  }
-                }'
-            ],
-            [
-                '{"prop1": [1,2]}',
-                '{
-                  "type": "object",
-                  "properties": {
-                    "prop1": {
-                      "anyOf": [
-                        {
-                          "type": "string",
-                          "pattern": "^[A-Z]*$"
-                        }
-                      ]
+                  ]
+                }
+              }
+            }'
+        ];
+        yield [
+            '{"prop1": [1,2]}',
+            '{
+              "type": "object",
+              "properties": {
+                "prop1": {
+                  "anyOf": [
+                    {
+                      "type": "string",
+                      "pattern": "^[A-Z]*$"
                     }
-                  }
-                }'
-            ],
-            [
-                '{"prop1": [1,2]}',
-                '{
-                  "type": "object",
-                  "properties": {
-                    "prop1": {
-                      "anyOf": [
-                        {
-                          "type": "number"
-                        },
-                        {
-                          "type": "string",
-                          "pattern": "^[A-Z]*$"
-                        }
-                      ]
+                  ]
+                }
+              }
+            }'
+        ];
+        yield[
+            '{"prop1": [1,2]}',
+            '{
+              "type": "object",
+              "properties": {
+                "prop1": {
+                  "anyOf": [
+                    {
+                      "type": "number"
+                    },
+                    {
+                      "type": "string",
+                      "pattern": "^[A-Z]*$"
                     }
-                  }
-                }'
-            ],
-            [
-                '{"prop1": [1,2]}',
-                '{
-                  "type": "object",
-                  "properties": {
-                    "prop1": {
-                      "anyOf": [
-                        {
-                          "type": "string"
-                        },
-                        {
-                          "type": "string",
-                          "pattern": "^[A-Z]*$"
-                        }
-                      ]
+                  ]
+                }
+              }
+            }'
+        ];
+        yield[
+            '{"prop1": [1,2]}',
+            '{
+              "type": "object",
+              "properties": {
+                "prop1": {
+                  "anyOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "string",
+                      "pattern": "^[A-Z]*$"
                     }
-                  }
-                }'
-            ],
-            [
-                '{"prop1": [1,2]}',
-                '{
-                  "type": "object",
-                  "properties": {
-                    "prop1": {
-                      "anyOf": [
-                        {
-                          "type": "string",
-                          "pattern": "^[a-z]*$"
-                        },
-                        {
-                          "type": "string",
-                          "pattern": "^[A-Z]*$"
-                        }
-                      ]
+                  ]
+                }
+              }
+            }'
+        ];
+        yield[
+            '{"prop1": [1,2]}',
+            '{
+              "type": "object",
+              "properties": {
+                "prop1": {
+                  "anyOf": [
+                    {
+                      "type": "string",
+                      "pattern": "^[a-z]*$"
+                    },
+                    {
+                      "type": "string",
+                      "pattern": "^[A-Z]*$"
                     }
-                  }
-                }'
-            ],
-            [
-                '{"prop1": [1,2]}',
-                '{
-                  "type": "object",
-                  "properties": {
-                    "prop1": {
-                      "anyOf": [
-                        {
-                          "type": "number"
-                        },
-                        {
-                          "type": "string"
-                        },
-                        {
-                          "type": "string"
-                        }
-                      ]
+                  ]
+                }
+              }
+            }'
+        ];
+        yield [
+            '{"prop1": [1,2]}',
+            '{
+              "type": "object",
+              "properties": {
+                "prop1": {
+                  "anyOf": [
+                    {
+                      "type": "number"
+                    },
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "string"
                     }
-                  }
-                }'
-            ]
+                  ]
+                }
+              }
+            }'
         ];
     }
 

--- a/tests/Constraints/OfPropertiesTest.php
+++ b/tests/Constraints/OfPropertiesTest.php
@@ -222,7 +222,8 @@ class OfPropertiesTest extends BaseTestCase
 
     public function testNoPrematureAnyOfException(): void
     {
-        $schema = json_decode('{
+        $schema = json_decode(
+            '{
             "type": "object",
             "properties": {
                 "propertyOne": {
@@ -232,8 +233,10 @@ class OfPropertiesTest extends BaseTestCase
                     ]
                 }
             }
-        }');
-        $data = json_decode('{"propertyOne":"ABC"}');
+        }',
+            false
+        );
+        $data = json_decode('{"propertyOne":"ABC"}', false);
 
         $v = new Validator();
         $v->validate($data, $schema, Constraint::CHECK_MODE_EXCEPTIONS);
@@ -242,7 +245,8 @@ class OfPropertiesTest extends BaseTestCase
 
     public function testNoPrematureOneOfException(): void
     {
-        $schema = json_decode('{
+        $schema = json_decode(
+            '{
             "type": "object",
             "properties": {
                 "propertyOne": {
@@ -252,8 +256,10 @@ class OfPropertiesTest extends BaseTestCase
                     ]
                 }
             }
-        }');
-        $data = json_decode('{"propertyOne":"ABC"}');
+        }',
+            false
+        );
+        $data = json_decode('{"propertyOne":"ABC"}', false);
 
         $v = new Validator();
         $v->validate($data, $schema, Constraint::CHECK_MODE_EXCEPTIONS);

--- a/tests/Constraints/OfPropertiesTest.php
+++ b/tests/Constraints/OfPropertiesTest.php
@@ -7,6 +7,7 @@ use JsonSchema\Validator;
 
 class OfPropertiesTest extends BaseTestCase
 {
+    /** @var bool */
     protected $validateSchema = true;
 
     public function getValidTests(): \Generator

--- a/tests/Constraints/OfPropertiesTest.php
+++ b/tests/Constraints/OfPropertiesTest.php
@@ -1,10 +1,4 @@
 <?php
-/*
- * This file is part of the JsonSchema package.
- *
- * For the full copyright and license information, please view the LICENSE
- * file that was distributed with this source code.
- */
 
 namespace JsonSchema\Tests\Constraints;
 

--- a/tests/Constraints/PatternPropertiesTest.php
+++ b/tests/Constraints/PatternPropertiesTest.php
@@ -1,12 +1,5 @@
 <?php
 
-/*
- * This file is part of the JsonSchema package.
- *
- * For the full copyright and license information, please view the LICENSE
- * file that was distributed with this source code.
- */
-
 namespace JsonSchema\Tests\Constraints;
 
 class PatternPropertiesTest extends BaseTestCase

--- a/tests/Constraints/PatternPropertiesTest.php
+++ b/tests/Constraints/PatternPropertiesTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace JsonSchema\Tests\Constraints;
 
 class PatternPropertiesTest extends BaseTestCase

--- a/tests/Constraints/PatternPropertiesTest.php
+++ b/tests/Constraints/PatternPropertiesTest.php
@@ -14,202 +14,192 @@ class PatternPropertiesTest extends BaseTestCase
     /** @var bool */
     protected $validateSchema = true;
 
-    public function getInvalidTests(): array
+    public function getInvalidTests(): \Generator
     {
-        return [
-            // matches pattern but invalid schema for object
-            [
-                json_encode([
-                    'someobject' => [
-                        'foobar' => 'foo',
-                        'barfoo' => 'bar',
-                    ]
-                ]),
-                json_encode([
-                    'type' => 'object',
-                    'patternProperties' => [
-                        '^someobject$' => [
-                            'type' => 'object',
-                            'additionalProperties' => false,
-                            'properties' => [
-                                'barfoo' => [
-                                    'type' => 'string',
-                                ],
-                            ]
+        yield 'matches pattern but invalid schema for object' => [
+            json_encode([
+                'someobject' => [
+                    'foobar' => 'foo',
+                    'barfoo' => 'bar',
+                ]
+            ]),
+            json_encode([
+                'type' => 'object',
+                'patternProperties' => [
+                    '^someobject$' => [
+                        'type' => 'object',
+                        'additionalProperties' => false,
+                        'properties' => [
+                            'barfoo' => [
+                                'type' => 'string',
+                            ],
                         ]
                     ]
-                ])
-            ],
-            // Does not match pattern
-            [
-                json_encode([
-                        'regex_us' => false,
-                ]),
-                json_encode([
-                        'type' => 'object',
-                        'patternProperties' => [
-                            '^[a-z]+_(jp|de)$' => [
-                                'type' => ['boolean']
-                            ]
-                        ],
-                        'additionalProperties' => false
-                ])
-            ],
-            // Does not match pattern with unicode
-            [
-                json_encode([
-                        '猡猡獛' => false,
-                ]),
-                json_encode([
-                        'type' => 'object',
-                        'patternProperties' => [
-                            '^[\\x{0080}-\\x{006FFF}]+$' => [
-                                'type' => ['boolean']
-                            ]
-                        ],
-                        'additionalProperties' => false
-                ])
-            ],
-            // An invalid regular expression pattern
-            [
-                json_encode([
-                        'regex_us' => false,
-                ]),
-                json_encode([
-                        'type' => 'object',
-                        'patternProperties' => [
-                            '^[a-z+_jp|de)$' => [
-                                'type' => ['boolean']
-                            ]
-                        ],
-                        'additionalProperties' => false
-                ])
-            ],
+                ]
+            ])
+        ];
+        yield 'Does not match pattern' => [
+            json_encode([
+                    'regex_us' => false,
+            ]),
+            json_encode([
+                'type' => 'object',
+                'patternProperties' => [
+                    '^[a-z]+_(jp|de)$' => [
+                        'type' => ['boolean']
+                    ]
+                ],
+                'additionalProperties' => false
+            ])
+        ];
+        yield 'Does not match pattern with unicode' => [
+            json_encode([
+                '猡猡獛' => false,
+            ]),
+            json_encode([
+                'type' => 'object',
+                'patternProperties' => [
+                    '^[\\x{0080}-\\x{006FFF}]+$' => [
+                        'type' => ['boolean']
+                    ]
+                ],
+                'additionalProperties' => false
+            ])
+        ];
+        yield 'An invalid regular expression pattern' => [
+            json_encode([
+                    'regex_us' => false,
+            ]),
+            json_encode([
+                'type' => 'object',
+                'patternProperties' => [
+                    '^[a-z+_jp|de)$' => [
+                        'type' => ['boolean']
+                    ]
+                ],
+                'additionalProperties' => false
+            ])
         ];
     }
 
-    public function getValidTests(): array
+    public function getValidTests(): \Generator
     {
-        return [
-            [
-                // validates pattern schema
-                json_encode([
-                    'someobject' => [
-                        'foobar' => 'foo',
-                        'barfoo' => 'bar',
-                    ],
-                    'someotherobject' => [
-                        'foobar' => 1234,
-                    ],
-                    '/products' => [
-                        'get' => []
-                    ],
-                    '#products' => [
-                        'get' => []
-                    ],
-                    '+products' => [
-                        'get' => []
-                    ],
-                    '~products' => [
-                        'get' => []
-                    ],
-                    '*products' => [
-                        'get' => []
-                    ],
-                    '%products' => [
-                        'get' => []
-                    ]
-                ]),
-                json_encode([
-                    'type' => 'object',
-                    'additionalProperties' => false,
-                    'patternProperties' => [
-                        '^someobject$' => [
-                            'type' => 'object',
-                            'properties' => [
-                                'foobar' => ['type' => 'string'],
-                                'barfoo' => ['type' => 'string'],
-                            ],
-                        ],
-                        '^someotherobject$' => [
-                            'type' => 'object',
-                            'properties' => [
-                                'foobar' => ['type' => 'number'],
-                            ],
-                        ],
-                        '^/' => [
-                            'type' => 'object',
-                            'properties' => [
-                                'get' => ['type' => 'array']
-                            ]
-                        ],
-                        '^#' => [
-                            'type' => 'object',
-                            'properties' => [
-                                'get' => ['type' => 'array']
-                            ]
-                        ],
-                        '^\+' => [
-                            'type' => 'object',
-                            'properties' => [
-                                'get' => ['type' => 'array']
-                            ]
-                        ],
-                        '^~' => [
-                            'type' => 'object',
-                            'properties' => [
-                                'get' => ['type' => 'array']
-                            ]
-                        ],
-                        '^\*' => [
-                            'type' => 'object',
-                            'properties' => [
-                                'get' => ['type' => 'array']
-                            ]
-                        ],
-                        '^%' => [
-                            'type' => 'object',
-                            'properties' => [
-                                'get' => ['type' => 'array']
-                            ]
-                        ]
-                    ]
-                ])
-            ],
-            [
-                json_encode([
-                        'foobar' => true,
-                        'regex_us' => 'foo',
-                        'regex_de' => 1234
-                ]),
-                json_encode([
+        [
+            yield 'validates pattern schema' => json_encode([
+                'someobject' => [
+                    'foobar' => 'foo',
+                    'barfoo' => 'bar',
+                ],
+                'someotherobject' => [
+                    'foobar' => 1234,
+                ],
+                '/products' => [
+                    'get' => []
+                ],
+                '#products' => [
+                    'get' => []
+                ],
+                '+products' => [
+                    'get' => []
+                ],
+                '~products' => [
+                    'get' => []
+                ],
+                '*products' => [
+                    'get' => []
+                ],
+                '%products' => [
+                    'get' => []
+                ]
+            ]),
+            json_encode([
+                'type' => 'object',
+                'additionalProperties' => false,
+                'patternProperties' => [
+                    '^someobject$' => [
                         'type' => 'object',
                         'properties' => [
-                            'foobar' => ['type' => 'boolean']
+                            'foobar' => ['type' => 'string'],
+                            'barfoo' => ['type' => 'string'],
                         ],
-                        'patternProperties' => [
-                            '^[a-z]+_(us|de)$' => [
-                                'type' => ['string', 'integer']
-                            ]
+                    ],
+                    '^someotherobject$' => [
+                        'type' => 'object',
+                        'properties' => [
+                            'foobar' => ['type' => 'number'],
                         ],
-                        'additionalProperties' => false
-                ])
-            ],
-            // Does match pattern with unicode
-            [
-                json_encode([
-                    'ðæſ' => 'unicode',
-                ]),
-                json_encode([
+                    ],
+                    '^/' => [
+                        'type' => 'object',
+                        'properties' => [
+                            'get' => ['type' => 'array']
+                        ]
+                    ],
+                    '^#' => [
+                        'type' => 'object',
+                        'properties' => [
+                            'get' => ['type' => 'array']
+                        ]
+                    ],
+                    '^\+' => [
+                        'type' => 'object',
+                        'properties' => [
+                            'get' => ['type' => 'array']
+                        ]
+                    ],
+                    '^~' => [
+                        'type' => 'object',
+                        'properties' => [
+                            'get' => ['type' => 'array']
+                        ]
+                    ],
+                    '^\*' => [
+                        'type' => 'object',
+                        'properties' => [
+                            'get' => ['type' => 'array']
+                        ]
+                    ],
+                    '^%' => [
+                        'type' => 'object',
+                        'properties' => [
+                            'get' => ['type' => 'array']
+                        ]
+                    ]
+                ]
+            ])
+        ];
+        yield [
+            json_encode([
+                    'foobar' => true,
+                    'regex_us' => 'foo',
+                    'regex_de' => 1234
+            ]),
+            json_encode([
                     'type' => 'object',
+                    'properties' => [
+                        'foobar' => ['type' => 'boolean']
+                    ],
                     'patternProperties' => [
-                        '^[\\x{0080}-\\x{10FFFF}]+$' => [
-                            'type' => ['string']
+                        '^[a-z]+_(us|de)$' => [
+                            'type' => ['string', 'integer']
                         ]
                     ],
                     'additionalProperties' => false
-                ])
-            ],
+            ])
+        ];
+        yield 'Does match pattern with unicode' => [
+            json_encode([
+                'ðæſ' => 'unicode',
+            ]),
+            json_encode([
+                'type' => 'object',
+                'patternProperties' => [
+                    '^[\\x{0080}-\\x{10FFFF}]+$' => [
+                        'type' => ['string']
+                    ]
+                ],
+                'additionalProperties' => false
+            ])
         ];
     }
 }

--- a/tests/Constraints/PatternPropertiesTest.php
+++ b/tests/Constraints/PatternPropertiesTest.php
@@ -11,6 +11,7 @@ namespace JsonSchema\Tests\Constraints;
 
 class PatternPropertiesTest extends BaseTestCase
 {
+    /** @var bool */
     protected $validateSchema = true;
 
     public function getInvalidTests(): array

--- a/tests/Constraints/PatternTest.php
+++ b/tests/Constraints/PatternTest.php
@@ -4,6 +4,7 @@ namespace JsonSchema\Tests\Constraints;
 
 class PatternTest extends BaseTestCase
 {
+    /** @var bool */
     protected $validateSchema = true;
 
     public function getInvalidTests(): \Generator

--- a/tests/Constraints/PatternTest.php
+++ b/tests/Constraints/PatternTest.php
@@ -13,91 +13,87 @@ class PatternTest extends BaseTestCase
 {
     protected $validateSchema = true;
 
-    public function getInvalidTests(): array
+    public function getInvalidTests(): \Generator
     {
-        return [
-            [
-                '{
-                  "value":"Abacates"
-                }',
-                '{
-                  "type":"object",
-                  "properties":{
-                    "value":{"type":"string","pattern":"^cat"}
-                  },
-                  "additionalProperties":false
-                }'
-            ],
-            [
-                '{"value": "abc"}',
-                '{
-                    "type": "object",
-                    "properties": {
-                        "value": {"type": "string", "pattern": "^a*$"}
-                    },
-                    "additionalProperties": false
-                }'
-            ],
-            [
-                '{"value": "Ã¼"}',
-                '{
-                    "type": "object",
-                    "properties": {
-                        "value": {"type": "string", "pattern": "^ü$"}
-                    },
-                    "additionalProperties": false
-                }'
-            ],
+        yield [
+            '{
+              "value":"Abacates"
+            }',
+            '{
+              "type":"object",
+              "properties":{
+                "value":{"type":"string","pattern":"^cat"}
+              },
+              "additionalProperties":false
+            }'
+        ];
+        yield [
+            '{"value": "abc"}',
+            '{
+                "type": "object",
+                "properties": {
+                    "value": {"type": "string", "pattern": "^a*$"}
+                },
+                "additionalProperties": false
+            }'
+        ];
+        yield [
+            '{"value": "Ã¼"}',
+            '{
+                "type": "object",
+                "properties": {
+                    "value": {"type": "string", "pattern": "^ü$"}
+                },
+                "additionalProperties": false
+            }'
         ];
     }
 
-    public function getValidTests(): array
+    public function getValidTests(): \Generator
     {
-        return [
-            [
-                '{
-                  "value":"Abacates"
-                }',
-                '{
-                  "type":"object",
-                  "properties":{
-                    "value":{"type":"string","pattern":"tes$"}
-                  },
-                  "additionalProperties":false
-                }'
-            ],
-            [
-                '{
-                  "value":"Abacates"
-                }',
-                '{
-                  "type":"object",
-                  "properties":{
-                    "value":{"type":"string","pattern":"cat"}
-                  },
-                  "additionalProperties":false
-                }'
-            ],
-            [
-                '{"value": "aaa"}',
-                '{
-                    "type": "object",
-                    "properties": {
-                        "value": {"type": "string", "pattern": "^a*$"}
-                    },
-                    "additionalProperties": false
-                }'
-            ],
-            [
-                '{"value": "↓æ→"}',
-                '{
-                    "type": "object",
-                    "properties": {
-                        "value": {"type": "string", "pattern": "^↓æ.$"}
-                    },
-                    "additionalProperties": false
-                }'
-            ]
+        yield [
+            '{
+              "value":"Abacates"
+            }',
+            '{
+              "type":"object",
+              "properties":{
+                "value":{"type":"string","pattern":"tes$"}
+              },
+              "additionalProperties":false
+            }'
+        ];
+        yield [
+            '{
+              "value":"Abacates"
+            }',
+            '{
+              "type":"object",
+              "properties":{
+                "value":{"type":"string","pattern":"cat"}
+              },
+              "additionalProperties":false
+            }'
+        ];
+        yield [
+            '{"value": "aaa"}',
+            '{
+                "type": "object",
+                "properties": {
+                    "value": {"type": "string", "pattern": "^a*$"}
+                },
+                "additionalProperties": false
+            }'
+        ];
+        yield [
+            '{"value": "↓æ→"}',
+            '{
+                "type": "object",
+                "properties": {
+                    "value": {"type": "string", "pattern": "^↓æ.$"}
+                },
+                "additionalProperties": false
+            }'
         ];
     }
 }

--- a/tests/Constraints/PatternTest.php
+++ b/tests/Constraints/PatternTest.php
@@ -1,12 +1,5 @@
 <?php
 
-/*
- * This file is part of the JsonSchema package.
- *
- * For the full copyright and license information, please view the LICENSE
- * file that was distributed with this source code.
- */
-
 namespace JsonSchema\Tests\Constraints;
 
 class PatternTest extends BaseTestCase

--- a/tests/Constraints/PatternTest.php
+++ b/tests/Constraints/PatternTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace JsonSchema\Tests\Constraints;
 
 class PatternTest extends BaseTestCase

--- a/tests/Constraints/PointerTest.php
+++ b/tests/Constraints/PointerTest.php
@@ -2,12 +2,6 @@
 
 declare(strict_types=1);
 
-/*
- * This file is part of the JsonSchema package.
- *
- * For the full copyright and license information, please view the LICENSE
- * file that was distributed with this source code.
- */
 namespace JsonSchema\Tests\Constraints;
 
 use JsonSchema\Validator;

--- a/tests/Constraints/PointerTest.php
+++ b/tests/Constraints/PointerTest.php
@@ -1,12 +1,13 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * This file is part of the JsonSchema package.
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  */
-
 namespace JsonSchema\Tests\Constraints;
 
 use JsonSchema\Validator;

--- a/tests/Constraints/ReadOnlyTest.php
+++ b/tests/Constraints/ReadOnlyTest.php
@@ -13,36 +13,31 @@ class ReadOnlyTest extends BaseTestCase
 {
     protected $validateSchema = true;
 
-    public function getInvalidTests(): array
+    public function getInvalidTests(): \Generator
     {
-        //is readonly really required?
-        return [
-            [
-                '{ "number": [] }',
-                '{
-                  "type":"object",
-                  "properties":{
-                    "number":{"type":"string","readonly":true}
-                  }
-                }'
-            ]
+        yield 'is readonly really required?' => [
+            '{ "number": [] }',
+            '{
+              "type":"object",
+              "properties":{
+                "number":{"type":"string","readonly":true}
+              }
+            }'
         ];
     }
 
-    public function getValidTests(): array
+    public function getValidTests(): \Generator
     {
-        return [
-            [
-                '{
-                  "number": "1.4"
-                }',
-                '{
-                  "type":"object",
-                  "properties":{
-                    "number":{"type":"string","readonly":true}
-                  }
-                }'
-            ]
+        yield [
+            '{
+              "number": "1.4"
+            }',
+            '{
+              "type":"object",
+              "properties":{
+                "number":{"type":"string","readonly":true}
+              }
+            }'
         ];
     }
 }

--- a/tests/Constraints/ReadOnlyTest.php
+++ b/tests/Constraints/ReadOnlyTest.php
@@ -4,6 +4,7 @@ namespace JsonSchema\Tests\Constraints;
 
 class ReadOnlyTest extends BaseTestCase
 {
+    /** @var bool */
     protected $validateSchema = true;
 
     public function getInvalidTests(): \Generator

--- a/tests/Constraints/ReadOnlyTest.php
+++ b/tests/Constraints/ReadOnlyTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace JsonSchema\Tests\Constraints;
 
 class ReadOnlyTest extends BaseTestCase

--- a/tests/Constraints/ReadOnlyTest.php
+++ b/tests/Constraints/ReadOnlyTest.php
@@ -1,12 +1,5 @@
 <?php
 
-/*
- * This file is part of the JsonSchema package.
- *
- * For the full copyright and license information, please view the LICENSE
- * file that was distributed with this source code.
- */
-
 namespace JsonSchema\Tests\Constraints;
 
 class ReadOnlyTest extends BaseTestCase

--- a/tests/Constraints/RequireTest.php
+++ b/tests/Constraints/RequireTest.php
@@ -13,40 +13,36 @@ class RequireTest extends BaseTestCase
 {
     protected $validateSchema = true;
 
-    public function getInvalidTests(): array
+    public function getInvalidTests(): \Generator
     {
-        return [
-            [
-                '{
-                  "state":"DF"
-                }',
-                '{
-                  "type":"object",
-                  "properties":{
-                    "state":{"type":"string","requires":"city"},
-                    "city":{"type":"string"}
-                  }
-                }'
-            ]
+        yield [
+            '{
+              "state":"DF"
+            }',
+            '{
+              "type":"object",
+              "properties":{
+                "state":{"type":"string","requires":"city"},
+                "city":{"type":"string"}
+              }
+            }'
         ];
     }
 
-    public function getValidTests(): array
+    public function getValidTests(): \Generator
     {
-        return [
-            [
-                '{
-                  "state":"DF",
-                  "city":"Brasília"
-                }',
-                '{
-                  "type":"object",
-                  "properties":{
-                    "state":{"type":"string","requires":"city"},
-                    "city":{"type":"string"}
-                  }
-                }'
-            ]
+        yield [
+            '{
+              "state":"DF",
+              "city":"Brasília"
+            }',
+            '{
+              "type":"object",
+              "properties":{
+                "state":{"type":"string","requires":"city"},
+                "city":{"type":"string"}
+              }
+            }'
         ];
     }
 }

--- a/tests/Constraints/RequireTest.php
+++ b/tests/Constraints/RequireTest.php
@@ -4,6 +4,7 @@ namespace JsonSchema\Tests\Constraints;
 
 class RequireTest extends BaseTestCase
 {
+    /** @var bool */
     protected $validateSchema = true;
 
     public function getInvalidTests(): \Generator

--- a/tests/Constraints/RequireTest.php
+++ b/tests/Constraints/RequireTest.php
@@ -1,12 +1,5 @@
 <?php
 
-/*
- * This file is part of the JsonSchema package.
- *
- * For the full copyright and license information, please view the LICENSE
- * file that was distributed with this source code.
- */
-
 namespace JsonSchema\Tests\Constraints;
 
 class RequireTest extends BaseTestCase

--- a/tests/Constraints/RequireTest.php
+++ b/tests/Constraints/RequireTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace JsonSchema\Tests\Constraints;
 
 class RequireTest extends BaseTestCase

--- a/tests/Constraints/RequiredPropertyTest.php
+++ b/tests/Constraints/RequiredPropertyTest.php
@@ -7,10 +7,15 @@ use JsonSchema\Constraints\UndefinedConstraint;
 
 class RequiredPropertyTest extends BaseTestCase
 {
-    // Most tests are draft-03 compliant, but some tests are draft-04, or mix draft-03 and
-    // draft-04 syntax within the same schema. Unfortunately, draft-03 and draft-04 required
-    // definitions are incompatible, so disabling schema validation for these tests.
+    /**
+     * Most tests are draft-03 compliant, but some tests are draft-04, or mix draft-03 and
+     * draft-04 syntax within the same schema. Unfortunately, draft-03 and draft-04 required
+     * definitions are incompatible, so disabling schema validation for these tests.
+     *
+     * @var string
+     * */
     protected $schemaSpec = 'http://json-schema.org/draft-03/schema#';
+    /** @var bool */
     protected $validateSchema = false;
 
     public function testErrorPropertyIsPopulatedForRequiredIfMissingInInput(): void

--- a/tests/Constraints/RequiredPropertyTest.php
+++ b/tests/Constraints/RequiredPropertyTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace JsonSchema\Tests\Constraints;
 
 use JsonSchema\Constraints\Constraint;

--- a/tests/Constraints/RequiredPropertyTest.php
+++ b/tests/Constraints/RequiredPropertyTest.php
@@ -113,329 +113,325 @@ class RequiredPropertyTest extends BaseTestCase
         $this->assertEquals($propertyValue, $error[0]['property']);
     }
 
-    public function getInvalidTests(): array
+    public function getInvalidTests(): \Generator
     {
-        return [
-            [
-                '{}',
-                '{
-                  "type":"object",
-                  "properties":{
-                    "number":{"type":"number","required":true}
-                  }
-                }'
-            ],
-            [
-                '{}',
-                '{
-                    "type": "object",
-                    "properties": {
-                        "number": {"type": "number"}
-                    },
-                    "required": ["number"]
-                }'
-            ],
-            [
-                '{
-                    "foo": {}
-                }',
-                '{
-                    "type": "object",
-                    "properties": {
-                        "foo": {
-                            "type": "object",
-                            "properties": {
-                                "bar": {"type": "number"}
-                            },
-                            "required": ["bar"]
-                        }
+        yield [
+            '{}',
+            '{
+              "type":"object",
+              "properties":{
+                "number":{"type":"number","required":true}
+              }
+            }'
+        ];
+        yield [
+            '{}',
+            '{
+                "type": "object",
+                "properties": {
+                    "number": {"type": "number"}
+                },
+                "required": ["number"]
+            }'
+        ];
+        yield [
+            '{
+                "foo": {}
+            }',
+            '{
+                "type": "object",
+                "properties": {
+                    "foo": {
+                        "type": "object",
+                        "properties": {
+                            "bar": {"type": "number"}
+                        },
+                        "required": ["bar"]
                     }
-                }'
-            ],
-            [
-                '{
-                    "bar": 1.4
-                 }',
-                '{
-                    "type": "object",
-                    "properties": {
-                        "foo": {"type": "string", "required": true},
-                        "bar": {"type": "number"}
-                    },
-                    "required": ["bar"]
-                }'
-            ],
-            [
-                '{}',
-                '{
-                    "required": ["foo"]
-                }'
-            ],
-            [
-                '{
-                }',
-                '{
-                    "type": "object",
-                    "properties": {
-                        "foo": { "required": true }
-                    }
-                }'
-            ],
-            [
-                '{
-                  "string":{}
-                }',
-                '{
-                  "type":"object",
-                  "properties": {
-                    "string":{"type":"string", "required": true}
-                  }
-                }'
-            ],
-            [
-                '{
-                  "number":{}
-                }',
-                '{
-                  "type":"object",
-                  "properties": {
-                    "number":{"type":"number", "required": true}
-                  }
-                }'
-            ],
-            [
-                '{
-                  "integer":{}
-                }',
-                '{
-                  "type":"object",
-                  "properties": {
-                    "integer":{"type":"integer", "required": true}
-                  }
-                }'
-            ],
-            [
-                '{
-                  "boolean":{}
-                }',
-                '{
-                  "type":"object",
-                  "properties": {
-                    "boolean":{"type":"boolean", "required": true}
-                  }
-                }'
-            ],
-            [
-                '{
-                  "array":{}
-                }',
-                '{
-                  "type":"object",
-                  "properties": {
-                    "array":{"type":"array", "required": true}
-                  }
-                }',
-                Constraint::CHECK_MODE_NORMAL
-            ],
-            [
-                '{
-                  "null":{}
-                }',
-                '{
-                  "type":"object",
-                  "properties": {
-                    "null":{"type":"null", "required": true}
-                  }
-                }'
-            ],
-            [
-                '{
-                  "foo": {"baz": 1.5}
-                }',
-                '{
+                }
+            }'
+        ];
+        yield [
+            '{
+                "bar": 1.4
+             }',
+            '{
+                "type": "object",
+                "properties": {
+                    "foo": {"type": "string", "required": true},
+                    "bar": {"type": "number"}
+                },
+                "required": ["bar"]
+            }'
+        ];
+        yield [
+            '{}',
+            '{
+                "required": ["foo"]
+            }'
+        ];
+        yield [
+            '{
+            }',
+            '{
+                "type": "object",
+                "properties": {
+                    "foo": { "required": true }
+                }
+            }'
+        ];
+        yield [
+            '{
+              "string":{}
+            }',
+            '{
+              "type":"object",
+              "properties": {
+                "string":{"type":"string", "required": true}
+              }
+            }'
+        ];
+        yield [
+            '{
+              "number":{}
+            }',
+            '{
+              "type":"object",
+              "properties": {
+                "number":{"type":"number", "required": true}
+              }
+            }'
+        ];
+        yield [
+            '{
+              "integer":{}
+            }',
+            '{
+              "type":"object",
+              "properties": {
+                "integer":{"type":"integer", "required": true}
+              }
+            }'
+        ];
+        yield [
+            '{
+                "boolean":{}
+            }',
+            '{
+              "type":"object",
+              "properties": {
+                "boolean":{"type":"boolean", "required": true}
+              }
+            }'
+        ];
+        yield [
+            '{
+              "array":{}
+            }',
+            '{
+              "type":"object",
+              "properties": {
+                "array":{"type":"array", "required": true}
+              }
+            }',
+            Constraint::CHECK_MODE_NORMAL
+        ];
+        yield [
+            '{
+              "null":{}
+            }',
+            '{
+              "type":"object",
+              "properties": {
+                "null":{"type":"null", "required": true}
+              }
+            }'
+        ];
+        yield [
+            '{
+              "foo": {"baz": 1.5}
+            }',
+            '{
+              "type": "object",
+              "properties": {
+                "foo": {
                   "type": "object",
                   "properties": {
-                    "foo": {
-                      "type": "object",
-                      "properties": {
-                        "bar": {"type": "number"}
-                      },
-                      "required": ["bar"]
-                    }
-                  }
-                }'
-            ],
-            [
-                '{
-                  "foo": {"baz": 1.5}
-                }',
-                '{
+                    "bar": {"type": "number"}
+                  },
+                  "required": ["bar"]
+                }
+              }
+            }'
+        ];
+        yield [
+            '{
+              "foo": {"baz": 1.5}
+            }',
+            '{
+              "type": "object",
+              "properties": {
+                "foo": {
                   "type": "object",
                   "properties": {
-                    "foo": {
-                      "type": "object",
-                      "properties": {
-                        "bar": {"type": "number", "required": true}
-                      }
-                    }
+                    "bar": {"type": "number", "required": true}
                   }
-                }'
-            ],
+                }
+              }
+            }'
         ];
     }
 
-    public function getValidTests(): array
+    public function getValidTests(): \Generator
     {
-        return [
-            [
-                '{
-                  "number": 1.4
-                }',
-                '{
-                  "type":"object",
-                  "properties":{
-                    "number":{"type":"number","required":true}
-                  }
-                }'
-            ],
-            [
-                '{}',
-                '{
-                  "type":"object",
-                  "properties":{
-                    "number":{"type":"number"}
-                  }
-                }'
-            ],
-            [
-                '{}',
-                '{
-                  "type":"object",
-                  "properties":{
-                    "number":{"type":"number","required":false}
-                  }
-                }'
-            ],
-            [
-                '{
-                  "number": 0
-                }',
-                '{
-                  "type":"object",
-                  "properties":{
-                    "number":{"type":"integer","required":true}
-                  }
-                }'
-            ],
-            [
-                '{
-                  "is_active": false
-                }',
-                '{
-                  "type":"object",
-                  "properties":{
-                    "is_active":{"type":"boolean","required":true}
-                  }
-                }'
-            ],
-            [
-                '{
-                  "status": null
-                }',
-                '{
-                  "type":"object",
-                  "properties":{
-                    "status":{"type":"null","required":true}
-                  }
-                }'
-            ],
-            [
-                '{
-                  "users": []
-                }',
-                '{
-                  "type":"object",
-                  "properties":{
-                    "users":{"type":"array","required":true}
-                  }
-                }'
-            ],
-            [
-                '{
-                    "foo": "foo",
-                    "bar": 1.4
-                 }',
-                '{
-                    "type": "object",
-                    "properties": {
-                        "foo": {"type": "string", "required": true},
-                        "bar": {"type": "number"}
-                    },
-                    "required": ["bar"]
-                }'
-            ],
-            [
-                '{
-                    "foo": {"bar": 1.5}
-                }',
-                '{
-                    "type": "object",
-                    "properties": {
-                        "foo": {
-                            "type": "object",
-                            "properties": {
-                                "bar": {"type": "number"}
-                            },
-                            "required": ["bar"]
-                        }
-                    },
-                    "required": ["foo"]
-                }'
-            ],
-            [
-                '{
-                    "foo": {}
-                }',
-                '{
-                    "type": "object",
-                    "properties": {
-                        "foo": { "required": true }
+        yield [
+            '{
+              "number": 1.4
+            }',
+            '{
+              "type":"object",
+              "properties":{
+                "number":{"type":"number","required":true}
+              }
+            }'
+        ];
+        yield [
+            '{}',
+            '{
+              "type":"object",
+              "properties":{
+                "number":{"type":"number"}
+              }
+            }'
+        ];
+        yield [
+            '{}',
+            '{
+              "type":"object",
+              "properties":{
+                "number":{"type":"number","required":false}
+              }
+            }'
+        ];
+        yield [
+            '{
+              "number": 0
+            }',
+            '{
+              "type":"object",
+              "properties":{
+                "number":{"type":"integer","required":true}
+              }
+            }'
+        ];
+        yield [
+            '{
+              "is_active": false
+            }',
+            '{
+              "type":"object",
+              "properties":{
+                "is_active":{"type":"boolean","required":true}
+              }
+            }'
+        ];
+        yield [
+            '{
+              "status": null
+            }',
+            '{
+              "type":"object",
+              "properties":{
+                "status":{"type":"null","required":true}
+              }
+            }'
+        ];
+        yield [
+            '{
+              "users": []
+            }',
+            '{
+              "type":"object",
+              "properties":{
+                "users":{"type":"array","required":true}
+              }
+            }'
+        ];
+        yield [
+            '{
+                "foo": "foo",
+                "bar": 1.4
+             }',
+            '{
+                "type": "object",
+                "properties": {
+                    "foo": {"type": "string", "required": true},
+                    "bar": {"type": "number"}
+                },
+                "required": ["bar"]
+            }'
+        ];
+        yield [
+            '{
+                "foo": {"bar": 1.5}
+            }',
+            '{
+                "type": "object",
+                "properties": {
+                    "foo": {
+                        "type": "object",
+                        "properties": {
+                            "bar": {"type": "number"}
+                        },
+                        "required": ["bar"]
                     }
-                }'
-            ],
-            [
-                '{
-                  "boo": {"bar": 1.5}
-                }',
-                '{
+                },
+                "required": ["foo"]
+            }'
+        ];
+        yield [
+            '{
+                "foo": {}
+            }',
+            '{
+                "type": "object",
+                "properties": {
+                    "foo": { "required": true }
+                }
+            }'
+        ];
+        yield [
+            '{
+              "boo": {"bar": 1.5}
+            }',
+            '{
+              "type": "object",
+              "properties": {
+                "foo": {
                   "type": "object",
                   "properties": {
-                    "foo": {
-                      "type": "object",
-                      "properties": {
-                        "bar": {"type": "number"}
-                      },
-                      "required": ["bar"]
-                    }
-                  }
-                }'
-            ],
-            [
-                '{
-                  "boo": {"bar": 1.5}
-                }',
-                '{
+                    "bar": {"type": "number"}
+                  },
+                  "required": ["bar"]
+                }
+              }
+            }'
+        ];
+        yield [
+            '{
+              "boo": {"bar": 1.5}
+            }',
+            '{
+              "type": "object",
+              "properties": {
+                "foo": {
                   "type": "object",
                   "properties": {
-                    "foo": {
-                      "type": "object",
-                      "properties": {
-                        "bar": {"type": "number", "required": true}
-                      }
-                    }
+                    "bar": {"type": "number", "required": true}
                   }
-                }'
-            ],
+                }
+              }
+            }'
         ];
     }
 }

--- a/tests/Constraints/RequiredPropertyTest.php
+++ b/tests/Constraints/RequiredPropertyTest.php
@@ -1,12 +1,5 @@
 <?php
 
-/*
- * This file is part of the JsonSchema package.
- *
- * For the full copyright and license information, please view the LICENSE
- * file that was distributed with this source code.
- */
-
 namespace JsonSchema\Tests\Constraints;
 
 use JsonSchema\Constraints\Constraint;

--- a/tests/Constraints/RequiredPropertyTest.php
+++ b/tests/Constraints/RequiredPropertyTest.php
@@ -21,20 +21,17 @@ class RequiredPropertyTest extends BaseTestCase
     public function testErrorPropertyIsPopulatedForRequiredIfMissingInInput(): void
     {
         $validator = new UndefinedConstraint();
-        $document = json_decode(
-            '{
-            "bar": 42
-        }'
-        );
+        $document = json_decode('{ "bar": 42 }', false);
         $schema = json_decode(
             '{
-            "type": "object",
-            "properties": {
-                "foo": {"type": "number"},
-                "bar": {"type": "number"}
-            },
-            "required": ["foo"]
-        }'
+                "type": "object",
+                "properties": {
+                    "foo": {"type": "number"},
+                    "bar": {"type": "number"}
+                },
+                "required": ["foo"]
+            }',
+            false
         );
 
         $validator->check($document, $schema);
@@ -45,11 +42,7 @@ class RequiredPropertyTest extends BaseTestCase
     public function testPathErrorPropertyIsPopulatedForRequiredIfMissingInInput(): void
     {
         $validator = new UndefinedConstraint();
-        $document = json_decode(
-            '{
-                "foo": [{"baz": 1.5}]
-            }'
-        );
+        $document = json_decode('{ "foo": [{"baz": 1.5}] }', false);
         $schema = json_decode(
             '{
                 "type": "object",
@@ -67,7 +60,8 @@ class RequiredPropertyTest extends BaseTestCase
                     }
                 },
                 "required": ["foo"]
-            }'
+            }',
+            false
         );
 
         $validator->check($document, $schema);
@@ -78,21 +72,17 @@ class RequiredPropertyTest extends BaseTestCase
     public function testErrorPropertyIsPopulatedForRequiredIfEmptyValueInInput(): void
     {
         $validator = new UndefinedConstraint();
-        $document = json_decode(
-            '{
-            "bar": 42,
-            "foo": null
-        }'
-        );
+        $document = json_decode('{ "bar": 42, "foo": null }', false);
         $schema = json_decode(
             '{
-            "type": "object",
-            "properties": {
-                "foo": {"type": "number"},
-                "bar": {"type": "number"}
-            },
-            "required": ["foo"]
-        }'
+                "type": "object",
+                "properties": {
+                    "foo": {"type": "number"},
+                    "bar": {"type": "number"}
+                },
+                "required": ["foo"]
+            }',
+            false
         );
 
         $validator->check($document, $schema);

--- a/tests/Constraints/RequiredPropertyTest.php
+++ b/tests/Constraints/RequiredPropertyTest.php
@@ -15,8 +15,6 @@ class RequiredPropertyTest extends BaseTestCase
      * @var string
      * */
     protected $schemaSpec = 'http://json-schema.org/draft-03/schema#';
-    /** @var bool */
-    protected $validateSchema = false;
 
     public function testErrorPropertyIsPopulatedForRequiredIfMissingInInput(): void
     {

--- a/tests/Constraints/SchemaValidationTest.php
+++ b/tests/Constraints/SchemaValidationTest.php
@@ -97,7 +97,7 @@ class SchemaValidationTest extends TestCase
 
     public function testNonObjectSchema(): void
     {
-        $this->expectException('\JsonSchema\Exception\RuntimeException');
+        $this->expectException(\JsonSchema\Exception\RuntimeException::class);
         $this->expectExceptionMessage('Cannot validate the schema of a non-object');
 
         $this->testValidCases('"notAnObject"');
@@ -105,7 +105,7 @@ class SchemaValidationTest extends TestCase
 
     public function testInvalidSchemaException(): void
     {
-        $this->expectException('\JsonSchema\Exception\InvalidSchemaException');
+        $this->expectException(\JsonSchema\Exception\InvalidSchemaException::class);
         $this->expectExceptionMessage('Schema did not pass validation');
 
         $input = json_decode('{}');

--- a/tests/Constraints/SchemaValidationTest.php
+++ b/tests/Constraints/SchemaValidationTest.php
@@ -1,12 +1,13 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * This file is part of the JsonSchema package.
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  */
-
 namespace JsonSchema\Tests\Constraints;
 
 use JsonSchema\Constraints\Constraint;

--- a/tests/Constraints/SchemaValidationTest.php
+++ b/tests/Constraints/SchemaValidationTest.php
@@ -2,12 +2,6 @@
 
 declare(strict_types=1);
 
-/*
- * This file is part of the JsonSchema package.
- *
- * For the full copyright and license information, please view the LICENSE
- * file that was distributed with this source code.
- */
 namespace JsonSchema\Tests\Constraints;
 
 use JsonSchema\Constraints\Constraint;

--- a/tests/Constraints/SelfDefinedSchemaTest.php
+++ b/tests/Constraints/SelfDefinedSchemaTest.php
@@ -15,55 +15,51 @@ class SelfDefinedSchemaTest extends BaseTestCase
 {
     protected $validateSchema = true;
 
-    public function getInvalidTests(): array
+    public function getInvalidTests(): \Generator
     {
-        return [
-            [
-                '{
-                    "$schema": {
-                        "$schema": "http://json-schema.org/draft-04/schema#",
-                        "properties": {
-                            "name": {
-                                "type": "string"
-                            },
-                            "age" : {
-                                "type": "integer",
-                                "maximum": 25
-                            }
+        yield [
+            '{
+                "$schema": {
+                    "$schema": "http://json-schema.org/draft-04/schema#",
+                    "properties": {
+                        "name": {
+                            "type": "string"
+                        },
+                        "age" : {
+                            "type": "integer",
+                            "maximum": 25
                         }
-                    },
-                    "name" : "John Doe",
-                    "age" : 30,
-                    "type" : "object"
-                }',
-                ''
-            ]
+                    }
+                },
+                "name" : "John Doe",
+                "age" : 30,
+                "type" : "object"
+            }',
+            ''
         ];
     }
 
-    public function getValidTests(): array
+    public function getValidTests(): \Generator
     {
-        return [
-            [
-                '{
-                    "$schema": {
-                        "$schema": "http://json-schema.org/draft-04/schema#",
-                        "properties": {
-                            "name": {
-                                "type": "string"
-                            },
-                            "age" : {
-                                "type": "integer",
-                                "maximum": 125
-                            }
+        yield [
+            '{
+                "$schema": {
+                    "$schema": "http://json-schema.org/draft-04/schema#",
+                    "properties": {
+                        "name": {
+                            "type": "string"
+                        },
+                        "age" : {
+                            "type": "integer",
+                            "maximum": 125
                         }
-                    },
-                    "name" : "John Doe",
-                    "age" : 30,
-                    "type" : "object"
-                }',
-                ''
-            ]
+                    }
+                },
+                "name" : "John Doe",
+                "age" : 30,
+                "type" : "object"
+            }',
+            ''
         ];
     }
 

--- a/tests/Constraints/SelfDefinedSchemaTest.php
+++ b/tests/Constraints/SelfDefinedSchemaTest.php
@@ -6,6 +6,7 @@ use JsonSchema\Validator;
 
 class SelfDefinedSchemaTest extends BaseTestCase
 {
+    /** @var bool */
     protected $validateSchema = true;
 
     public function getInvalidTests(): \Generator

--- a/tests/Constraints/SelfDefinedSchemaTest.php
+++ b/tests/Constraints/SelfDefinedSchemaTest.php
@@ -1,12 +1,5 @@
 <?php
 
-/*
- * This file is part of the JsonSchema package.
- *
- * For the full copyright and license information, please view the LICENSE
- * file that was distributed with this source code.
- */
-
 namespace JsonSchema\Tests\Constraints;
 
 use JsonSchema\Validator;

--- a/tests/Constraints/SelfDefinedSchemaTest.php
+++ b/tests/Constraints/SelfDefinedSchemaTest.php
@@ -2,8 +2,8 @@
 
 namespace JsonSchema\Tests\Constraints;
 
-use JsonSchema\Validator;
 use JsonSchema\Exception\InvalidArgumentException;
+use JsonSchema\Validator;
 use stdClass;
 
 class SelfDefinedSchemaTest extends BaseTestCase

--- a/tests/Constraints/SelfDefinedSchemaTest.php
+++ b/tests/Constraints/SelfDefinedSchemaTest.php
@@ -3,6 +3,8 @@
 namespace JsonSchema\Tests\Constraints;
 
 use JsonSchema\Validator;
+use JsonSchema\Exception\InvalidArgumentException;
+use stdClass;
 
 class SelfDefinedSchemaTest extends BaseTestCase
 {
@@ -59,12 +61,12 @@ class SelfDefinedSchemaTest extends BaseTestCase
 
     public function testInvalidArgumentException(): void
     {
-        $value = json_decode('{}');
-        $schema = json_decode('');
+        $value = new stdClass();
+        $schema = null;
 
         $v = new Validator();
 
-        $this->expectException('\JsonSchema\Exception\InvalidArgumentException');
+        $this->expectException(InvalidArgumentException::class);
 
         $v->validate($value, $schema);
     }

--- a/tests/Constraints/SelfDefinedSchemaTest.php
+++ b/tests/Constraints/SelfDefinedSchemaTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace JsonSchema\Tests\Constraints;
 
 use JsonSchema\Exception\InvalidArgumentException;

--- a/tests/Constraints/TupleTypingTest.php
+++ b/tests/Constraints/TupleTypingTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace JsonSchema\Tests\Constraints;
 
 class TupleTypingTest extends BaseTestCase

--- a/tests/Constraints/TupleTypingTest.php
+++ b/tests/Constraints/TupleTypingTest.php
@@ -1,12 +1,5 @@
 <?php
 
-/*
- * This file is part of the JsonSchema package.
- *
- * For the full copyright and license information, please view the LICENSE
- * file that was distributed with this source code.
- */
-
 namespace JsonSchema\Tests\Constraints;
 
 class TupleTypingTest extends BaseTestCase

--- a/tests/Constraints/TupleTypingTest.php
+++ b/tests/Constraints/TupleTypingTest.php
@@ -13,128 +13,124 @@ class TupleTypingTest extends BaseTestCase
 {
     protected $validateSchema = true;
 
-    public function getInvalidTests(): array
+    public function getInvalidTests(): \Generator
     {
-        return [
-            [
-                '{
-                  "tupleTyping":[2,"a"]
-                }',
-                '{
-                  "type":"object",
-                  "properties":{
-                    "tupleTyping":{
-                      "type":"array",
-                      "items":[
-                        {"type":"string"},
-                        {"type":"number"}
-                      ]
+        yield [
+            '{
+              "tupleTyping":[2,"a"]
+            }',
+            '{
+              "type":"object",
+              "properties":{
+                "tupleTyping":{
+                  "type":"array",
+                  "items":[
+                    {"type":"string"},
+                    {"type":"number"}
+                  ]
+                }
+              }
+            }'
+        ];
+        yield [
+            '{
+              "tupleTyping":["2",2,true]
+            }',
+            '{
+              "type":"object",
+              "properties":{
+                "tupleTyping":{
+                  "type":"array",
+                  "items":[
+                    {"type":"string"},
+                    {"type":"number"}
+                  ] ,
+                  "additionalItems":false
+                }
+              }
+            }'
+        ];
+        yield [
+            '{
+              "tupleTyping":["2",2,3]
+            }',
+            '{
+              "type":"object",
+              "properties":{
+                "tupleTyping":{
+                  "type":"array",
+                  "items":[
+                    {"type":"string"},
+                    {"type":"number"}
+                  ] ,
+                  "additionalItems":{"type":"string"}
+                }
+              }
+            }'
+        ];
+        yield [
+            '{"data": [1, "foo", true, 1.5]}',
+            '{
+                "type": "object",
+                "properties": {
+                    "data": {
+                        "type": "array",
+                        "items": [{}, {}, {}],
+                        "additionalItems": false
                     }
-                  }
-                }'
-            ],
-            [
-                '{
-                  "tupleTyping":["2",2,true]
-                }',
-                '{
-                  "type":"object",
-                  "properties":{
-                    "tupleTyping":{
-                      "type":"array",
-                      "items":[
-                        {"type":"string"},
-                        {"type":"number"}
-                      ] ,
-                      "additionalItems":false
-                    }
-                  }
-                }'
-            ],
-            [
-                '{
-                  "tupleTyping":["2",2,3]
-                }',
-                '{
-                  "type":"object",
-                  "properties":{
-                    "tupleTyping":{
-                      "type":"array",
-                      "items":[
-                        {"type":"string"},
-                        {"type":"number"}
-                      ] ,
-                      "additionalItems":{"type":"string"}
-                    }
-                  }
-                }'
-            ],
-            [
-                '{"data": [1, "foo", true, 1.5]}',
-                '{
-                    "type": "object",
-                    "properties": {
-                        "data": {
-                            "type": "array",
-                            "items": [{}, {}, {}],
-                            "additionalItems": false
-                        }
-                    }
-                }'
-            ]
+                }
+            }'
         ];
     }
 
-    public function getValidTests(): array
+    public function getValidTests(): \Generator
     {
-        return [
-            [
-                '{
-                  "tupleTyping":["2", 1]
-                }',
-                '{
-                  "type":"object",
-                  "properties":{
-                    "tupleTyping":{
-                      "type":"array",
-                      "items":[
-                        {"type":"string"},
-                        {"type":"number"}
-                      ]
+        yield [
+            '{
+              "tupleTyping":["2", 1]
+            }',
+            '{
+              "type":"object",
+              "properties":{
+                "tupleTyping":{
+                  "type":"array",
+                  "items":[
+                    {"type":"string"},
+                    {"type":"number"}
+                  ]
+                }
+              }
+            }'
+        ];
+        yield [
+            '{
+              "tupleTyping":["2",2,3]
+            }',
+            '{
+              "type":"object",
+              "properties":{
+                "tupleTyping":{
+                  "type":"array",
+                  "items":[
+                    {"type":"string"},
+                    {"type":"number"}
+                  ]
+                }
+              }
+            }'
+        ];
+        yield [
+            '{"data": [1, "foo", true]}',
+            '{
+                "type": "object",
+                "properties": {
+                    "data": {
+                        "type": "array",
+                        "items": [{}, {}, {}],
+                        "additionalItems": false
                     }
-                  }
-                }'
-            ],
-            [
-                '{
-                  "tupleTyping":["2",2,3]
-                }',
-                '{
-                  "type":"object",
-                  "properties":{
-                    "tupleTyping":{
-                      "type":"array",
-                      "items":[
-                        {"type":"string"},
-                        {"type":"number"}
-                      ]
-                    }
-                  }
-                }'
-            ],
-            [
-                '{"data": [1, "foo", true]}',
-                '{
-                    "type": "object",
-                    "properties": {
-                        "data": {
-                            "type": "array",
-                            "items": [{}, {}, {}],
-                            "additionalItems": false
-                        }
-                    }
-                }'
-            ]
+                }
+            }'
         ];
     }
 }

--- a/tests/Constraints/TupleTypingTest.php
+++ b/tests/Constraints/TupleTypingTest.php
@@ -4,6 +4,7 @@ namespace JsonSchema\Tests\Constraints;
 
 class TupleTypingTest extends BaseTestCase
 {
+    /** @var bool */
     protected $validateSchema = true;
 
     public function getInvalidTests(): \Generator

--- a/tests/Constraints/TypeTest.php
+++ b/tests/Constraints/TypeTest.php
@@ -1,12 +1,13 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * This file is part of the JsonSchema package.
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  */
-
 namespace JsonSchema\Tests\Constraints;
 
 use JsonSchema\Constraints\TypeCheck\LooseTypeCheck;

--- a/tests/Constraints/TypeTest.php
+++ b/tests/Constraints/TypeTest.php
@@ -121,7 +121,7 @@ class TypeTest extends TestCase
         $data = new \stdClass();
         $schema = json_decode('{"type": "notAValidTypeName"}');
 
-        $this->expectException('JsonSchema\Exception\InvalidArgumentException');
+        $this->expectException(\JsonSchema\Exception\InvalidArgumentException::class);
         $this->expectExceptionMessage('object is an invalid type for notAValidTypeName');
 
         $t->check($data, $schema);

--- a/tests/Constraints/TypeTest.php
+++ b/tests/Constraints/TypeTest.php
@@ -8,13 +8,6 @@ use JsonSchema\Constraints\TypeCheck\LooseTypeCheck;
 use JsonSchema\Constraints\TypeConstraint;
 use PHPUnit\Framework\TestCase;
 
-/**
- * Class TypeTest
- *
- * @package JsonSchema\Tests\Constraints
- *
- * @author hakre <https://github.com/hakre>
- */
 class TypeTest extends TestCase
 {
     /**

--- a/tests/Constraints/TypeTest.php
+++ b/tests/Constraints/TypeTest.php
@@ -2,12 +2,6 @@
 
 declare(strict_types=1);
 
-/*
- * This file is part of the JsonSchema package.
- *
- * For the full copyright and license information, please view the LICENSE
- * file that was distributed with this source code.
- */
 namespace JsonSchema\Tests\Constraints;
 
 use JsonSchema\Constraints\TypeCheck\LooseTypeCheck;

--- a/tests/Constraints/UndefinedConstraintTest.php
+++ b/tests/Constraints/UndefinedConstraintTest.php
@@ -8,21 +8,12 @@ use JsonSchema\Constraints\Constraint;
 
 class UndefinedConstraintTest extends BaseTestCase
 {
-    /**
-     * @return array{}
-     */
-    public function getInvalidTests(): array
-    {
-        return [];
-    }
+    public function getInvalidTests(): \Generator
+    {}
 
-    /**
-     * @return array<string, array{input: string, schema: string, checkMode?: int}>
-     */
-    public function getValidTests(): array
+    public function getValidTests(): \Generator
     {
-        return [
-            'oneOf with type coercion should not affect value passed to each sub schema (#790)' => [
+            yield 'oneOf with type coercion should not affect value passed to each sub schema (#790)' => [
                 'input' => <<<JSON
                     {
                         "id": "LOC1",
@@ -33,8 +24,7 @@ class UndefinedConstraintTest extends BaseTestCase
                             }
                         ]
                     }
-JSON
-                ,
+JSON,
                 'schema' => <<<JSON
                     {
                         "title": "Location",
@@ -66,80 +56,76 @@ JSON
                             }
                         }
                     }
-JSON
-                ,
-                'checkMode' => Constraint::CHECK_MODE_COERCE_TYPES
-            ],
-            'oneOf with apply defaults should not affect value passed to each sub schema (#510)' => [
-                'input' => <<<JSON
-                    {"foo": {"name": "bar"}}
-JSON
-                ,
-                'schema' => <<<JSON
-                    {
-                        "oneOf": [
-                            {
-                                "type": "object",
-                                "properties": {
-                                    "foo": {
-                                        "type": "object",
-                                        "properties": {
-                                            "name": {"enum":["baz"],"default":"baz"},
-                                            "meta": {"enum":["baz"],"default":"baz"}
-                                        }
-                                    }
-                                }
-                            },
-                            {
-                                "type": "object",
-                                "properties": {
-                                    "foo": {
-                                        "type": "object",
-                                        "properties": {
-                                            "name": {"enum":["bar"],"default":"bar"},
-                                            "meta": {"enum":["bar"],"default":"bar"}
-                                        }
-                                    }
-                                }
-                            },
-                            {
-                                "type": "object",
-                                "properties": {
-                                    "foo": {
-                                        "type": "object",
-                                        "properties": {
-                                            "name": {"enum":["zip"],"default":"zip"},
-                                            "meta": {"enum":["zip"],"default":"zip"}
-                                        }
+JSON,
+            'checkMode' => Constraint::CHECK_MODE_COERCE_TYPES
+        ];
+        yield 'oneOf with apply defaults should not affect value passed to each sub schema (#510)' => [
+            'input' => <<<JSON
+                {"foo": {"name": "bar"}}
+JSON,
+            'schema' => <<<JSON
+                {
+                    "oneOf": [
+                        {
+                            "type": "object",
+                            "properties": {
+                                "foo": {
+                                    "type": "object",
+                                    "properties": {
+                                        "name": {"enum":["baz"],"default":"baz"},
+                                        "meta": {"enum":["baz"],"default":"baz"}
                                     }
                                 }
                             }
-                        ]
-                    }
-JSON
-                ,
-                'checkMode' => Constraint::CHECK_MODE_APPLY_DEFAULTS
-            ],
-            'anyOf with apply defaults should not affect value passed to each sub schema (#711)' => [
-                'input' => <<<JSON
+                        },
+                        {
+                            "type": "object",
+                            "properties": {
+                                "foo": {
+                                    "type": "object",
+                                    "properties": {
+                                        "name": {"enum":["bar"],"default":"bar"},
+                                        "meta": {"enum":["bar"],"default":"bar"}
+                                    }
+                                }
+                            }
+                        },
+                        {
+                            "type": "object",
+                            "properties": {
+                                "foo": {
+                                    "type": "object",
+                                    "properties": {
+                                        "name": {"enum":["zip"],"default":"zip"},
+                                        "meta": {"enum":["zip"],"default":"zip"}
+                                    }
+                                }
+                            }
+                        }
+                    ]
+                }
+JSON,
+            'checkMode' => Constraint::CHECK_MODE_APPLY_DEFAULTS
+        ];
+        yield 'anyOf with apply defaults should not affect value passed to each sub schema (#711)' => [
+            'input' => <<<JSON
+                {
+                    "b": 2
+                }
+JSON,
+            'schema' => <<<JSON
+                {
+                  "anyOf": [
                     {
-                        "b": 2
-                    }
-JSON
-                ,
-                'schema' => <<<JSON
-                    {
-                        "anyOf": [
-                            {
-                                "required": [ "a" ],
-                      "properties": {
-                          "a": {
-                              "type": "integer"
-                          },
-                          "aDefault": {
-                              "type": "integer",
-                              "default": 1
-                          }
+                      "required": [ "a" ],
+                      "pro": {
+                        "a": {
+                          "type": "integer"
+                        },
+                        "aDefault": {
+                          "type": "integer",
+                          "default": 1
+                        }
                       },
                       "type": "object",
                       "additionalProperties": false
@@ -147,23 +133,21 @@ JSON
                     {
                       "required": [ "b" ],
                       "properties": {
-                          "b": {
-                              "type": "integer"
-                          },
-                          "bDefault": {
-                              "type": "integer",
-                              "default": 2
-                          }
+                        "b": {
+                          "type": "integer"
+                        },
+                        "bDefault": {
+                          "type": "integer",
+                          "default": 2
+                        }
                       },
                       "type": "object",
                       "additionalProperties": false
                     }
                   ]
                 }
-JSON
-                ,
-                'checkMode' => Constraint::CHECK_MODE_APPLY_DEFAULTS
-            ]
+JSON,
+            'checkMode' => Constraint::CHECK_MODE_APPLY_DEFAULTS
         ];
     }
 }

--- a/tests/Constraints/UndefinedConstraintTest.php
+++ b/tests/Constraints/UndefinedConstraintTest.php
@@ -10,144 +10,131 @@ class UndefinedConstraintTest extends BaseTestCase
 {
     public function getInvalidTests(): \Generator
     {
+        yield from [];
     }
 
     public function getValidTests(): \Generator
     {
         yield 'oneOf with type coercion should not affect value passed to each sub schema (#790)' => [
-                'input' => <<<JSON
+            'input' => '{
+                "id": "LOC1",
+                "related_locations": [
                     {
-                        "id": "LOC1",
-                        "related_locations": [
+                        "latitude": "51.047598",
+                        "longitude": "3.729943"
+                    }
+                ]
+            }',
+            'schema' => '{
+                "title": "Location",
+                "type": "object",
+                "properties": {
+                    "id": {
+                        "type": "string"
+                    },
+                    "related_locations": {
+                        "oneOf": [
                             {
-                                "latitude": "51.047598",
-                                "longitude": "3.729943"
+                                "type": "null"
+                            },
+                            {
+                                "type": "array",
+                                "items": {
+                                    "type": "object",
+                                    "properties": {
+                                        "latitude": {
+                                            "type": "string"
+                                        },
+                                        "longitude": {
+                                            "type": "string"
+                                        }
+                                    }
+                                }
                             }
                         ]
                     }
-JSON,
-                'schema' => <<<JSON
-                    {
-                        "title": "Location",
-                        "type": "object",
-                        "properties": {
-                            "id": {
-                                "type": "string"
-                            },
-                            "related_locations": {
-                                "oneOf": [
-                                    {
-                                        "type": "null"
-                                    },
-                                    {
-                                        "type": "array",
-                                        "items": {
-                                            "type": "object",
-                                            "properties": {
-                                                "latitude": {
-                                                    "type": "string"
-                                                },
-                                                "longitude": {
-                                                    "type": "string"
-                                                }
-                                            }
-                                        }
-                                    }
-                                ]
-                            }
-                        }
-                    }
-JSON,
+                }
+            }',
             'checkMode' => Constraint::CHECK_MODE_COERCE_TYPES
         ];
         yield 'oneOf with apply defaults should not affect value passed to each sub schema (#510)' => [
-            'input' => <<<JSON
-                {"foo": {"name": "bar"}}
-JSON,
-            'schema' => <<<JSON
-                {
-                    "oneOf": [
-                        {
-                            "type": "object",
-                            "properties": {
-                                "foo": {
-                                    "type": "object",
-                                    "properties": {
-                                        "name": {"enum":["baz"],"default":"baz"},
-                                        "meta": {"enum":["baz"],"default":"baz"}
-                                    }
-                                }
-                            }
-                        },
-                        {
-                            "type": "object",
-                            "properties": {
-                                "foo": {
-                                    "type": "object",
-                                    "properties": {
-                                        "name": {"enum":["bar"],"default":"bar"},
-                                        "meta": {"enum":["bar"],"default":"bar"}
-                                    }
-                                }
-                            }
-                        },
-                        {
-                            "type": "object",
-                            "properties": {
-                                "foo": {
-                                    "type": "object",
-                                    "properties": {
-                                        "name": {"enum":["zip"],"default":"zip"},
-                                        "meta": {"enum":["zip"],"default":"zip"}
-                                    }
+            'input' => '{"foo": {"name": "bar"}}',
+            'schema' => '{
+                "oneOf": [
+                    {
+                        "type": "object",
+                        "properties": {
+                            "foo": {
+                                "type": "object",
+                                "properties": {
+                                    "name": {"enum":["baz"],"default":"baz"},
+                                    "meta": {"enum":["baz"],"default":"baz"}
                                 }
                             }
                         }
-                    ]
-                }
-JSON,
+                    },
+                    {
+                        "type": "object",
+                        "properties": {
+                            "foo": {
+                                "type": "object",
+                                "properties": {
+                                    "name": {"enum":["bar"],"default":"bar"},
+                                    "meta": {"enum":["bar"],"default":"bar"}
+                                }
+                            }
+                        }
+                    },
+                    {
+                        "type": "object",
+                        "properties": {
+                            "foo": {
+                                "type": "object",
+                                "properties": {
+                                    "name": {"enum":["zip"],"default":"zip"},
+                                    "meta": {"enum":["zip"],"default":"zip"}
+                                }
+                            }
+                        }
+                    }
+                ]
+            }',
             'checkMode' => Constraint::CHECK_MODE_APPLY_DEFAULTS
         ];
         yield 'anyOf with apply defaults should not affect value passed to each sub schema (#711)' => [
-            'input' => <<<JSON
+            'input' => '{ "b": 2 }',
+            'schema' => '{
+              "anyOf": [
                 {
-                    "b": 2
-                }
-JSON,
-            'schema' => <<<JSON
-                {
-                  "anyOf": [
-                    {
-                      "required": [ "a" ],
-                      "pro": {
-                        "a": {
-                          "type": "integer"
-                        },
-                        "aDefault": {
-                          "type": "integer",
-                          "default": 1
-                        }
-                      },
-                      "type": "object",
-                      "additionalProperties": false
+                  "required": [ "a" ],
+                  "pro": {
+                    "a": {
+                      "type": "integer"
                     },
-                    {
-                      "required": [ "b" ],
-                      "properties": {
-                        "b": {
-                          "type": "integer"
-                        },
-                        "bDefault": {
-                          "type": "integer",
-                          "default": 2
-                        }
-                      },
-                      "type": "object",
-                      "additionalProperties": false
+                    "aDefault": {
+                      "type": "integer",
+                      "default": 1
                     }
-                  ]
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                {
+                  "required": [ "b" ],
+                  "properties": {
+                    "b": {
+                      "type": "integer"
+                    },
+                    "bDefault": {
+                      "type": "integer",
+                      "default": 2
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
                 }
-JSON,
+              ]
+            }',
             'checkMode' => Constraint::CHECK_MODE_APPLY_DEFAULTS
         ];
     }

--- a/tests/Constraints/UndefinedConstraintTest.php
+++ b/tests/Constraints/UndefinedConstraintTest.php
@@ -9,11 +9,12 @@ use JsonSchema\Constraints\Constraint;
 class UndefinedConstraintTest extends BaseTestCase
 {
     public function getInvalidTests(): \Generator
-    {}
+    {
+    }
 
     public function getValidTests(): \Generator
     {
-            yield 'oneOf with type coercion should not affect value passed to each sub schema (#790)' => [
+        yield 'oneOf with type coercion should not affect value passed to each sub schema (#790)' => [
                 'input' => <<<JSON
                     {
                         "id": "LOC1",

--- a/tests/Constraints/UnionTypesTest.php
+++ b/tests/Constraints/UnionTypesTest.php
@@ -4,6 +4,7 @@ namespace JsonSchema\Tests\Constraints;
 
 class UnionTypesTest extends BaseTestCase
 {
+    /** @var bool */
     protected $validateSchema = true;
 
     public function getInvalidTests(): \Generator

--- a/tests/Constraints/UnionTypesTest.php
+++ b/tests/Constraints/UnionTypesTest.php
@@ -13,41 +13,37 @@ class UnionTypesTest extends BaseTestCase
 {
     protected $validateSchema = true;
 
-    public function getInvalidTests(): array
+    public function getInvalidTests(): \Generator
     {
-        return [
-            [
-                '{
-                  "stringOrNumber":4.8,
-                  "booleanOrNull":5
-                }',
-                '{
-                  "type":"object",
-                  "properties":{
-                    "stringOrNumber":{"type":["string","number"]},
-                    "booleanOrNull":{"type":["boolean","null"]}
-                  }
-                }'
-            ]
+        yield [
+            '{
+              "stringOrNumber":4.8,
+              "booleanOrNull":5
+            }',
+            '{
+              "type":"object",
+              "properties":{
+                "stringOrNumber":{"type":["string","number"]},
+                "booleanOrNull":{"type":["boolean","null"]}
+              }
+            }'
         ];
     }
 
-    public function getValidTests(): array
+    public function getValidTests(): \Generator
     {
-        return [
-            [
-                '{
-                  "stringOrNumber":4.8,
-                  "booleanOrNull":false
-                }',
-                '{
-                  "type":"object",
-                  "properties":{
-                    "stringOrNumber":{"type":["string","number"]},
-                    "booleanOrNull":{"type":["boolean","null"]}
-                  }
-                }'
-            ]
+        yield [
+            '{
+              "stringOrNumber":4.8,
+              "booleanOrNull":false
+            }',
+            '{
+              "type":"object",
+              "properties":{
+                "stringOrNumber":{"type":["string","number"]},
+                "booleanOrNull":{"type":["boolean","null"]}
+              }
+            }'
         ];
     }
 }

--- a/tests/Constraints/UnionTypesTest.php
+++ b/tests/Constraints/UnionTypesTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace JsonSchema\Tests\Constraints;
 
 class UnionTypesTest extends BaseTestCase

--- a/tests/Constraints/UnionTypesTest.php
+++ b/tests/Constraints/UnionTypesTest.php
@@ -1,12 +1,5 @@
 <?php
 
-/*
- * This file is part of the JsonSchema package.
- *
- * For the full copyright and license information, please view the LICENSE
- * file that was distributed with this source code.
- */
-
 namespace JsonSchema\Tests\Constraints;
 
 class UnionTypesTest extends BaseTestCase

--- a/tests/Constraints/UnionWithNullValueTest.php
+++ b/tests/Constraints/UnionWithNullValueTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace JsonSchema\Tests\Constraints;
 
 class UnionWithNullValueTest extends BaseTestCase

--- a/tests/Constraints/UnionWithNullValueTest.php
+++ b/tests/Constraints/UnionWithNullValueTest.php
@@ -13,41 +13,37 @@ class UnionWithNullValueTest extends BaseTestCase
 {
     protected $validateSchema = true;
 
-    public function getInvalidTests(): array
+    public function getInvalidTests(): \Generator
     {
-        return [
-            [
-                '{
-                  "stringOrNumber":null,
-                  "booleanOrNull":null
-                }',
-                '{
-                  "type":"object",
-                  "properties":{
-                    "stringOrNumber":{"type":["string","number"]},
-                    "booleanOrNull":{"type":["boolean","null"]}
-                  }
-                }'
-            ]
+        yield [
+            '{
+              "stringOrNumber":null,
+              "booleanOrNull":null
+            }',
+            '{
+              "type":"object",
+              "properties":{
+                "stringOrNumber":{"type":["string","number"]},
+                "booleanOrNull":{"type":["boolean","null"]}
+              }
+            }'
         ];
     }
 
-    public function getValidTests(): array
+    public function getValidTests(): \Generator
     {
-        return [
-            [
-                '{
-                  "stringOrNumber":12,
-                  "booleanOrNull":null
-                }',
-                '{
-                  "type":"object",
-                  "properties":{
-                    "stringOrNumber":{"type":["string","number"]},
-                    "booleanOrNull":{"type":["boolean","null"]}
-                  }
-                }'
-            ]
+        yield [
+            '{
+              "stringOrNumber":12,
+              "booleanOrNull":null
+            }',
+            '{
+              "type":"object",
+              "properties":{
+                "stringOrNumber":{"type":["string","number"]},
+                "booleanOrNull":{"type":["boolean","null"]}
+              }
+            }'
         ];
     }
 }

--- a/tests/Constraints/UnionWithNullValueTest.php
+++ b/tests/Constraints/UnionWithNullValueTest.php
@@ -4,6 +4,7 @@ namespace JsonSchema\Tests\Constraints;
 
 class UnionWithNullValueTest extends BaseTestCase
 {
+    /** @var bool */
     protected $validateSchema = true;
 
     public function getInvalidTests(): \Generator

--- a/tests/Constraints/UnionWithNullValueTest.php
+++ b/tests/Constraints/UnionWithNullValueTest.php
@@ -1,12 +1,5 @@
 <?php
 
-/*
- * This file is part of the JsonSchema package.
- *
- * For the full copyright and license information, please view the LICENSE
- * file that was distributed with this source code.
- */
-
 namespace JsonSchema\Tests\Constraints;
 
 class UnionWithNullValueTest extends BaseTestCase

--- a/tests/Constraints/UniqueItemsTest.php
+++ b/tests/Constraints/UniqueItemsTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace JsonSchema\Tests\Constraints;
 
 class UniqueItemsTest extends BaseTestCase

--- a/tests/Constraints/UniqueItemsTest.php
+++ b/tests/Constraints/UniqueItemsTest.php
@@ -13,153 +13,149 @@ class UniqueItemsTest extends BaseTestCase
 {
     protected $validateSchema = true;
 
-    public function getInvalidTests(): array
-    {
-        return [
-            'Non unique integers' => [
-                'input' => '[1,2,2]',
-                'schema' => '{
-                  "type":"array",
-                  "uniqueItems": true
-                }'
-            ],
-            'Non unique objects' => [
-                'input' => '[{"a":"b"},{"a":"c"},{"a":"b"}]',
-                'schema' => '{
-                  "type":"array",
-                  "uniqueItems": true
-                }'
-            ],
-            'Non unique objects - three levels deep' => [
-                'input' => '[{"foo": {"bar" : {"baz" : true}}}, {"foo": {"bar" : {"baz" : true}}}]',
-                'schema' => '{
-                    "type": "array",
-                    "uniqueItems": true
-                }'
-            ],
-            'Non unique mathematical values for the number one' => [
-                'input' => '[1.0, 1.00, 1]',
-                'schema' => '{
-                    "type": "array",
-                    "uniqueItems": true
-                }'
-            ],
-            'Non unique arrays' => [
-                'input' => '[["foo"], ["foo"]]',
-                'schema' => '{
-                    "type": "array",
-                    "uniqueItems": true
-                }'
-            ],
-            'Non unique mix of different types' => [
-                'input' => '[{}, [1], true, null, {}, 1]',
-                'schema' => '{
-                    "type": "array",
-                    "uniqueItems": true
-                }'
-            ],
-            'objects are non-unique despite key order' => [
-                'input' => '[{"a": 1, "b": 2}, {"b": 2, "a": 1}]',
-                'schema' => '{"uniqueItems": true}',
-            ]
+    public function getInvalidTests(): \Generator
+{
+        yield 'Non unique integers' => [
+            'input' => '[1,2,2]',
+            'schema' => '{
+              "type":"array",
+              "uniqueItems": true
+            }'
+        ];
+        yield 'Non unique objects' => [
+            'input' => '[{"a":"b"},{"a":"c"},{"a":"b"}]',
+            'schema' => '{
+              "type":"array",
+              "uniqueItems": true
+            }'
+        ];
+        yield 'Non unique objects - three levels deep' => [
+            'input' => '[{"foo": {"bar" : {"baz" : true}}}, {"foo": {"bar" : {"baz" : true}}}]',
+            'schema' => '{
+                "type": "array",
+                "uniqueItems": true
+            }'
+        ];
+        yield 'Non unique mathematical values for the number one' => [
+            'input' => '[1.0, 1.00, 1]',
+            'schema' => '{
+                "type": "array",
+                "uniqueItems": true
+            }'
+        ];
+        yield 'Non unique arrays' => [
+            'input' => '[["foo"], ["foo"]]',
+            'schema' => '{
+                "type": "array",
+                "uniqueItems": true
+            }'
+        ];
+        yield 'Non unique mix of different types' => [
+            'input' => '[{}, [1], true, null, {}, 1]',
+            'schema' => '{
+                "type": "array",
+                "uniqueItems": true
+            }'
+        ];
+        yield 'objects are non-unique despite key order' => [
+            'input' => '[{"a": 1, "b": 2}, {"b": 2, "a": 1}]',
+            'schema' => '{"uniqueItems": true}',
         ];
     }
 
-    public function getValidTests(): array
+    public function getValidTests(): \Generator
     {
-        return [
-            'unique integers' => [
-                'input' => '[1,2,3]',
-                'schema' => '{
-                    "type":"array",
-                    "uniqueItems": true
-                }'
-            ],
-            'unique objects' =>[
-                'input' => '[{"foo": 12}, {"bar": false}]',
-                'schema' => '{
-                    "type": "array",
-                    "uniqueItems": true
-                }'
-            ],
-            'Integer one and boolean true' => [
-                'input' => '[1, true]',
-                'schema' => '{
-                    "type": "array",
-                    "uniqueItems": true
-                }'
-            ],
-            'Integer zero and boolean false' => [
-                'input' => '[0, false]',
-                'schema' => '{
-                    "type": "array",
-                    "uniqueItems": true
-                }'
-            ],
-            'Objects with different value three levels deep' => [
-                'input' => '[{"foo": {"bar" : {"baz" : true}}}, {"foo": {"bar" : {"baz" : false}}}]',
-                'schema' => '{
-                    "type": "array",
-                    "uniqueItems": true
-                }'
-            ],
-            'Array of strings' => [
-                'input' => '[["foo"], ["bar"]]',
-                'schema' => '{
-                    "type": "array",
-                    "uniqueItems": true
-                }'
-            ],
-            'Object, Array, boolean, null and integer' => [
-                'input' => '[{}, [1], true, null, 1]',
-                'schema' => '{
-                    "type": "array",
-                    "uniqueItems": true
-                }'
-            ],
-            // below equals the invalid tests, but with uniqueItems set to false
-            'Non unique integers' => [
-                'input' => '[1,2,2]',
-                'schema' =>  '{
-                  "type":"array",
-                  "uniqueItems": false
-                }'
-            ],
-            'Non unique objects' => [
-                'input' => '[{"a":"b"},{"a":"c"},{"a":"b"}]',
-                'schema' => '{
-                  "type":"array",
-                  "uniqueItems": false
-                }'
-            ],
-            'Non unique objects - three levels deep' => [
-                'input' => '[{"foo": {"bar" : {"baz" : true}}}, {"foo": {"bar" : {"baz" : true}}}]',
-                'schema' => '{
-                    "type": "array",
-                    "uniqueItems": false
-                }'
-            ],
-            'Non unique mathematical values for the number one' => [
-                'input' => '[1.0, 1.00, 1]',
-                'schema' => '{
-                    "type": "array",
-                    "uniqueItems": false
-                }'
-            ],
-            'Non unique arrays' => [
-                'input' => '[["foo"], ["foo"]]',
-                'schema' => '{
-                    "type": "array",
-                    "uniqueItems": false
-                }'
-            ],
-            'Non unique mix of different types' => [
-                'input' => '[{}, [1], true, null, {}, 1]',
-                'schema' => '{
-                    "type": "array",
-                    "uniqueItems": false
-                }'
-            ]
+        yield 'unique integers' => [
+            'input' => '[1,2,3]',
+            'schema' => '{
+                "type":"array",
+                "uniqueItems": true
+            }'
+        ];
+        yield 'unique objects' =>[
+            'input' => '[{"foo": 12}, {"bar": false}]',
+            'schema' => '{
+                "type": "array",
+                "uniqueItems": true
+            }'
+        ];
+        yield 'Integer one and boolean true' => [
+            'input' => '[1, true]',
+            'schema' => '{
+                "type": "array",
+                "uniqueItems": true
+            }'
+        ];
+        yield 'Integer zero and boolean false' => [
+            'input' => '[0, false]',
+            'schema' => '{
+                "type": "array",
+                "uniqueItems": true
+            }'
+        ];
+        yield 'Objects with different value three levels deep' => [
+            'input' => '[{"foo": {"bar" : {"baz" : true}}}, {"foo": {"bar" : {"baz" : false}}}]',
+            'schema' => '{
+                "type": "array",
+                "uniqueItems": true
+            }'
+        ];
+        yield 'Array of strings' => [
+            'input' => '[["foo"], ["bar"]]',
+            'schema' => '{
+                "type": "array",
+                "uniqueItems": true
+            }'
+        ];
+        yield 'Object, Array, boolean, null and integer' => [
+            'input' => '[{}, [1], true, null, 1]',
+            'schema' => '{
+                "type": "array",
+                "uniqueItems": true
+            }'
+        ];
+        // below equals the invalid tests, but with uniqueItems set to false
+        yield 'Non unique integers' => [
+            'input' => '[1,2,2]',
+            'schema' =>  '{
+              "type":"array",
+              "uniqueItems": false
+            }'
+        ];
+        yield 'Non unique objects' => [
+            'input' => '[{"a":"b"},{"a":"c"},{"a":"b"}]',
+            'schema' => '{
+              "type":"array",
+              "uniqueItems": false
+            }'
+        ];
+        yield 'Non unique objects - three levels deep' => [
+            'input' => '[{"foo": {"bar" : {"baz" : true}}}, {"foo": {"bar" : {"baz" : true}}}]',
+            'schema' => '{
+                "type": "array",
+                "uniqueItems": false
+            }'
+        ];
+        yield 'Non unique mathematical values for the number one' => [
+            'input' => '[1.0, 1.00, 1]',
+            'schema' => '{
+                "type": "array",
+                "uniqueItems": false
+            }'
+        ];
+        yield 'Non unique arrays' => [
+            'input' => '[["foo"], ["foo"]]',
+            'schema' => '{
+                "type": "array",
+                "uniqueItems": false
+            }'
+        ];
+        yield 'Non unique mix of different types' => [
+            'input' => '[{}, [1], true, null, {}, 1]',
+            'schema' => '{
+                "type": "array",
+                "uniqueItems": false
+            }'
         ];
     }
 }

--- a/tests/Constraints/UniqueItemsTest.php
+++ b/tests/Constraints/UniqueItemsTest.php
@@ -8,7 +8,7 @@ class UniqueItemsTest extends BaseTestCase
     protected $validateSchema = true;
 
     public function getInvalidTests(): \Generator
-{
+    {
         yield 'Non unique integers' => [
             'input' => '[1,2,2]',
             'schema' => '{

--- a/tests/Constraints/UniqueItemsTest.php
+++ b/tests/Constraints/UniqueItemsTest.php
@@ -1,12 +1,5 @@
 <?php
 
-/*
- * This file is part of the JsonSchema package.
- *
- * For the full copyright and license information, please view the LICENSE
- * file that was distributed with this source code.
- */
-
 namespace JsonSchema\Tests\Constraints;
 
 class UniqueItemsTest extends BaseTestCase

--- a/tests/Constraints/UniqueItemsTest.php
+++ b/tests/Constraints/UniqueItemsTest.php
@@ -4,6 +4,7 @@ namespace JsonSchema\Tests\Constraints;
 
 class UniqueItemsTest extends BaseTestCase
 {
+    /** @var bool */
     protected $validateSchema = true;
 
     public function getInvalidTests(): \Generator

--- a/tests/Constraints/ValidationExceptionTest.php
+++ b/tests/Constraints/ValidationExceptionTest.php
@@ -1,12 +1,13 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * This file is part of the JsonSchema package.
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  */
-
 namespace JsonSchema\Tests\Constraints;
 
 use JsonSchema\Constraints\Constraint;

--- a/tests/Constraints/ValidationExceptionTest.php
+++ b/tests/Constraints/ValidationExceptionTest.php
@@ -2,12 +2,6 @@
 
 declare(strict_types=1);
 
-/*
- * This file is part of the JsonSchema package.
- *
- * For the full copyright and license information, please view the LICENSE
- * file that was distributed with this source code.
- */
 namespace JsonSchema\Tests\Constraints;
 
 use JsonSchema\Constraints\Constraint;

--- a/tests/Constraints/ValidationExceptionTest.php
+++ b/tests/Constraints/ValidationExceptionTest.php
@@ -14,7 +14,7 @@ class ValidationExceptionTest extends TestCase
     public function testValidationException(): void
     {
         $exception = new ValidationException();
-        $this->assertInstanceOf('\JsonSchema\Exception\ValidationException', $exception);
+        $this->assertInstanceOf(\JsonSchema\Exception\ValidationException::class, $exception);
 
         $checkValue = json_decode('{"propertyOne": "thisIsNotAnObject"}');
         $schema = json_decode('{
@@ -40,7 +40,7 @@ class ValidationExceptionTest extends TestCase
             $exception->getMessage()
         );
 
-        $this->expectException('JsonSchema\Exception\ValidationException');
+        $this->expectException(\JsonSchema\Exception\ValidationException::class);
         throw $exception;
     }
 }

--- a/tests/Constraints/WrongMessagesFailingTestCaseTest.php
+++ b/tests/Constraints/WrongMessagesFailingTestCaseTest.php
@@ -13,41 +13,37 @@ class WrongMessagesFailingTestCaseTest extends BaseTestCase
 {
     protected $validateSchema = true;
 
-    public function getInvalidTests(): array
+    public function getInvalidTests(): \Generator
     {
-        return [
-            [
-                '{
-                  "stringOrNumber":4.8,
-                  "booleanOrNull":["A","B"]
-                }',
-                '{
-                  "type":"object",
-                  "properties":{
-                    "stringOrNumber":{"type":["string","number"]},
-                    "booleanOrNull":{"type":["boolean","null"]}
-                  }
-                }'
-            ]
+        yield [
+            '{
+              "stringOrNumber":4.8,
+              "booleanOrNull":["A","B"]
+            }',
+            '{
+              "type":"object",
+              "properties":{
+                "stringOrNumber":{"type":["string","number"]},
+                "booleanOrNull":{"type":["boolean","null"]}
+              }
+            }'
         ];
     }
 
-    public function getValidTests(): array
+    public function getValidTests(): \Generator
     {
-        return [
-            [
-                '{
-                  "stringOrNumber":4.8,
-                  "booleanOrNull":true
-                }',
-                '{
-                  "type":"object",
-                  "properties":{
-                    "stringOrNumber":{"type":["string","number"]},
-                    "booleanOrNull":{"type":["boolean","null"]}
-                  }
-                }'
-            ]
+        yield [
+            '{
+              "stringOrNumber":4.8,
+              "booleanOrNull":true
+            }',
+            '{
+              "type":"object",
+              "properties":{
+                "stringOrNumber":{"type":["string","number"]},
+                "booleanOrNull":{"type":["boolean","null"]}
+              }
+            }'
         ];
     }
 }

--- a/tests/Constraints/WrongMessagesFailingTestCaseTest.php
+++ b/tests/Constraints/WrongMessagesFailingTestCaseTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace JsonSchema\Tests\Constraints;
 
 class WrongMessagesFailingTestCaseTest extends BaseTestCase

--- a/tests/Constraints/WrongMessagesFailingTestCaseTest.php
+++ b/tests/Constraints/WrongMessagesFailingTestCaseTest.php
@@ -1,12 +1,5 @@
 <?php
 
-/*
- * This file is part of the JsonSchema package.
- *
- * For the full copyright and license information, please view the LICENSE
- * file that was distributed with this source code.
- */
-
 namespace JsonSchema\Tests\Constraints;
 
 class WrongMessagesFailingTestCaseTest extends BaseTestCase

--- a/tests/Constraints/WrongMessagesFailingTestCaseTest.php
+++ b/tests/Constraints/WrongMessagesFailingTestCaseTest.php
@@ -4,6 +4,7 @@ namespace JsonSchema\Tests\Constraints;
 
 class WrongMessagesFailingTestCaseTest extends BaseTestCase
 {
+    /** @var bool */
     protected $validateSchema = true;
 
     public function getInvalidTests(): \Generator

--- a/tests/Drafts/BaseDraftTestCase.php
+++ b/tests/Drafts/BaseDraftTestCase.php
@@ -45,14 +45,14 @@ abstract class BaseDraftTestCase extends BaseTestCase
         return $tests;
     }
 
-    public function getInvalidTests(): array
+    public function getInvalidTests(): \Generator
     {
-        return $this->setUpTests(false);
+        yield from $this->setUpTests(false);
     }
 
-    public function getValidTests(): array
+    public function getValidTests(): \Generator
     {
-        return $this->setUpTests(true);
+        yield from $this->setUpTests(true);
     }
 
     /**

--- a/tests/Drafts/Draft3Test.php
+++ b/tests/Drafts/Draft3Test.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace JsonSchema\Tests\Drafts;
 
 use JsonSchema\Constraints\Factory;

--- a/tests/Drafts/Draft3Test.php
+++ b/tests/Drafts/Draft3Test.php
@@ -81,26 +81,34 @@ JSON
         ];
     }
 
-    public function getInvalidForAssocTests(): array
+    public function getInvalidForAssocTests(): \Generator
     {
-        $tests = parent::getInvalidForAssocTests();
-        unset(
-            $tests['type.json / object type matches objects / an array is not an object'],
-            $tests['type.json / array type matches arrays / an object is not an array']
-        );
+        $skip = [
+            'type.json / object type matches objects / an array is not an object',
+            'type.json / array type matches arrays / an object is not an array',
+        ];
 
-        return $tests;
+        foreach (parent::getInvalidForAssocTests() as $name => $testcase) {
+            if (in_array($name, $skip, true)) {
+                continue;
+            }
+            yield $name => $testcase;
+        }
     }
 
-    public function getValidForAssocTests(): array
+    public function getValidForAssocTests(): \Generator
     {
-        $tests = parent::getValidForAssocTests();
-        unset(
-            $tests['type.json / object type matches objects / an array is not an object'],
-            $tests['type.json / array type matches arrays / an object is not an array']
-        );
+        $skip = [
+            'type.json / object type matches objects / an array is not an object',
+            'type.json / array type matches arrays / an object is not an array',
+        ];
 
-        return $tests;
+        foreach (parent::getValidForAssocTests() as $name => $testcase) {
+            if (in_array($name, $skip, true)) {
+                continue;
+            }
+            yield $name => $testcase;
+        }
     }
 
     /**

--- a/tests/Drafts/Draft3Test.php
+++ b/tests/Drafts/Draft3Test.php
@@ -6,9 +6,6 @@ use JsonSchema\Constraints\Factory;
 use JsonSchema\SchemaStorage;
 use JsonSchema\Validator;
 
-/**
- * @package JsonSchema\Tests\Drafts
- */
 class Draft3Test extends BaseDraftTestCase
 {
     protected $schemaSpec = 'http://json-schema.org/draft-03/schema#';

--- a/tests/Drafts/Draft3Test.php
+++ b/tests/Drafts/Draft3Test.php
@@ -1,12 +1,5 @@
 <?php
 
-/*
- * This file is part of the JsonSchema package.
- *
- * For the full copyright and license information, please view the LICENSE
- * file that was distributed with this source code.
- */
-
 namespace JsonSchema\Tests\Drafts;
 
 use JsonSchema\Constraints\Factory;

--- a/tests/Drafts/Draft3Test.php
+++ b/tests/Drafts/Draft3Test.php
@@ -8,7 +8,9 @@ use JsonSchema\Validator;
 
 class Draft3Test extends BaseDraftTestCase
 {
+    /** @var string */
     protected $schemaSpec = 'http://json-schema.org/draft-03/schema#';
+    /** @var bool */
     protected $validateSchema = true;
 
     /**

--- a/tests/Drafts/Draft4Test.php
+++ b/tests/Drafts/Draft4Test.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace JsonSchema\Tests\Drafts;
 
 class Draft4Test extends BaseDraftTestCase

--- a/tests/Drafts/Draft4Test.php
+++ b/tests/Drafts/Draft4Test.php
@@ -2,9 +2,6 @@
 
 namespace JsonSchema\Tests\Drafts;
 
-/**
- * @package JsonSchema\Tests\Drafts
- */
 class Draft4Test extends BaseDraftTestCase
 {
     /** @var bool */

--- a/tests/Drafts/Draft4Test.php
+++ b/tests/Drafts/Draft4Test.php
@@ -28,26 +28,34 @@ class Draft4Test extends BaseDraftTestCase
         ];
     }
 
-    public function getInvalidForAssocTests(): array
+    public function getInvalidForAssocTests(): \Generator
     {
-        $tests = parent::getInvalidForAssocTests();
-        unset(
-            $tests['type.json / object type matches objects / an array is not an object'],
-            $tests['type.json / array type matches arrays / an object is not an array']
-        );
+        $skip = [
+            'type.json / object type matches objects / an array is not an object',
+            'type.json / array type matches arrays / an object is not an array',
+        ];
 
-        return $tests;
+        foreach (parent::getInvalidForAssocTests() as $name => $testcase) {
+            if (in_array($name, $skip, true)) {
+                continue;
+            }
+            yield $name => $testcase;
+        }
     }
 
-    public function getValidForAssocTests(): array
+    public function getValidForAssocTests(): \Generator
     {
-        $tests = parent::getValidForAssocTests();
-        unset(
-            $tests['type.json / object type matches objects / an array is not an object'],
-            $tests['type.json / array type matches arrays / an object is not an array']
-        );
+        $skip = [
+            'type.json / object type matches objects / an array is not an object',
+            'type.json / array type matches arrays / an object is not an array',
+        ];
 
-        return $tests;
+        foreach (parent::getValidForAssocTests() as $name => $testcase) {
+            if (in_array($name, $skip, true)) {
+                continue;
+            }
+            yield $name => $testcase;
+        }
     }
 
     /**

--- a/tests/Drafts/Draft4Test.php
+++ b/tests/Drafts/Draft4Test.php
@@ -1,12 +1,5 @@
 <?php
 
-/*
- * This file is part of the JsonSchema package.
- *
- * For the full copyright and license information, please view the LICENSE
- * file that was distributed with this source code.
- */
-
 namespace JsonSchema\Tests\Drafts;
 
 /**

--- a/tests/Entity/JsonPointerTest.php
+++ b/tests/Entity/JsonPointerTest.php
@@ -8,11 +8,6 @@ use JsonSchema\Entity\JsonPointer;
 use JsonSchema\Exception\InvalidArgumentException;
 use PHPUnit\Framework\TestCase;
 
-/**
- * @package JsonSchema\Tests\Entity
- *
- * @author Joost Nijhuis <jnijhuis81@gmail.com>
- */
 class JsonPointerTest extends TestCase
 {
     /**

--- a/tests/Entity/JsonPointerTest.php
+++ b/tests/Entity/JsonPointerTest.php
@@ -2,13 +2,6 @@
 
 declare(strict_types=1);
 
-/*
- * This file is part of the JsonSchema package.
- *
- * For the full copyright and license information, please view the LICENSE
- * file that was distributed with this source code.
- */
-
 namespace JsonSchema\Tests\Entity;
 
 use JsonSchema\Entity\JsonPointer;

--- a/tests/Exception/InvalidArgumentExceptionTest.php
+++ b/tests/Exception/InvalidArgumentExceptionTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace JsonSchema\Tests\Exception;
 
 use JsonSchema\Exception\InvalidArgumentException;

--- a/tests/Exception/InvalidArgumentExceptionTest.php
+++ b/tests/Exception/InvalidArgumentExceptionTest.php
@@ -13,6 +13,6 @@ class InvalidArgumentExceptionTest extends TestCase
     {
         $exception = new InvalidArgumentException();
         self::assertInstanceOf('\InvalidArgumentException', $exception);
-        self::assertInstanceOf('\JsonSchema\Exception\ExceptionInterface', $exception);
+        self::assertInstanceOf(\JsonSchema\Exception\ExceptionInterface::class, $exception);
     }
 }

--- a/tests/Exception/InvalidSchemaMediaTypeExceptionTest.php
+++ b/tests/Exception/InvalidSchemaMediaTypeExceptionTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace JsonSchema\Tests\Exception;
 
 use JsonSchema\Exception\InvalidSchemaMediaTypeException;

--- a/tests/Exception/InvalidSchemaMediaTypeExceptionTest.php
+++ b/tests/Exception/InvalidSchemaMediaTypeExceptionTest.php
@@ -13,7 +13,7 @@ class InvalidSchemaMediaTypeExceptionTest extends TestCase
     {
         $exception = new InvalidSchemaMediaTypeException();
         self::assertInstanceOf('\RuntimeException', $exception);
-        self::assertInstanceOf('\JsonSchema\Exception\RuntimeException', $exception);
-        self::assertInstanceOf('\JsonSchema\Exception\ExceptionInterface', $exception);
+        self::assertInstanceOf(\JsonSchema\Exception\RuntimeException::class, $exception);
+        self::assertInstanceOf(\JsonSchema\Exception\ExceptionInterface::class, $exception);
     }
 }

--- a/tests/Exception/InvalidSourceUriExceptionTest.php
+++ b/tests/Exception/InvalidSourceUriExceptionTest.php
@@ -13,7 +13,7 @@ class InvalidSourceUriExceptionTest extends TestCase
     {
         $exception = new InvalidSourceUriException();
         self::assertInstanceOf('\InvalidArgumentException', $exception);
-        self::assertInstanceOf('\JsonSchema\Exception\InvalidArgumentException', $exception);
-        self::assertInstanceOf('\JsonSchema\Exception\ExceptionInterface', $exception);
+        self::assertInstanceOf(\JsonSchema\Exception\InvalidArgumentException::class, $exception);
+        self::assertInstanceOf(\JsonSchema\Exception\ExceptionInterface::class, $exception);
     }
 }

--- a/tests/Exception/InvalidSourceUriExceptionTest.php
+++ b/tests/Exception/InvalidSourceUriExceptionTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace JsonSchema\Tests\Exception;
 
 use JsonSchema\Exception\InvalidSourceUriException;

--- a/tests/Exception/JsonDecodingExceptionTest.php
+++ b/tests/Exception/JsonDecodingExceptionTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace JsonSchema\Tests\Exception;
 
 use JsonSchema\Exception\JsonDecodingException;

--- a/tests/Exception/JsonDecodingExceptionTest.php
+++ b/tests/Exception/JsonDecodingExceptionTest.php
@@ -13,8 +13,8 @@ class JsonDecodingExceptionTest extends TestCase
     {
         $exception = new JsonDecodingException();
         self::assertInstanceOf('\RuntimeException', $exception);
-        self::assertInstanceOf('\JsonSchema\Exception\RuntimeException', $exception);
-        self::assertInstanceOf('\JsonSchema\Exception\ExceptionInterface', $exception);
+        self::assertInstanceOf(\JsonSchema\Exception\RuntimeException::class, $exception);
+        self::assertInstanceOf(\JsonSchema\Exception\ExceptionInterface::class, $exception);
     }
 
     public function testDefaultMessage()

--- a/tests/Exception/ResourceNotFoundExceptionTest.php
+++ b/tests/Exception/ResourceNotFoundExceptionTest.php
@@ -13,7 +13,7 @@ class ResourceNotFoundExceptionTest extends TestCase
     {
         $exception = new ResourceNotFoundException();
         self::assertInstanceOf('\RuntimeException', $exception);
-        self::assertInstanceOf('\JsonSchema\Exception\RuntimeException', $exception);
-        self::assertInstanceOf('\JsonSchema\Exception\ExceptionInterface', $exception);
+        self::assertInstanceOf(\JsonSchema\Exception\RuntimeException::class, $exception);
+        self::assertInstanceOf(\JsonSchema\Exception\ExceptionInterface::class, $exception);
     }
 }

--- a/tests/Exception/ResourceNotFoundExceptionTest.php
+++ b/tests/Exception/ResourceNotFoundExceptionTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace JsonSchema\Tests\Exception;
 
 use JsonSchema\Exception\ResourceNotFoundException;

--- a/tests/Exception/RuntimeExceptionTest.php
+++ b/tests/Exception/RuntimeExceptionTest.php
@@ -13,6 +13,6 @@ class RuntimeExceptionTest extends TestCase
     {
         $exception = new RuntimeException();
         self::assertInstanceOf('\RuntimeException', $exception);
-        self::assertInstanceOf('\JsonSchema\Exception\ExceptionInterface', $exception);
+        self::assertInstanceOf(\JsonSchema\Exception\ExceptionInterface::class, $exception);
     }
 }

--- a/tests/Exception/RuntimeExceptionTest.php
+++ b/tests/Exception/RuntimeExceptionTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace JsonSchema\Tests\Exception;
 
 use JsonSchema\Exception\RuntimeException;

--- a/tests/Exception/UnresolvableJsonPointerExceptionTest.php
+++ b/tests/Exception/UnresolvableJsonPointerExceptionTest.php
@@ -13,7 +13,7 @@ class UnresolvableJsonPointerExceptionTest extends TestCase
     {
         $exception = new UnresolvableJsonPointerException();
         self::assertInstanceOf('\InvalidArgumentException', $exception);
-        self::assertInstanceOf('\JsonSchema\Exception\InvalidArgumentException', $exception);
-        self::assertInstanceOf('\JsonSchema\Exception\ExceptionInterface', $exception);
+        self::assertInstanceOf(\JsonSchema\Exception\InvalidArgumentException::class, $exception);
+        self::assertInstanceOf(\JsonSchema\Exception\ExceptionInterface::class, $exception);
     }
 }

--- a/tests/Exception/UnresolvableJsonPointerExceptionTest.php
+++ b/tests/Exception/UnresolvableJsonPointerExceptionTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace JsonSchema\Tests\Exception;
 
 use JsonSchema\Exception\UnresolvableJsonPointerException;

--- a/tests/Exception/UriResolverExceptionTest.php
+++ b/tests/Exception/UriResolverExceptionTest.php
@@ -13,7 +13,7 @@ class UriResolverExceptionTest extends TestCase
     {
         $exception = new UriResolverException();
         self::assertInstanceOf('\RuntimeException', $exception);
-        self::assertInstanceOf('\JsonSchema\Exception\RuntimeException', $exception);
-        self::assertInstanceOf('\JsonSchema\Exception\ExceptionInterface', $exception);
+        self::assertInstanceOf(\JsonSchema\Exception\RuntimeException::class, $exception);
+        self::assertInstanceOf(\JsonSchema\Exception\ExceptionInterface::class, $exception);
     }
 }

--- a/tests/Exception/UriResolverExceptionTest.php
+++ b/tests/Exception/UriResolverExceptionTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace JsonSchema\Tests\Exception;
 
 use JsonSchema\Exception\UriResolverException;

--- a/tests/Iterators/ObjectIteratorTest.php
+++ b/tests/Iterators/ObjectIteratorTest.php
@@ -1,12 +1,13 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * This file is part of the JsonSchema package.
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  */
-
 namespace JsonSchema\Tests\Iterators;
 
 use JsonSchema\Iterator\ObjectIterator;

--- a/tests/Iterators/ObjectIteratorTest.php
+++ b/tests/Iterators/ObjectIteratorTest.php
@@ -2,12 +2,6 @@
 
 declare(strict_types=1);
 
-/*
- * This file is part of the JsonSchema package.
- *
- * For the full copyright and license information, please view the LICENSE
- * file that was distributed with this source code.
- */
 namespace JsonSchema\Tests\Iterators;
 
 use JsonSchema\Iterator\ObjectIterator;

--- a/tests/Iterators/ObjectIteratorTest.php
+++ b/tests/Iterators/ObjectIteratorTest.php
@@ -34,7 +34,7 @@ class ObjectIteratorTest extends TestCase
     {
         $i = new ObjectIterator($this->testObject);
 
-        $this->assertInstanceOf('\JsonSchema\Iterator\ObjectIterator', $i);
+        $this->assertInstanceOf(\JsonSchema\Iterator\ObjectIterator::class, $i);
     }
 
     public function testInitialState(): void

--- a/tests/RefTest.php
+++ b/tests/RefTest.php
@@ -51,7 +51,7 @@ class RefTest extends TestCase
                 }',
                 '{"propertyOne": 5}',
                 true,
-                '\JsonSchema\Exception\UnresolvableJsonPointerException'
+                \JsonSchema\Exception\UnresolvableJsonPointerException::class
             ]
         ];
     }

--- a/tests/RefTest.php
+++ b/tests/RefTest.php
@@ -2,12 +2,6 @@
 
 declare(strict_types=1);
 
-/*
- * This file is part of the JsonSchema package.
- *
- * For the full copyright and license information, please view the LICENSE
- * file that was distributed with this source code.
- */
 namespace JsonSchema\Tests;
 
 use JsonSchema\Validator;

--- a/tests/RefTest.php
+++ b/tests/RefTest.php
@@ -1,12 +1,13 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * This file is part of the JsonSchema package.
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  */
-
 namespace JsonSchema\Tests;
 
 use JsonSchema\Validator;

--- a/tests/SchemaStorageTest.php
+++ b/tests/SchemaStorageTest.php
@@ -1,12 +1,13 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * This file is part of the JsonSchema package.
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  */
-
 namespace JsonSchema\Tests;
 
 use JsonSchema\SchemaStorage;

--- a/tests/SchemaStorageTest.php
+++ b/tests/SchemaStorageTest.php
@@ -16,7 +16,7 @@ class SchemaStorageTest extends TestCase
         $mainSchema = $this->getMainSchema();
         $mainSchemaPath = 'http://www.example.com/schema.json';
 
-        $uriRetriever = $this->prophesize('JsonSchema\UriRetrieverInterface');
+        $uriRetriever = $this->prophesize(\JsonSchema\UriRetrieverInterface::class);
         $uriRetriever->retrieve($mainSchemaPath)->willReturn($mainSchema)->shouldBeCalled();
 
         $schemaStorage = new SchemaStorage($uriRetriever->reveal());
@@ -50,7 +50,7 @@ class SchemaStorageTest extends TestCase
         $schema3Path = 'http://www.my-domain.com/schema3.json';
 
         /** @var UriRetriever $uriRetriever */
-        $uriRetriever = $this->prophesize('JsonSchema\UriRetrieverInterface');
+        $uriRetriever = $this->prophesize(\JsonSchema\UriRetrieverInterface::class);
         $uriRetriever->retrieve($mainSchemaPath)->willReturn($mainSchema)->shouldBeCalled();
         $uriRetriever->retrieve($schema2Path)->willReturn($schema2)->shouldBeCalled();
         $uriRetriever->retrieve($schema3Path)->willReturn($schema3)->shouldBeCalled();
@@ -97,13 +97,13 @@ class SchemaStorageTest extends TestCase
 
     public function testUnresolvableJsonPointExceptionShouldBeThrown(): void
     {
-        $this->expectException('JsonSchema\Exception\UnresolvableJsonPointerException');
+        $this->expectException(\JsonSchema\Exception\UnresolvableJsonPointerException::class);
         $this->expectExceptionMessage('File: http://www.example.com/schema.json is found, but could not resolve fragment: #/definitions/car');
 
         $mainSchema = $this->getInvalidSchema();
         $mainSchemaPath = 'http://www.example.com/schema.json';
 
-        $uriRetriever = $this->prophesize('JsonSchema\UriRetrieverInterface');
+        $uriRetriever = $this->prophesize(\JsonSchema\UriRetrieverInterface::class);
         $uriRetriever->retrieve($mainSchemaPath)
             ->willReturn($mainSchema)
             ->shouldBeCalled();
@@ -114,7 +114,7 @@ class SchemaStorageTest extends TestCase
 
     public function testResolveRefWithNoAssociatedFileName(): void
     {
-        $this->expectException('JsonSchema\Exception\UnresolvableJsonPointerException');
+        $this->expectException(\JsonSchema\Exception\UnresolvableJsonPointerException::class);
         $this->expectExceptionMessage("Could not resolve fragment '#': no file is defined");
 
         $schemaStorage = new SchemaStorage();
@@ -259,14 +259,14 @@ class SchemaStorageTest extends TestCase
     {
         $s = new SchemaStorage();
         $s->addSchema('http://json-schema.org/draft-04/schema#');
-        $this->assertInstanceOf('\JsonSchema\Uri\UriRetriever', $s->getUriRetriever());
+        $this->assertInstanceOf(\JsonSchema\Uri\UriRetriever::class, $s->getUriRetriever());
     }
 
     public function testGetUriResolver(): void
     {
         $s = new SchemaStorage();
         $s->addSchema('http://json-schema.org/draft-04/schema#');
-        $this->assertInstanceOf('\JsonSchema\Uri\UriResolver', $s->getUriResolver());
+        $this->assertInstanceOf(\JsonSchema\Uri\UriResolver::class, $s->getUriResolver());
     }
 
     public function testMetaSchemaFixes(): void
@@ -286,7 +286,7 @@ class SchemaStorageTest extends TestCase
     {
         $schemaOne = json_decode('{"id": "test/schema", "$ref": "../test2/schema2"}');
 
-        $uriRetriever = $this->prophesize('JsonSchema\UriRetrieverInterface');
+        $uriRetriever = $this->prophesize(\JsonSchema\UriRetrieverInterface::class);
         $uriRetriever->retrieve('test/schema')->willReturn($schemaOne)->shouldBeCalled();
 
         $s = new SchemaStorage($uriRetriever->reveal());

--- a/tests/SchemaStorageTest.php
+++ b/tests/SchemaStorageTest.php
@@ -2,12 +2,6 @@
 
 declare(strict_types=1);
 
-/*
- * This file is part of the JsonSchema package.
- *
- * For the full copyright and license information, please view the LICENSE
- * file that was distributed with this source code.
- */
 namespace JsonSchema\Tests;
 
 use JsonSchema\SchemaStorage;

--- a/tests/Uri/Retrievers/CurlTest.php
+++ b/tests/Uri/Retrievers/CurlTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace JsonSchema\Tests\Uri\Retrievers
 {
     use JsonSchema\Uri\Retrievers\Curl;

--- a/tests/Uri/Retrievers/CurlTest.php
+++ b/tests/Uri/Retrievers/CurlTest.php
@@ -21,7 +21,7 @@ namespace JsonSchema\Tests\Uri\Retrievers
         {
             $c = new Curl();
 
-            $this->expectException('\JsonSchema\Exception\ResourceNotFoundException');
+            $this->expectException(\JsonSchema\Exception\ResourceNotFoundException::class);
             $this->expectExceptionMessage('JSON schema not found');
 
             $c->retrieve(__DIR__ . '/notARealFile');

--- a/tests/Uri/Retrievers/FileGetContentsTest.php
+++ b/tests/Uri/Retrievers/FileGetContentsTest.php
@@ -7,9 +7,6 @@ namespace JsonSchema\Tests\Uri\Retrievers;
 use JsonSchema\Uri\Retrievers\FileGetContents;
 use PHPUnit\Framework\TestCase;
 
-/**
- * @group FileGetContents
- */
 class FileGetContentsTest extends TestCase
 {
     public function testFetchMissingFile(): void

--- a/tests/Uri/Retrievers/FileGetContentsTest.php
+++ b/tests/Uri/Retrievers/FileGetContentsTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace JsonSchema\Tests\Uri\Retrievers;
 
 use JsonSchema\Uri\Retrievers\FileGetContents;

--- a/tests/Uri/Retrievers/PredefinedArrayTest.php
+++ b/tests/Uri/Retrievers/PredefinedArrayTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace JsonSchema\Tests\Uri\Retrievers;
 
 use JsonSchema\Uri\Retrievers\PredefinedArray;

--- a/tests/Uri/Retrievers/PredefinedArrayTest.php
+++ b/tests/Uri/Retrievers/PredefinedArrayTest.php
@@ -7,9 +7,6 @@ namespace JsonSchema\Tests\Uri\Retrievers;
 use JsonSchema\Uri\Retrievers\PredefinedArray;
 use PHPUnit\Framework\TestCase;
 
-/**
- * @group PredefinedArray
- */
 class PredefinedArrayTest extends TestCase
 {
     private $retriever;

--- a/tests/Uri/UriResolverTest.php
+++ b/tests/Uri/UriResolverTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace JsonSchema\Tests\Uri;
 
 use JsonSchema\Uri\UriResolver;

--- a/tests/Uri/UriRetrieverTest.php
+++ b/tests/Uri/UriRetrieverTest.php
@@ -2,12 +2,6 @@
 
 declare(strict_types=1);
 
-/*
- * This file is part of the JsonSchema package.
- *
- * For the full copyright and license information, please view the LICENSE
- * file that was distributed with this source code.
- */
 namespace JsonSchema\Tests\Uri;
 
 use JsonSchema\Exception\InvalidSchemaMediaTypeException;

--- a/tests/Uri/UriRetrieverTest.php
+++ b/tests/Uri/UriRetrieverTest.php
@@ -12,9 +12,6 @@ use JsonSchema\Uri\UriRetriever;
 use JsonSchema\Validator;
 use PHPUnit\Framework\TestCase;
 
-/**
- * @group UriRetriever
- */
 class UriRetrieverTest extends TestCase
 {
     protected $validator;

--- a/tests/Uri/UriRetrieverTest.php
+++ b/tests/Uri/UriRetrieverTest.php
@@ -29,7 +29,7 @@ class UriRetrieverTest extends TestCase
             throw new JsonDecodingException($error);
         }
 
-        $retriever = $this->createMock('JsonSchema\Uri\UriRetriever');
+        $retriever = $this->createMock(\JsonSchema\Uri\UriRetriever::class);
 
         $retriever->expects($this->at(0))
                   ->method('retrieve')
@@ -227,7 +227,7 @@ EOF;
 
     public function testConfirmMediaTypeAcceptsJsonSchemaType(): void
     {
-        $uriRetriever = $this->createMock('JsonSchema\Uri\Retrievers\UriRetrieverInterface');
+        $uriRetriever = $this->createMock(\JsonSchema\Uri\Retrievers\UriRetrieverInterface::class);
         $retriever = new UriRetriever();
 
         $uriRetriever->expects($this->at(0))
@@ -239,7 +239,7 @@ EOF;
 
     public function testConfirmMediaTypeAcceptsJsonType(): void
     {
-        $uriRetriever = $this->createMock('JsonSchema\Uri\Retrievers\UriRetrieverInterface');
+        $uriRetriever = $this->createMock(\JsonSchema\Uri\Retrievers\UriRetrieverInterface::class);
         $retriever = new UriRetriever();
 
         $uriRetriever->expects($this->at(0))
@@ -251,7 +251,7 @@ EOF;
 
     public function testConfirmMediaTypeThrowsExceptionForUnsupportedTypes(): void
     {
-        $uriRetriever = $this->createMock('JsonSchema\Uri\Retrievers\UriRetrieverInterface');
+        $uriRetriever = $this->createMock(\JsonSchema\Uri\Retrievers\UriRetrieverInterface::class);
         $retriever = new UriRetriever();
         $uriRetriever->expects($this->at(0))
                 ->method('getContentType')
@@ -266,11 +266,11 @@ EOF;
     {
         $retrieverMock = $this->getRetrieverMock($schema);
 
-        $factory = new \ReflectionProperty('JsonSchema\Constraints\BaseConstraint', 'factory');
+        $factory = new \ReflectionProperty(\JsonSchema\Constraints\BaseConstraint::class, 'factory');
         $factory->setAccessible(true);
         $factory = $factory->getValue($this->validator);
 
-        $retriever = new \ReflectionProperty('JsonSchema\Constraints\Factory', 'uriRetriever');
+        $retriever = new \ReflectionProperty(\JsonSchema\Constraints\Factory::class, 'uriRetriever');
         $retriever->setAccessible(true);
         $retriever->setValue($factory, $retrieverMock);
     }
@@ -325,7 +325,7 @@ EOF;
 
     public function testInvalidContentTypeEndpointsDefault(): void
     {
-        $mock = $this->createMock('JsonSchema\Uri\Retrievers\UriRetrieverInterface');
+        $mock = $this->createMock(\JsonSchema\Uri\Retrievers\UriRetrieverInterface::class);
         $mock->method('getContentType')->willReturn('Application/X-Fake-Type');
         $retriever = new UriRetriever();
 
@@ -335,7 +335,7 @@ EOF;
 
     public function testInvalidContentTypeEndpointsUnknown(): void
     {
-        $mock = $this->createMock('JsonSchema\Uri\Retrievers\UriRetrieverInterface');
+        $mock = $this->createMock(\JsonSchema\Uri\Retrievers\UriRetrieverInterface::class);
         $mock->method('getContentType')->willReturn('Application/X-Fake-Type');
         $retriever = new UriRetriever();
 
@@ -345,7 +345,7 @@ EOF;
 
     public function testInvalidContentTypeEndpointsAdded(): void
     {
-        $mock = $this->createMock('JsonSchema\Uri\Retrievers\UriRetrieverInterface');
+        $mock = $this->createMock(\JsonSchema\Uri\Retrievers\UriRetrieverInterface::class);
         $mock->method('getContentType')->willReturn('Application/X-Fake-Type');
         $retriever = new UriRetriever();
         $retriever->addInvalidContentTypeEndpoint('http://example.com');
@@ -378,7 +378,7 @@ EOF;
     {
         $retriever = new UriRetriever();
 
-        $this->expectException('JsonSchema\Exception\JsonDecodingException');
+        $this->expectException(\JsonSchema\Exception\JsonDecodingException::class);
         $this->expectExceptionMessage('JSON syntax is malformed');
 
         $retriever->retrieve('package://tests/fixtures/bad-syntax.json');

--- a/tests/Uri/UriRetrieverTest.php
+++ b/tests/Uri/UriRetrieverTest.php
@@ -1,12 +1,13 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * This file is part of the JsonSchema package.
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  */
-
 namespace JsonSchema\Tests\Uri;
 
 use JsonSchema\Exception\InvalidSchemaMediaTypeException;

--- a/tests/ValidatorTest.php
+++ b/tests/ValidatorTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace JsonSchema\Tests;
 
 use JsonSchema\Exception\InvalidArgumentException;


### PR DESCRIPTION
This PR will:
- Update all data providers to return `Generator` objects.
- Remove file headers with a license reference in favour of the `LICENSE.md` at the root
- Remove class docbocks which where defining unused attributes
- Add `declare(strict_types=1);` to all test files
- Replace class strings with their resp. `::class` constant.
- More updates bringing test files to PHP 7.2 level using rector