### PR TITLE
feat: add proof-of-concept implementation for strict fully validating using draft-06 schema

### DIFF
--- a/src/JsonSchema/Constraints/Constraint.php
+++ b/src/JsonSchema/Constraints/Constraint.php
@@ -21,6 +21,7 @@ abstract class Constraint extends BaseConstraint implements ConstraintInterface
     public const CHECK_MODE_EARLY_COERCE =     0x00000040;
     public const CHECK_MODE_ONLY_REQUIRED_DEFAULTS   = 0x00000080;
     public const CHECK_MODE_VALIDATE_SCHEMA =  0x00000100;
+    public const CHECK_MODE_STRICT =  0x00000200;
 
     /**
      * Bubble down the path

--- a/src/JsonSchema/Constraints/Drafts/Draft06/ConstConstraint.php
+++ b/src/JsonSchema/Constraints/Drafts/Draft06/ConstConstraint.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JsonSchema\Constraints\Drafts\Draft06;
+
+use JsonSchema\ConstraintError;
+use JsonSchema\Constraints\ConstraintInterface;
+use JsonSchema\Constraints\Factory;
+use JsonSchema\Entity\ErrorBagProxy;
+use JsonSchema\Entity\JsonPointer;
+use JsonSchema\Tool\DeepComparer;
+
+class ConstConstraint implements ConstraintInterface
+{
+    use ErrorBagProxy;
+
+    public function __construct(?Factory $factory = null)
+    {
+        $this->initialiseErrorBag($factory ?: new Factory());
+    }
+
+    public function check(&$value, $schema = null, ?JsonPointer $path = null, $i = null): void
+    {
+        if (!property_exists($schema, 'const')) {
+            return;
+        }
+
+        if (DeepComparer::isEqual($value, $schema->const)) {
+            return;
+        }
+
+        $this->addError(ConstraintError::CONSTANT(), $path, ['const' => $schema->const]);
+    }
+}

--- a/src/JsonSchema/Constraints/Drafts/Draft06/Draft06Constraint.php
+++ b/src/JsonSchema/Constraints/Drafts/Draft06/Draft06Constraint.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JsonSchema\Constraints\Drafts\Draft06;
+
+use JsonSchema\Constraints\Constraint;
+use JsonSchema\Entity\JsonPointer;
+
+class Draft06Constraint extends Constraint
+{
+    public function __construct()
+    {
+        parent::__construct(new Factory());
+    }
+
+    public function check(&$value, $schema = null, ?JsonPointer $path = null, $i = null): void
+    {
+        // Apply defaults
+        // Required keyword
+        $this->checkForKeyword('type', $value, $schema, $path, $i);
+        // Not
+        // Dependencies
+        // allof
+        // anyof
+        // oneof
+
+        // array
+        // object
+        // string
+        $this->checkForKeyword('number', $value, $schema, $path, $i);
+        $this->checkForKeyword('uniqueItems', $value, $schema, $path, $i);
+        $this->checkForKeyword('minItems', $value, $schema, $path, $i);
+        $this->checkForKeyword('minProperties', $value, $schema, $path, $i);
+        $this->checkForKeyword('minimum', $value, $schema, $path, $i);
+        $this->checkForKeyword('minLength', $value, $schema, $path, $i);
+        $this->checkForKeyword('exclusiveMinimum', $value, $schema, $path, $i);
+        $this->checkForKeyword('maxItems', $value, $schema, $path, $i);
+        $this->checkForKeyword('enum', $value, $schema, $path, $i);
+        $this->checkForKeyword('const', $value, $schema, $path, $i);
+    }
+
+    protected function checkForKeyword(string $keyword, $value, $schema = null, ?JsonPointer $path = null, $i = null): void
+    {
+        $validator = $this->factory->createInstanceFor($keyword);
+        $validator->check($value, $schema, $path, $i);
+
+        $this->addErrors($validator->getErrors());
+    }
+}

--- a/src/JsonSchema/Constraints/Drafts/Draft06/EnumConstraint.php
+++ b/src/JsonSchema/Constraints/Drafts/Draft06/EnumConstraint.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JsonSchema\Constraints\Drafts\Draft06;
+
+use JsonSchema\ConstraintError;
+use JsonSchema\Constraints\ConstraintInterface;
+use JsonSchema\Constraints\Factory;
+use JsonSchema\Constraints\UndefinedConstraint;
+use JsonSchema\Entity\ErrorBagProxy;
+use JsonSchema\Entity\JsonPointer;
+use JsonSchema\Tool\DeepComparer;
+
+class EnumConstraint implements ConstraintInterface
+{
+    use ErrorBagProxy;
+
+    public function __construct(?Factory $factory = null)
+    {
+        $this->initialiseErrorBag($factory ?: new Factory());
+    }
+
+    public function check(&$value, $schema = null, ?JsonPointer $path = null, $i = null): void
+    {
+        if (!property_exists($schema, 'enum')) {
+            return;
+        }
+
+        foreach ($schema->enum as $enumCase) {
+            if (DeepComparer::isEqual($value, $enumCase)) {
+                return;
+            }
+
+            if (is_numeric($value) && is_numeric($enumCase) && DeepComparer::isEqual((float) $value, (float) $enumCase)) {
+                return;
+            }
+        }
+
+        $this->addError(ConstraintError::ENUM(), $path, ['enum' => $schema->enum]);
+    }
+}

--- a/src/JsonSchema/Constraints/Drafts/Draft06/ExclusiveMinimumConstraint.php
+++ b/src/JsonSchema/Constraints/Drafts/Draft06/ExclusiveMinimumConstraint.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JsonSchema\Constraints\Drafts\Draft06;
+
+use JsonSchema\ConstraintError;
+use JsonSchema\Constraints\ConstraintInterface;
+use JsonSchema\Constraints\Factory;
+use JsonSchema\Entity\ErrorBagProxy;
+use JsonSchema\Entity\JsonPointer;
+
+class ExclusiveMinimumConstraint implements ConstraintInterface
+{
+    use ErrorBagProxy;
+
+    public function __construct(?Factory $factory = null)
+    {
+        $this->initialiseErrorBag($factory ?: new Factory());
+    }
+
+    public function check(&$value, $schema = null, ?JsonPointer $path = null, $i = null): void
+    {
+        if (!property_exists($schema, 'exclusiveMinimum')) {
+            return;
+        }
+
+        if ($value > $schema->exclusiveMinimum) {
+            return;
+        }
+
+        $this->addError(ConstraintError::EXCLUSIVE_MINIMUM(), $path, ['exclusiveMinimum' => $schema->exclusiveMinimum, 'found' => $value]);
+    }
+}

--- a/src/JsonSchema/Constraints/Drafts/Draft06/Factory.php
+++ b/src/JsonSchema/Constraints/Drafts/Draft06/Factory.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JsonSchema\Constraints\Drafts\Draft06;
+
+class Factory extends \JsonSchema\Constraints\Factory
+{
+    /**
+     * @var array<string, class-string>
+     */
+    protected $constraintMap = [
+        'type' => TypeConstraint::class,
+        'const' => ConstConstraint::class,
+        'enum' => EnumConstraint::class,
+        'number' => NumberConstraint::class,
+        'uniqueItems' => UniqueItemsConstraint::class,
+        'minItems' => MinItemsConstraint::class,
+        'minProperties' => MinPropertiesConstraint::class,
+        'minimum' => MinimumConstraint::class,
+        'exclusiveMinimum' => ExclusiveMinimumConstraint::class,
+        'minLength' => MinLengthConstraint::class,
+        'maxItems' => MaxItemsConstraint::class,
+    ];
+}

--- a/src/JsonSchema/Constraints/Drafts/Draft06/MaxItemsConstraint.php
+++ b/src/JsonSchema/Constraints/Drafts/Draft06/MaxItemsConstraint.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JsonSchema\Constraints\Drafts\Draft06;
+
+use JsonSchema\ConstraintError;
+use JsonSchema\Constraints\ConstraintInterface;
+use JsonSchema\Constraints\Factory;
+use JsonSchema\Entity\ErrorBagProxy;
+use JsonSchema\Entity\JsonPointer;
+
+class MaxItemsConstraint implements ConstraintInterface
+{
+    use ErrorBagProxy;
+
+    public function __construct(?Factory $factory = null)
+    {
+        $this->initialiseErrorBag($factory ?: new Factory());
+    }
+
+    public function check(&$value, $schema = null, ?JsonPointer $path = null, $i = null): void
+    {
+        if (!property_exists($schema, 'maxItems')) {
+            return;
+        }
+
+        if (!is_array($value)) {
+            return;
+        }
+
+        $count = count($value);
+        if ($count <= $schema->maxItems) {
+            return;
+        }
+
+        $this->addError(ConstraintError::MAX_ITEMS(), $path, ['maxItems' => $schema->maxItems, 'found' => $count]);
+    }
+}

--- a/src/JsonSchema/Constraints/Drafts/Draft06/MinItemsConstraint.php
+++ b/src/JsonSchema/Constraints/Drafts/Draft06/MinItemsConstraint.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JsonSchema\Constraints\Drafts\Draft06;
+
+use JsonSchema\ConstraintError;
+use JsonSchema\Constraints\ConstraintInterface;
+use JsonSchema\Constraints\Factory;
+use JsonSchema\Entity\ErrorBagProxy;
+use JsonSchema\Entity\JsonPointer;
+
+class MinItemsConstraint implements ConstraintInterface
+{
+    use ErrorBagProxy;
+
+    public function __construct(?Factory $factory = null)
+    {
+        $this->initialiseErrorBag($factory ?: new Factory());
+    }
+
+    public function check(&$value, $schema = null, ?JsonPointer $path = null, $i = null): void
+    {
+        if (!property_exists($schema, 'minItems')) {
+            return;
+        }
+
+        if (!is_array($value)) {
+            return;
+        }
+
+        $count = count($value);
+        if ($count >= $schema->minItems) {
+            return;
+        }
+
+        $this->addError(ConstraintError::MIN_ITEMS(), $path, ['minItems' => $schema->minItems, 'found' => $count]);
+    }
+}

--- a/src/JsonSchema/Constraints/Drafts/Draft06/MinLengthConstraint.php
+++ b/src/JsonSchema/Constraints/Drafts/Draft06/MinLengthConstraint.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JsonSchema\Constraints\Drafts\Draft06;
+
+use JsonSchema\ConstraintError;
+use JsonSchema\Constraints\ConstraintInterface;
+use JsonSchema\Constraints\Factory;
+use JsonSchema\Entity\ErrorBagProxy;
+use JsonSchema\Entity\JsonPointer;
+
+class MinLengthConstraint implements ConstraintInterface
+{
+    use ErrorBagProxy;
+
+    public function __construct(?Factory $factory = null)
+    {
+        $this->initialiseErrorBag($factory ?: new Factory());
+    }
+
+    public function check(&$value, $schema = null, ?JsonPointer $path = null, $i = null): void
+    {
+        if (!property_exists($schema, 'minLength')) {
+            return;
+        }
+
+        if (!is_string($value)) {
+            return;
+        }
+
+        $length = mb_strlen($value);
+        if ($length >= $schema->minLength) {
+            return;
+        }
+
+        $this->addError(ConstraintError::LENGTH_MIN(), $path, ['minLength' => $schema->minLength, 'found' => $length]);
+    }
+}

--- a/src/JsonSchema/Constraints/Drafts/Draft06/MinPropertiesConstraint.php
+++ b/src/JsonSchema/Constraints/Drafts/Draft06/MinPropertiesConstraint.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JsonSchema\Constraints\Drafts\Draft06;
+
+use JsonSchema\ConstraintError;
+use JsonSchema\Constraints\ConstraintInterface;
+use JsonSchema\Constraints\Factory;
+use JsonSchema\Entity\ErrorBagProxy;
+use JsonSchema\Entity\JsonPointer;
+
+class MinPropertiesConstraint implements ConstraintInterface
+{
+    use ErrorBagProxy;
+
+    public function __construct(?Factory $factory = null)
+    {
+        $this->initialiseErrorBag($factory ?: new Factory());
+    }
+
+    public function check(&$value, $schema = null, ?JsonPointer $path = null, $i = null): void
+    {
+        if (!property_exists($schema, 'minProperties')) {
+            return;
+        }
+
+        if (!is_object($value)) {
+            return;
+        }
+
+        $count = count(get_object_vars($value));
+        if ($count >= $schema->minProperties) {
+            return;
+        }
+
+        $this->addError(ConstraintError::PROPERTIES_MIN(), $path, ['minProperties' => $schema->minProperties, 'found' => $count]);
+    }
+}

--- a/src/JsonSchema/Constraints/Drafts/Draft06/MinimumConstraint.php
+++ b/src/JsonSchema/Constraints/Drafts/Draft06/MinimumConstraint.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JsonSchema\Constraints\Drafts\Draft06;
+
+use JsonSchema\ConstraintError;
+use JsonSchema\Constraints\ConstraintInterface;
+use JsonSchema\Constraints\Factory;
+use JsonSchema\Entity\ErrorBagProxy;
+use JsonSchema\Entity\JsonPointer;
+
+class MinimumConstraint implements ConstraintInterface
+{
+    use ErrorBagProxy;
+
+    public function __construct(?Factory $factory = null)
+    {
+        $this->initialiseErrorBag($factory ?: new Factory());
+    }
+
+    public function check(&$value, $schema = null, ?JsonPointer $path = null, $i = null): void
+    {
+        if (!property_exists($schema, 'minimum')) {
+            return;
+        }
+
+        if ($value >= $schema->minimum) {
+            return;
+        }
+
+        $this->addError(ConstraintError::MINIMUM(), $path, ['minimum' => $schema->minimum, 'found' => $value]);
+    }
+}

--- a/src/JsonSchema/Constraints/Drafts/Draft06/NumberConstraint.php
+++ b/src/JsonSchema/Constraints/Drafts/Draft06/NumberConstraint.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JsonSchema\Constraints\Drafts\Draft06;
+
+use JsonSchema\Constraints\ConstraintInterface;
+use JsonSchema\Constraints\Factory;
+use JsonSchema\Entity\ErrorBagProxy;
+use JsonSchema\Entity\JsonPointer;
+
+class NumberConstraint implements ConstraintInterface
+{
+    use ErrorBagProxy;
+
+    public function __construct(?Factory $factory = null)
+    {
+        $this->initialiseErrorBag($factory ?: new Factory());
+    }
+
+    public function check(&$value, $schema = null, ?JsonPointer $path = null, $i = null): void
+    {
+        if (!property_exists($schema, 'type')) {
+            return;
+        }
+
+        throw new \Exception('Implement check method');
+    }
+}

--- a/src/JsonSchema/Constraints/Drafts/Draft06/TypeConstraint.php
+++ b/src/JsonSchema/Constraints/Drafts/Draft06/TypeConstraint.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JsonSchema\Constraints\Drafts\Draft06;
+
+use JsonSchema\Constraints\ConstraintInterface;
+use JsonSchema\Constraints\Factory;
+use JsonSchema\Entity\ErrorBagProxy;
+use JsonSchema\Entity\JsonPointer;
+
+class TypeConstraint implements ConstraintInterface
+{
+    use ErrorBagProxy;
+
+    public function __construct(?Factory $factory = null)
+    {
+        $this->initialiseErrorBag($factory ?: new Factory());
+    }
+
+    public function check(&$value, $schema = null, ?JsonPointer $path = null, $i = null): void
+    {
+        if (!property_exists($schema, 'type')) {
+            return;
+        }
+
+        throw new \Exception('Implement check method');
+    }
+}

--- a/src/JsonSchema/Constraints/Drafts/Draft06/UniqueItemsConstraint.php
+++ b/src/JsonSchema/Constraints/Drafts/Draft06/UniqueItemsConstraint.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JsonSchema\Constraints\Drafts\Draft06;
+
+use JsonSchema\ConstraintError;
+use JsonSchema\Constraints\ConstraintInterface;
+use JsonSchema\Constraints\Factory;
+use JsonSchema\Entity\ErrorBagProxy;
+use JsonSchema\Entity\JsonPointer;
+use JsonSchema\Tool\DeepComparer;
+
+class UniqueItemsConstraint implements ConstraintInterface
+{
+    use ErrorBagProxy;
+
+    public function __construct(?Factory $factory = null)
+    {
+        $this->initialiseErrorBag($factory ?: new Factory());
+    }
+
+    public function check(&$value, $schema = null, ?JsonPointer $path = null, $i = null): void
+    {
+        if (!property_exists($schema, 'uniqueItems')) {
+            return;
+        }
+
+        if ($schema->uniqueItems !== true) {
+            // If unique items not is true duplicates are allowed.
+            return;
+        }
+
+        $count = count($value);
+        for ($x = 0; $x < $count - 1; $x++) {
+            for ($y = $x + 1; $y < $count; $y++) {
+                if (DeepComparer::isEqual($value[$x], $value[$y])) {
+                    $this->addError(ConstraintError::UNIQUE_ITEMS(), $path);
+                    return;
+                }
+            }
+        }
+    }
+}

--- a/src/JsonSchema/Constraints/Factory.php
+++ b/src/JsonSchema/Constraints/Factory.php
@@ -65,7 +65,8 @@ class Factory
         'const' => 'JsonSchema\Constraints\ConstConstraint',
         'format' => 'JsonSchema\Constraints\FormatConstraint',
         'schema' => 'JsonSchema\Constraints\SchemaConstraint',
-        'validator' => 'JsonSchema\Validator'
+        'validator' => 'JsonSchema\Validator',
+        'draft06' => Drafts\Draft06\Draft06Constraint::class,
     ];
 
     /**

--- a/src/JsonSchema/Entity/ErrorBag.php
+++ b/src/JsonSchema/Entity/ErrorBag.php
@@ -1,0 +1,105 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JsonSchema\Entity;
+
+use JsonSchema\ConstraintError;
+use JsonSchema\Constraints\Constraint;
+use JsonSchema\Constraints\Factory;
+use JsonSchema\Exception\ValidationException;
+use JsonSchema\Validator;
+
+/**
+ * @phpstan-type Error array{
+ *     property: string,
+ *     pointer: string,
+ *     message: string,
+ *     constraint: array{name: string, params: array<string, mixed>},
+ *     context: int
+ * }
+ * @phpstan-type ErrorList list<Error>
+ */
+class ErrorBag
+{
+    /** @var Factory */
+    private $factory;
+
+    /** @var ErrorList */
+    private $errors = [];
+
+    /**
+     * @var int All error types that have occurred
+     * @phpstan-var int-mask-of<Validator::ERROR_*>
+     */
+    protected $errorMask = Validator::ERROR_NONE;
+
+    public function __construct(Factory $factory)
+    {
+        $this->factory = $factory;
+    }
+
+    /** @return ErrorList */
+    public function getErrors(): array
+    {
+        return $this->errors;
+    }
+
+    /** @param array<string, mixed> $more */
+    public function addError(ConstraintError $constraint, ?JsonPointer $path = null, array $more = []): void
+    {
+        $message = $constraint->getMessage();
+        $name = $constraint->getValue();
+        $error = [
+            'property' => $this->convertJsonPointerIntoPropertyPath($path ?: new JsonPointer('')),
+            'pointer' => ltrim((string) ($path ?: new JsonPointer('')), '#'),
+            'message' => ucfirst(vsprintf($message, array_map(static function ($val) {
+                if (is_scalar($val)) {
+                    return is_bool($val) ? var_export($val, true) : $val;
+                }
+
+                return json_encode($val);
+            }, array_values($more)))),
+            'constraint' => [
+                'name' => $name,
+                'params' => $more
+            ],
+            'context' => $this->factory->getErrorContext(),
+        ];
+
+        if ($this->factory->getConfig(Constraint::CHECK_MODE_EXCEPTIONS)) {
+            throw new ValidationException(sprintf('Error validating %s: %s', $error['pointer'], $error['message']));
+        }
+
+        $this->errors[] = $error;
+        $this->errorMask |= $error['context'];
+    }
+
+    /** @param ErrorList $errors */
+    public function addErrors(array $errors): void
+    {
+        if (! $errors) {
+            return;
+        }
+
+        $this->errors = array_merge($this->errors, $errors);
+        $errorMask = &$this->errorMask;
+        array_walk($errors, static function ($error) use (&$errorMask) {
+            if (isset($error['context'])) {
+                $errorMask |= $error['context'];
+            }
+        });
+    }
+
+    private function convertJsonPointerIntoPropertyPath(JsonPointer $pointer): string
+    {
+        $result = array_map(
+            static function ($path) {
+                return sprintf(is_numeric($path) ? '[%d]' : '.%s', $path);
+            },
+            $pointer->getPropertyPaths()
+        );
+
+        return trim(implode('', $result), '.');
+    }
+}

--- a/src/JsonSchema/Entity/ErrorBagProxy.php
+++ b/src/JsonSchema/Entity/ErrorBagProxy.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JsonSchema\Entity;
+
+use JsonSchema\ConstraintError;
+use JsonSchema\Constraints\Factory;
+
+/**
+ * @phpstan-import-type Error from ErrorBag
+ * @phpstan-import-type ErrorList from ErrorBag
+ */
+trait ErrorBagProxy
+{
+    /** @var ErrorBag */
+    protected $errorBag;
+
+    /** @return ErrorList */
+    public function getErrors(): array
+    {
+        return $this->errorBag()->getErrors();
+    }
+
+    /** @param ErrorList $errors */
+    public function addErrors(array $errors): void
+    {
+        $this->errorBag()->addErrors($errors);
+    }
+
+    /**
+     * @param array $more more array elements to add to the error
+     */
+    public function addError(ConstraintError $constraint, ?JsonPointer $path = null, array $more = []): void
+    {
+        $this->errorBag()->addError($constraint, $path, $more);
+    }
+
+    public function isValid(): bool
+    {
+        return $this->errorBag()->getErrors() === [];
+    }
+
+    protected function initialiseErrorBag(Factory $factory): ErrorBag
+    {
+        if (!isset($this->errorBag)) {
+            $this->errorBag = new ErrorBag($factory);
+        }
+
+        return $this->errorBag;
+    }
+
+    protected function errorBag(): ErrorBag
+    {
+        if (!isset($this->errorBag)) {
+            throw new \RuntimeException('ErrorBag not initialized');
+        }
+
+        return $this->errorBag;
+    }
+}

--- a/tests/Constraints/VeryBaseTestCase.php
+++ b/tests/Constraints/VeryBaseTestCase.php
@@ -17,7 +17,11 @@ abstract class VeryBaseTestCase extends TestCase
     /** @var array<string, stdClass> */
     private $draftSchemas = [];
 
-    protected function getUriRetrieverMock(?object $schema): object
+    /**
+     * @param object|bool|null $schema
+     * @return object
+     */
+    protected function getUriRetrieverMock($schema): object
     {
         $uriRetriever = $this->prophesize(UriRetrieverInterface::class);
         $uriRetriever->retrieve($schema->id ?? 'http://www.my-domain.com/schema.json')

--- a/tests/JsonSchemaTestSuiteTest.php
+++ b/tests/JsonSchemaTestSuiteTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace JsonSchema\Tests;
 
 use CallbackFilterIterator;
+use JsonSchema\Constraints\Constraint;
 use JsonSchema\Constraints\Factory;
 use JsonSchema\SchemaStorage;
 use JsonSchema\SchemaStorageInterface;
@@ -35,7 +36,7 @@ class JsonSchemaTestSuiteTest extends TestCase
         $validator = new Validator(new Factory($schemaStorage));
 
         try {
-            $validator->validate($data, $schema);
+            $validator->validate($data, $schema, Constraint::CHECK_MODE_NORMAL | Constraint::CHECK_MODE_STRICT);
         } catch (\Exception $e) {
             if ($optional) {
                 $this->markTestSkipped('Optional test case would during validate() invocation');
@@ -57,7 +58,7 @@ class JsonSchemaTestSuiteTest extends TestCase
         $drafts = array_filter(glob($testDir . '/*'), static function (string $filename) {
             return is_dir($filename);
         });
-        $skippedDrafts = ['draft6', 'draft7', 'draft2019-09', 'draft2020-12', 'draft-next', 'latest'];
+        $skippedDrafts = ['draft3', 'draft4', 'draft7', 'draft2019-09', 'draft2020-12', 'draft-next', 'latest'];
 
         foreach ($drafts as $draft) {
             if (in_array(basename($draft), $skippedDrafts, true)) {
@@ -76,6 +77,9 @@ class JsonSchemaTestSuiteTest extends TestCase
             foreach ($files as $file) {
                 $contents = json_decode(file_get_contents($file->getPathname()), false);
                 foreach ($contents as $testCase) {
+                    if (is_object($testCase->schema)) {
+                        $testCase->schema->{'$schema'} = 'http://json-schema.org/draft-06/schema#'; // Hardcode $schema property in schema
+                    }
                     foreach ($testCase->tests as $test) {
                         $name = sprintf(
                             '[%s/%s%s]: %s: %s is expected to be %s',


### PR DESCRIPTION
⚠️ This is a draft PR as some blockers have been resolved breaking other things in order to get a proof of concept of the approach for supporting multiple drafts.

This PR will:
- Introduce the `JsonSchema\Constraints\Drafts\Draft06` namespace
- A constraint per keyword
- Enable the `draft6` in the test, locally I have 633 passing test, 312 failing tests and 157 ignored tests.