### PR TITLE
Fix PHP 8.5 $http_response_header deprecation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Update test case to current (PHP) standards ([#831](https://github.com/jsonrainbow/json-schema/pull/831))
 - Upgrade test suite to use generators ([#834](https://github.com/jsonrainbow/json-schema/pull/834))
 - update to latest json schema test suite ([#821](https://github.com/jsonrainbow/json-schema/pull/821))
+- ### Fixed
+- Fix PHP 8.5 $http_response_header deprecation ([#840](https://github.com/jsonrainbow/json-schema/pull/840))
 
 ## [6.4.2] - 2025-06-03
 ### Fixed

--- a/src/JsonSchema/Uri/Retrievers/FileGetContents.php
+++ b/src/JsonSchema/Uri/Retrievers/FileGetContents.php
@@ -52,6 +52,8 @@ class FileGetContents extends AbstractRetriever
 
         $this->messageBody = $response;
         if (function_exists('http_get_last_response_headers')) {
+            // Use http_get_last_response_headers() for BC compatibility with PHP 8.5+
+            // where $http_response_header is deprecated.
             $http_response_header = http_get_last_response_headers();
         }
         if (!empty($http_response_header)) {

--- a/src/JsonSchema/Uri/Retrievers/FileGetContents.php
+++ b/src/JsonSchema/Uri/Retrievers/FileGetContents.php
@@ -51,6 +51,9 @@ class FileGetContents extends AbstractRetriever
         }
 
         $this->messageBody = $response;
+        if (function_exists('http_get_last_response_headers')) {
+            $http_response_header = http_get_last_response_headers();
+        }
         if (!empty($http_response_header)) {
             // $http_response_header cannot be tested, because it's defined in the method's local scope
             // See http://php.net/manual/en/reserved.variables.httpresponseheader.php for more info.


### PR DESCRIPTION
Replaces #840 (due to blocked write access on fork)