### PR TITLE
Fix issue when http headers are already present

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Fix issue when http headers are already present ([#843](https://github.com/jsonrainbow/json-schema/pull/843))
 
 ## [6.5.1] - 2025-08-29
 ### Changed

--- a/src/JsonSchema/Uri/Retrievers/FileGetContents.php
+++ b/src/JsonSchema/Uri/Retrievers/FileGetContents.php
@@ -29,6 +29,10 @@ class FileGetContents extends AbstractRetriever
      */
     public function retrieve($uri)
     {
+        if (function_exists('http_clear_last_response_headers')) {
+            http_clear_last_response_headers();
+        }
+
         $errorMessage = null;
         set_error_handler(function ($errno, $errstr) use (&$errorMessage) {
             $errorMessage = $errstr;


### PR DESCRIPTION
This fixes a regression introduced in https://github.com/jsonrainbow/json-schema/pull/841

If a process/request runs:

- file_get_contents on an HTTP URL.
- then a json-schema validation using a file://... URL as schema (not all schema are remotely loaded)
- and `http_get_last_response_headers()` is available

Then you end up with:

- file_get_contents on the URL fills up the headers of that request
- json-schema validation loads the schema file but using file:// there are no headers, and it seems like file_get_contents does not clear previous headers itself
- http_get_last_response_headers() then returns the headers of the previous request
- and then `$this->fetchContentType()` will fail unless the response headers were of the correct `application/schema+json` mime type (which is very unlikely).

So this PR clears the headers before we fetch the schema, to make sure we have a clean slate. I'll probably report this to PHP as well because IMO it is a bit surprising.