### PR TITLE
Update composer.json authors to reflect current active maintainer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,20 +10,9 @@
     "license": "MIT",
     "authors": [
         {
-            "name": "Bruno Prieto Reis",
-            "email": "bruno.p.reis@gmail.com"
-        },
-        {
-            "name": "Justin Rainbow",
-            "email": "justin.rainbow@gmail.com"
-        },
-        {
-            "name": "Igor Wiedler",
-            "email": "igor@wiedler.ch"
-        },
-        {
-            "name": "Robert Schönthal",
-            "email": "seroscho@googlemail.com"
+            "name": "Danny van der Sluijs",
+            "email": "danny.vandersluijs@icloud.com",
+            "role": "Maintainer"
         }
     ],
     "require": {


### PR DESCRIPTION
## Summary
- Replaces the `authors` array in `composer.json`, which still listed the four original founders (inactive for years), with the current active maintainer.
- Founders' contributions remain fully credited via git history and the README contributor graph — this only updates the package metadata used by Packagist/Composer.

## Why
See #927 for full rationale. Short version: keeping inactive founders listed as authors implies they're responsible for present-day issues (e.g. CVEs) they have no involvement in, and doesn't let people reach out to whoever is actually maintaining the project today.

Closes #927

## Test plan
- [x] `php -r "json_decode(file_get_contents('composer.json')); echo json_last_error_msg();"` → `No error`
- [x] `composer validate` → composer.json itself reports valid (unrelated pre-existing lock file drift noted, not touched by this change)