### PR TITLE
feat: Add --allow-invalid-content-type-endpoint option to validate-json

### DIFF
--- a/bin/validate-json
+++ b/bin/validate-json
@@ -23,13 +23,40 @@ require($composerAutoload);
 $arOptions = [];
 $arArgs = [];
 array_shift($argv);//script itself
-foreach ($argv as $arg) {
-    if (strpos($arg, '--allow-invalid-content-type-endpoint=') === 0) {
-        $endpoint = substr($arg, strlen('--allow-invalid-content-type-endpoint='));
-        if ($endpoint !== '') {
-            $arOptions['--allow-invalid-content-type-endpoint'][] = $endpoint;
+
+// options that take a value; each may be repeated
+$multiValueOptions = [
+    '--allow-invalid-content-type-endpoint',
+];
+
+$argCount = count($argv);
+for ($i = 0; $i < $argCount; $i++) {
+    $arg = $argv[$i];
+
+    foreach ($multiValueOptions as $valueOption) {
+        if ($arg === $valueOption) {
+            // space-separated form: --option <value>
+            if (!isset($argv[$i + 1]) || strpos($argv[$i + 1], '-') === 0) {
+                output("Missing value for $valueOption\n");
+                exit(1);
+            }
+            $arOptions[$valueOption][] = $argv[++$i];
+            continue 2;
         }
-    } elseif ($arg[0] == '-') {
+
+        if (strpos($arg, $valueOption . '=') === 0) {
+            // equals form: --option=<value>
+            $value = substr($arg, strlen($valueOption . '='));
+            if ($value === '') {
+                output("Missing value for $valueOption\n");
+                exit(1);
+            }
+            $arOptions[$valueOption][] = $value;
+            continue 2;
+        }
+    }
+
+    if ($arg[0] == '-') {
         $arOptions[$arg] = true;
     } else {
         $arArgs[] = $arg;

--- a/bin/validate-json
+++ b/bin/validate-json
@@ -257,7 +257,7 @@ if (isset($arOptions['--dump-schema'])) {
 }
 
 try {
-    $validator = new JsonSchema\Validator();
+    $validator = new JsonSchema\Validator(new JsonSchema\Constraints\Factory($refResolver, $retriever));
     $validator->validate($data, $schema);
 
     if ($validator->isValid()) {

--- a/bin/validate-json
+++ b/bin/validate-json
@@ -24,7 +24,12 @@ $arOptions = [];
 $arArgs = [];
 array_shift($argv);//script itself
 foreach ($argv as $arg) {
-    if ($arg[0] == '-') {
+    if (strpos($arg, '--allow-invalid-content-type-endpoint=') === 0) {
+        $endpoint = substr($arg, strlen('--allow-invalid-content-type-endpoint='));
+        if ($endpoint !== '') {
+            $arOptions['--allow-invalid-content-type-endpoint'][] = $endpoint;
+        }
+    } elseif ($arg[0] == '-') {
         $arOptions[$arg] = true;
     } else {
         $arArgs[] = $arg;
@@ -42,6 +47,10 @@ Usage: validate-json data.json
 Options:
       --dump-schema     Output full schema and exit
       --dump-schema-url Output URL of schema
+      --allow-invalid-content-type-endpoint=<url>
+                        Skip the Content-Type check for schemas fetched
+                        from the given URL prefix. May be given multiple
+                        times.
       --verbose         Show additional output
       --quiet           Suppress all output
    -h --help            Show this help
@@ -191,6 +200,13 @@ if ($pathSchema[0] == '/') {
 
 $resolver = new JsonSchema\Uri\UriResolver();
 $retriever = new JsonSchema\Uri\UriRetriever();
+if (isset($arOptions['--allow-invalid-content-type-endpoint'])
+    && is_array($arOptions['--allow-invalid-content-type-endpoint'])
+) {
+    foreach ($arOptions['--allow-invalid-content-type-endpoint'] as $endpoint) {
+        $retriever->addInvalidContentTypeEndpoint($endpoint);
+    }
+}
 try {
     $urlSchema = $resolver->resolve($pathSchema, $urlData);
 


### PR DESCRIPTION
## Description

The `validate-json` CLI now accepts a repeatable `--allow-invalid-content-type-endpoint=<url>` option. Each URL prefix is registered on the UriRetriever via the existing `addInvalidContentTypeEndpoint()` method, bypassing the schema media type check for schemas fetched from that host.

## Related Issue

N/A

## Type of Change

<!-- Mark the appropriate option with an "x" -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Other (please describe):

## Checklist

<!-- Mark completed items with an "x" -->

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) guidelines
- [x] My code follows the code style of this project
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] All new and existing tests pass
- [ ] I have updated the documentation accordingly
- [x] My changes generate no new warnings

## Additional Notes

### Example use case:
WordPress's `theme.json` uses `https://schemas.wp.org/trunk/theme.json` as its JSON schema (docs here: https://developer.wordpress.org/block-editor/reference-guides/theme-json-reference/theme-json-living/). That URL redirects to `https://raw.githubusercontent.com/WordPress/gutenberg/trunk/schemas/json/theme.json`, which serves `Content-Type: text/plain; charset=utf-8`, so running
```
vendor/bin/validate-json theme.json https://schemas.wp.org/trunk/theme.json
```
fails with `InvalidSchemaMediaTypeException`.

With the included changes, passing `--allow-invalid-content-type-endpoint=https://schemas.wp.org/` whitelists the requested host and lets the validation run.
```
vendor/bin/validate-json theme.json https://schemas.wp.org/trunk/theme.json --allow-invalid-content-type-endpoint=https://schemas.wp.org/
```
