### PR TITLE
fix: Ignore Content-Type header parameters when checking media type

### DIFF
--- a/src/JsonSchema/Uri/Retrievers/Curl.php
+++ b/src/JsonSchema/Uri/Retrievers/Curl.php
@@ -76,7 +76,7 @@ class Curl extends AbstractRetriever
      */
     protected function fetchContentType($response)
     {
-        if (0 < preg_match("/Content-Type:(\V*)/ims", $response, $match)) {
+        if (0 < preg_match("/Content-Type:([^;\v]*)/ims", $response, $match)) {
             $this->contentType = trim($match[1]);
 
             return true;

--- a/src/JsonSchema/Uri/Retrievers/Curl.php
+++ b/src/JsonSchema/Uri/Retrievers/Curl.php
@@ -76,7 +76,7 @@ class Curl extends AbstractRetriever
      */
     protected function fetchContentType($response)
     {
-        if (0 < preg_match("/Content-Type:([^;\v]*)/ims", $response, $match)) {
+        if (0 < preg_match('/^Content-Type:([^;\v]*)/im', $response, $match)) {
             $this->contentType = trim($match[1]);
 
             return true;

--- a/src/JsonSchema/Uri/Retrievers/FileGetContents.php
+++ b/src/JsonSchema/Uri/Retrievers/FileGetContents.php
@@ -97,7 +97,7 @@ class FileGetContents extends AbstractRetriever
      */
     protected static function getContentTypeMatchInHeader($header)
     {
-        if (0 < preg_match("/Content-Type:(\V*)/ims", $header, $match)) {
+        if (0 < preg_match("/Content-Type:([^;\v]*)/ims", $header, $match)) {
             return trim($match[1]);
         }
 

--- a/src/JsonSchema/Uri/Retrievers/FileGetContents.php
+++ b/src/JsonSchema/Uri/Retrievers/FileGetContents.php
@@ -97,7 +97,7 @@ class FileGetContents extends AbstractRetriever
      */
     protected static function getContentTypeMatchInHeader($header)
     {
-        if (0 < preg_match("/Content-Type:([^;\v]*)/ims", $header, $match)) {
+        if (0 < preg_match('/^Content-Type:([^;\v]*)/im', $header, $match)) {
             return trim($match[1]);
         }
 

--- a/tests/Uri/Retrievers/CurlTest.php
+++ b/tests/Uri/Retrievers/CurlTest.php
@@ -38,7 +38,7 @@ namespace JsonSchema\Tests\Uri\Retrievers
         /**
          * @dataProvider contentTypeParameterProvider
          */
-        public function testContentTypeIgnoresParameters(string $response, string $expected): void
+        public function testContentTypeIgnoresParameters(string $response, ?string $expected, bool $matches): void
         {
             $c = new Curl();
 
@@ -48,16 +48,18 @@ namespace JsonSchema\Tests\Uri\Retrievers
                 $fetchContentType->setAccessible(true);
             }
 
-            $this->assertTrue($fetchContentType->invoke($c, $response));
+            $this->assertSame($matches, $fetchContentType->invoke($c, $response));
             $this->assertSame($expected, $c->getContentType());
         }
 
         public function contentTypeParameterProvider(): array
         {
             return [
-                'json with charset' => ["Content-Type: application/json; charset=utf-8\r\n\r\n{}", 'application/json'],
-                'schema media type with charset' => ["Content-Type: application/schema+json; charset=utf-8\r\n\r\n{}", 'application/schema+json'],
-                'multiple parameters' => ["Content-Type: application/json; charset=utf-8; profile=schema\r\n\r\n{}", 'application/json'],
+                'json without parameters' => ["Content-Type: application/json\r\n\r\n{}", 'application/json', true],
+                'json with charset' => ["Content-Type: application/json; charset=utf-8\r\n\r\n{}", 'application/json', true],
+                'schema media type with charset' => ["Content-Type: application/schema+json; charset=utf-8\r\n\r\n{}", 'application/schema+json', true],
+                'multiple parameters' => ["Content-Type: application/json; charset=utf-8; profile=schema\r\n\r\n{}", 'application/json', true],
+                'X-Content-Type is not a content type' => ["HTTP/1.1 200 OK\r\nX-Content-Type: text/plain\r\n\r\n{}", null, false],
             ];
         }
     }

--- a/tests/Uri/Retrievers/CurlTest.php
+++ b/tests/Uri/Retrievers/CurlTest.php
@@ -36,9 +36,9 @@ namespace JsonSchema\Tests\Uri\Retrievers
         }
 
         /**
-         * @dataProvider contentTypeParameterProvider
+         * @dataProvider contentTypeProvider
          */
-        public function testContentTypeIgnoresParameters(string $response, ?string $expected, bool $matches): void
+        public function testFetchContentType(string $response, ?string $expected, bool $matches): void
         {
             $c = new Curl();
 
@@ -52,7 +52,7 @@ namespace JsonSchema\Tests\Uri\Retrievers
             $this->assertSame($expected, $c->getContentType());
         }
 
-        public function contentTypeParameterProvider(): array
+        public function contentTypeProvider(): array
         {
             return [
                 'json without parameters' => ["Content-Type: application/json\r\n\r\n{}", 'application/json', true],

--- a/tests/Uri/Retrievers/CurlTest.php
+++ b/tests/Uri/Retrievers/CurlTest.php
@@ -34,6 +34,32 @@ namespace JsonSchema\Tests\Uri\Retrievers
 
             self::assertStringEqualsFileCanonicalizing(realpath(__DIR__ . '/../../fixtures/foobar.json'), $result);
         }
+
+        /**
+         * @dataProvider contentTypeParameterProvider
+         */
+        public function testContentTypeIgnoresParameters(string $response, string $expected): void
+        {
+            $c = new Curl();
+
+            $reflector = new \ReflectionObject($c);
+            $fetchContentType = $reflector->getMethod('fetchContentType');
+            if (PHP_VERSION_ID < 80100) {
+                $fetchContentType->setAccessible(true);
+            }
+
+            $this->assertTrue($fetchContentType->invoke($c, $response));
+            $this->assertSame($expected, $c->getContentType());
+        }
+
+        public function contentTypeParameterProvider(): array
+        {
+            return [
+                'json with charset' => ["Content-Type: application/json; charset=utf-8\r\n\r\n{}", 'application/json'],
+                'schema media type with charset' => ["Content-Type: application/schema+json; charset=utf-8\r\n\r\n{}", 'application/schema+json'],
+                'multiple parameters' => ["Content-Type: application/json; charset=utf-8; profile=schema\r\n\r\n{}", 'application/json'],
+            ];
+        }
     }
 }
 

--- a/tests/Uri/Retrievers/FileGetContentsTest.php
+++ b/tests/Uri/Retrievers/FileGetContentsTest.php
@@ -26,9 +26,9 @@ class FileGetContentsTest extends TestCase
     }
 
     /**
-     * @dataProvider contentTypeParameterProvider
+     * @dataProvider contentTypeProvider
      */
-    public function testContentTypeIgnoresParameters(string $header, ?string $expected, bool $matches): void
+    public function testFetchContentType(string $header, ?string $expected, bool $matches): void
     {
         $res = new FileGetContents();
 
@@ -42,7 +42,7 @@ class FileGetContentsTest extends TestCase
         $this->assertSame($expected, $res->getContentType());
     }
 
-    public function contentTypeParameterProvider(): array
+    public function contentTypeProvider(): array
     {
         return [
             'json without parameters' => ['Content-Type: application/json', 'application/json', true],

--- a/tests/Uri/Retrievers/FileGetContentsTest.php
+++ b/tests/Uri/Retrievers/FileGetContentsTest.php
@@ -25,24 +25,10 @@ class FileGetContentsTest extends TestCase
         $this->assertNotEmpty($result);
     }
 
-    public function testContentType(): void
-    {
-        $res = new FileGetContents();
-
-        $reflector = new \ReflectionObject($res);
-        $fetchContentType = $reflector->getMethod('fetchContentType');
-        if (PHP_VERSION_ID < 80100) {
-            $fetchContentType->setAccessible(true);
-        }
-
-        $this->assertTrue($fetchContentType->invoke($res, ['Content-Type: application/json']));
-        $this->assertFalse($fetchContentType->invoke($res, ['X-Some-Header: whateverValue']));
-    }
-
     /**
      * @dataProvider contentTypeParameterProvider
      */
-    public function testContentTypeIgnoresParameters(string $header, string $expected): void
+    public function testContentTypeIgnoresParameters(string $header, ?string $expected, bool $matches): void
     {
         $res = new FileGetContents();
 
@@ -52,16 +38,19 @@ class FileGetContentsTest extends TestCase
             $fetchContentType->setAccessible(true);
         }
 
-        $this->assertTrue($fetchContentType->invoke($res, [$header]));
+        $this->assertSame($matches, $fetchContentType->invoke($res, [$header]));
         $this->assertSame($expected, $res->getContentType());
     }
 
     public function contentTypeParameterProvider(): array
     {
         return [
-            'json with charset' => ['Content-Type: application/json; charset=utf-8', 'application/json'],
-            'schema media type with charset' => ['Content-Type: application/schema+json; charset=utf-8', 'application/schema+json'],
-            'multiple parameters' => ['Content-Type: application/json; charset=utf-8; profile=schema', 'application/json'],
+            'json without parameters' => ['Content-Type: application/json', 'application/json', true],
+            'json with charset' => ['Content-Type: application/json; charset=utf-8', 'application/json', true],
+            'schema media type with charset' => ['Content-Type: application/schema+json; charset=utf-8', 'application/schema+json', true],
+            'multiple parameters' => ['Content-Type: application/json; charset=utf-8; profile=schema', 'application/json', true],
+            'non-content-type header' => ['X-Some-Header: whateverValue', null, false],
+            'X-Content-Type is not a content type' => ['X-Content-Type: text/plain', null, false],
         ];
     }
 

--- a/tests/Uri/Retrievers/FileGetContentsTest.php
+++ b/tests/Uri/Retrievers/FileGetContentsTest.php
@@ -39,6 +39,32 @@ class FileGetContentsTest extends TestCase
         $this->assertFalse($fetchContentType->invoke($res, ['X-Some-Header: whateverValue']));
     }
 
+    /**
+     * @dataProvider contentTypeParameterProvider
+     */
+    public function testContentTypeIgnoresParameters(string $header, string $expected): void
+    {
+        $res = new FileGetContents();
+
+        $reflector = new \ReflectionObject($res);
+        $fetchContentType = $reflector->getMethod('fetchContentType');
+        if (PHP_VERSION_ID < 80100) {
+            $fetchContentType->setAccessible(true);
+        }
+
+        $this->assertTrue($fetchContentType->invoke($res, [$header]));
+        $this->assertSame($expected, $res->getContentType());
+    }
+
+    public function contentTypeParameterProvider(): array
+    {
+        return [
+            'json with charset' => ['Content-Type: application/json; charset=utf-8', 'application/json'],
+            'schema media type with charset' => ['Content-Type: application/schema+json; charset=utf-8', 'application/schema+json'],
+            'multiple parameters' => ['Content-Type: application/json; charset=utf-8; profile=schema', 'application/json'],
+        ];
+    }
+
     public function testCanHandleHttp301PermanentRedirect(): void
     {
         $res = new FileGetContents();


### PR DESCRIPTION
## Description

Both HTTP retrievers (`FileGetContents` and `Curl`) capture the raw `Content-Type` header value verbatim (regex `/Content-Type:(\V*)/ims`), charset included. CDNs serve schemas with e.g. `application/json; charset=utf-8`, which fails the exact media type check against `application/json` in `confirmMediaType()`.

RFC 8259 (JSON Data Interchange Format, https://www.rfc-editor.org/info/rfc8259/) does not define a charset parameter for the application/json media type: section 11 says "_No 'charset' parameter is defined for this registration. Adding one really has no effect on compliant recipients._". The parameter therefore must not affect the comparison.

In the updated version, the retrievers capture only up to the first `;` (`/Content-Type:([^;\v]*)/ims`), so the `Content-Type` is normalized to its base type before the check, ignoring any parameters.

CDN example: https://cdn.jsdelivr.net/gh/WordPress/gutenberg@trunk/schemas/json/theme.json.

## Related Issue

N/A

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Other (please describe):

## Checklist

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) guidelines
- [x] My code follows the code style of this project
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All new and existing tests pass
- [ ] I have updated the documentation accordingly
- [x] My changes generate no new warnings

## Additional Notes

N/A
