### PR TITLE
Fix RFC 3339 date-time validation with high-precision fractional seconds

### DIFF
--- a/src/JsonSchema/Rfc3339.php
+++ b/src/JsonSchema/Rfc3339.php
@@ -25,7 +25,7 @@ class Rfc3339
         $inputHasTSeparator = strpos($input, 'T');
 
         $dateAndTime = $matches[1];
-        $microseconds = $matches[5] ?: '.000000';
+        $microseconds = $matches[5] ? substr($matches[5], 0, 7) : '.000000';
         $timeZone = 'Z' !== $matches[6] ? $matches[6] : '+00:00';
         $dateFormat = $inputHasTSeparator === false ? 'Y-m-d H:i:s.uP' : 'Y-m-d\TH:i:s.uP';
         $dateTime = \DateTimeImmutable::createFromFormat($dateFormat, $dateAndTime . $microseconds . $timeZone, new \DateTimeZone('UTC'));

--- a/tests/Constraints/Draft06/FormatConstraintTest.php
+++ b/tests/Constraints/Draft06/FormatConstraintTest.php
@@ -20,15 +20,33 @@ class FormatConstraintTest extends VeryBaseTestCase
         $schema->format = $format;
 
         $validator->check($string, $schema);
+
         $this->assertCount(1, $validator->getErrors(), 'Expected 1 error');
+    }
+
+    /**
+     * @dataProvider getValidFormats
+     */
+    public function testValidFormat($string, $format): void
+    {
+        $validator = new FormatConstraint();
+        $schema = new \stdClass();
+        $schema->format = $format;
+
+        $validator->check($string, $schema);
+
+        $this->assertTrue($validator->isValid());
     }
 
     public function getInvalidFormats(): Generator
     {
         yield 'Date-time format with value containing null byte' => ["2020-01-01T12:34:56\x00", 'date-time'];
-
         yield 'Date format with value containing null byte' => ["2020-01-01\x00", 'date'];
-
         yield 'Time format with value containing null byte' => ["13:37:00\x00", 'time'];
+    }
+
+    public function getValidFormats(): Generator
+    {
+        yield 'Date-time format with value containing high-precision fractional seconds' => ['2020-01-01T12:00:02.0000001Z', 'date-time'];
     }
 }

--- a/tests/Constraints/Draft07/FormatConstraintTest.php
+++ b/tests/Constraints/Draft07/FormatConstraintTest.php
@@ -23,12 +23,29 @@ class FormatConstraintTest extends VeryBaseTestCase
         $this->assertCount(1, $validator->getErrors(), 'Expected 1 error');
     }
 
+    /**
+     * @dataProvider getValidFormats
+     */
+    public function testValidFormat($string, $format): void
+    {
+        $validator = new FormatConstraint();
+        $schema = new \stdClass();
+        $schema->format = $format;
+
+        $validator->check($string, $schema);
+
+        $this->assertTrue($validator->isValid());
+    }
+
     public function getInvalidFormats(): Generator
     {
         yield 'Date-time format with value containing null byte' => ["2020-01-01T12:34:56\x00", 'date-time'];
-
         yield 'Date format with value containing null byte' => ["2020-01-01\x00", 'date'];
-
         yield 'Time format with value containing null byte' => ["13:37:00\x00", 'time'];
+    }
+
+    public function getValidFormats(): Generator
+    {
+        yield 'Date-time format with value containing high-precision fractional seconds' => ['2020-01-01T12:00:02.0000001Z', 'date-time'];
     }
 }

--- a/tests/Constraints/Draft2019/FormatConstraintTest.php
+++ b/tests/Constraints/Draft2019/FormatConstraintTest.php
@@ -23,12 +23,29 @@ class FormatConstraintTest extends VeryBaseTestCase
         $this->assertCount(1, $validator->getErrors(), 'Expected 1 error');
     }
 
+    /**
+     * @dataProvider getValidFormats
+     */
+    public function testValidFormat($string, $format): void
+    {
+        $validator = new FormatConstraint();
+        $schema = new \stdClass();
+        $schema->format = $format;
+
+        $validator->check($string, $schema);
+
+        $this->assertTrue($validator->isValid());
+    }
+
     public function getInvalidFormats(): Generator
     {
         yield 'Date-time format with value containing null byte' => ["2020-01-01T12:34:56\x00", 'date-time'];
-
         yield 'Date format with value containing null byte' => ["2020-01-01\x00", 'date'];
-
         yield 'Time format with value containing null byte' => ["13:37:00\x00", 'time'];
+    }
+
+    public function getValidFormats(): Generator
+    {
+        yield 'Date-time format with value containing high-precision fractional seconds' => ['2020-01-01T12:00:02.0000001Z', 'date-time'];
     }
 }

--- a/tests/Constraints/FormatConstraintTest.php
+++ b/tests/Constraints/FormatConstraintTest.php
@@ -113,6 +113,7 @@ class FormatConstraintTest extends BaseTestCase
         yield ['2000-05-01T12:12:12.0Z', 'date-time'];
         yield ['2000-05-01T12:12:12.000Z', 'date-time'];
         yield ['2000-05-01T12:12:12.000000Z', 'date-time'];
+        yield ['2020-01-01T12:00:02.0000001Z', 'date-time'];
         yield [42, 'date-time'];
         yield [4.2, 'date-time'];
 

--- a/tests/Constraints/FormatConstraintTest.php
+++ b/tests/Constraints/FormatConstraintTest.php
@@ -113,7 +113,7 @@ class FormatConstraintTest extends BaseTestCase
         yield ['2000-05-01T12:12:12.0Z', 'date-time'];
         yield ['2000-05-01T12:12:12.000Z', 'date-time'];
         yield ['2000-05-01T12:12:12.000000Z', 'date-time'];
-        yield ['2020-01-01T12:00:02.0000001Z', 'date-time'];
+        yield 'Date-time format with value containing high-precision fractional seconds' => ['2020-01-01T12:00:02.0000001Z', 'date-time'];
         yield [42, 'date-time'];
         yield [4.2, 'date-time'];
 

--- a/tests/Rfc3339Test.php
+++ b/tests/Rfc3339Test.php
@@ -46,6 +46,18 @@ class Rfc3339Test extends TestCase
             '2000-05-01T12:12:12.123456Z',
             \DateTime::createFromFormat('Y-m-d\TH:i:s.u', '2000-05-01T12:12:12.123456', new \DateTimeZone('UTC'))
         ];
+        yield 'Zulu time - with seven fractional digits' => [
+            '2020-01-01T12:00:02.0000001Z',
+            \DateTime::createFromFormat('Y-m-d\TH:i:s.u', '2020-01-01T12:00:02.000000', new \DateTimeZone('UTC'))
+        ];
+        yield 'Zulu time - with nine fractional digits' => [
+            '2020-01-01T12:00:02.123456789Z',
+            \DateTime::createFromFormat('Y-m-d\TH:i:s.u', '2020-01-01T12:00:02.123456', new \DateTimeZone('UTC'))
+        ];
+        yield 'With time offset - with seven fractional digits' => [
+            '2020-01-01T12:00:02.1234567+01:00',
+            \DateTime::createFromFormat('Y-m-d\TH:i:s.uP', '2020-01-01T12:00:02.123456+01:00')
+        ];
         yield 'Zulu time - with milliseconds' => [
             '2000-05-01T12:12:12.123Z',
             \DateTime::createFromFormat('Y-m-d\TH:i:s.u', '2000-05-01T12:12:12.123000', new \DateTimeZone('UTC'))
@@ -67,5 +79,6 @@ class Rfc3339Test extends TestCase
         yield 'Missing leading zero in timezone offset - with colon' => ['1999-01-11T00:00:00+1:00'];
         yield 'Double space between date and time' => ['1999-01-01  00:00:00Z'];
         yield 'Missing leading zero in month - without T separator' => ['1999-1-11 00:00:00Z'];
+        yield 'Non-digit in long fractional seconds' => ['2020-01-01T12:00:02.123456aZ'];
     }
 }


### PR DESCRIPTION
## Description

Fix RFC 3339 `date-time` validation for timestamps containing more than six fractional-second digits.

RFC 3339 allows one or more digits in the fractional-second component, but PHP's `DateTimeImmutable::createFromFormat()` only accepts up to six microsecond digits.

The full input continues to be validated by the existing RFC 3339 pattern. Only the fractional component passed internally to `DateTimeImmutable` is truncated to six digits, avoiding PHP's parser limitation without rejecting otherwise valid RFC 3339 timestamps.

Regression tests have been added for fractional seconds beyond six digits, including timezone offsets.

## Related Issue

Fixes #929

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Other (please describe):

## Checklist

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) guidelines
- [x] My code follows the code style of this project
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All new and existing tests pass
- [ ] I have updated the documentation accordingly
- [x] My changes generate no new warnings

## Additional Notes

Tested with:

- Targeted RFC 3339 tests: 16 tests, 26 assertions
- Targeted format constraint tests: 162 tests, 180 assertions
- Full test suite: 3165 tests, 9808 assertions, 1 existing warning, 11 skipped
- PHPStan: 157/157 files, no errors

The existing PHPUnit warning is unchanged from the pre-change baseline.