### PR TITLE
Define minimal permissions on every workflow

### DIFF
--- a/.github/workflows/code-cov.yml
+++ b/.github/workflows/code-cov.yml
@@ -17,6 +17,9 @@ jobs:
 
     runs-on: ubuntu-latest
 
+    permissions:
+      contents: read
+
     steps:
       - name: "Checkout"
         uses: "actions/checkout@v5"

--- a/.github/workflows/continuous-integration-32-bits.yml
+++ b/.github/workflows/continuous-integration-32-bits.yml
@@ -18,6 +18,9 @@ jobs:
     name: "PHP 8.4 - 32-bits"
 
     runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
     container: shivammathur/node:latest-i386
 
     steps:

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -18,6 +18,9 @@ jobs:
     name: "PHP ${{ matrix.php-version }}, ${{ matrix.dependencies }} dependecies, experimental: ${{ matrix.experimental || false}}"
 
     runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
     continue-on-error: ${{ matrix.experimental || false }}
 
     strategy:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -15,6 +15,9 @@ jobs:
 
     runs-on: ubuntu-latest
 
+    permissions:
+      contents: read
+
     strategy:
       matrix:
         php-version:

--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -17,6 +17,9 @@ jobs:
 
     runs-on: ubuntu-latest
 
+    permissions:
+      contents: read
+
     strategy:
       matrix:
         php-version:

--- a/.github/workflows/style-check.yml
+++ b/.github/workflows/style-check.yml
@@ -16,6 +16,9 @@ jobs:
 
     runs-on: ubuntu-latest
 
+    permissions:
+      contents: read
+
     steps:
       - name: "Checkout"
         uses: "actions/checkout@v5"

--- a/.github/workflows/update-changelog.yml
+++ b/.github/workflows/update-changelog.yml
@@ -13,7 +13,6 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
-      pull-requests: read
 
     steps:
       - name: "Checkout"


### PR DESCRIPTION
Closes #936.

Six of the ten workflows had no `permissions:` block at all, so they ran with whatever the repository default grants. They now declare the minimum, at job level to match the four that already did.

### What each one actually needs

`code-cov`, `continuous-integration`, `continuous-integration-32-bits`, `lint`, `phpstan` and `style-check` all do the same three things: check out, install PHP, run a Composer script locally. None of them touches the GitHub API, so `contents: read` is enough. I checked rather than assumed: no `octokit`, no `gh`, no `GITHUB_TOKEN`, no `actions/github-script` anywhere in them.

Two details worth naming, since they look like they might need more and do not:

- `lint` and `style-check` pipe through `cs2pr`, and `continuous-integration` uses `::add-matcher::`. Both are workflow commands written to stdout, not API calls, so they need no permission.
- `code-cov` runs `composer coverage` and stops there. There is no upload step, so no token is involved despite the name.

### One reduction on an existing block

`update-changelog` declared `pull-requests: read` alongside `contents: write`. It reads the labels from `github.event.pull_request.labels`, which comes from the event payload rather than the API, and neither the workflow nor `bin/update-changelog.sh` calls the API at all. So the read is unused and I dropped it. Happy to put it back if you would rather keep the margin.

`release` (`contents: write` for the commit, the tag and `gh release create`) and `copilot-setup-steps` (`contents: read`) are already minimal, so they are untouched.

### The one I deliberately left alone

`welcome` keeps its `issues: write` + `pull-requests: write`. Tightening it further would be the wrong direction right now: #933 shows it failing with `HttpError: Resource not accessible by integration`, which means its current set is already too narrow rather than too wide.

For what it is worth while you look at that one, `wow-actions/welcome` calls `GET /repos/{owner}/{repo}/stargazers`, `issues.listForRepo`, `issues.createComment`, `reactions.createForIssueComment` and `search.issuesAndPullRequests`. The search call is the one I would suspect first. I did not touch it here because pinning it down needs a run in this repository's own CI rather than reading.
