### PR TITLE
Report additional property errors at the property path

### DIFF
--- a/src/JsonSchema/Constraints/Drafts/Draft06/AdditionalPropertiesConstraint.php
+++ b/src/JsonSchema/Constraints/Drafts/Draft06/AdditionalPropertiesConstraint.php
@@ -58,10 +58,15 @@ class AdditionalPropertiesConstraint implements ConstraintInterface
         if (is_object($schema->additionalProperties)) {
             foreach ($additionalProperties as $key => $additionalPropertiesValue) {
                 $schemaConstraint = $this->factory->createInstanceFor('schema');
-                $schemaConstraint->check($additionalPropertiesValue, $schema->additionalProperties, $path, $i); // @todo increment path
-                if ($schemaConstraint->isValid()) {
-                    unset($additionalProperties[$key]);
+                $schemaConstraint->check($additionalPropertiesValue, $schema->additionalProperties, ($path ?? new JsonPointer(''))->withAppendedPath($key), $i);
+
+                // The property is permitted by the schema, so it is never an "additional property"
+                // error; what it failed is the sub-schema, and those errors carry the reason.
+                if (!$schemaConstraint->isValid()) {
+                    $this->addErrors($schemaConstraint->getErrors());
                 }
+
+                unset($additionalProperties[$key]);
             }
         }
 

--- a/src/JsonSchema/Constraints/Drafts/Draft06/AdditionalPropertiesConstraint.php
+++ b/src/JsonSchema/Constraints/Drafts/Draft06/AdditionalPropertiesConstraint.php
@@ -71,7 +71,7 @@ class AdditionalPropertiesConstraint implements ConstraintInterface
         }
 
         foreach ($additionalProperties as $key => $additionalPropertiesValue) {
-            $this->addError(ConstraintError::ADDITIONAL_PROPERTIES(), $path, ['found' => $key]);
+            $this->addError(ConstraintError::ADDITIONAL_PROPERTIES(), ($path ?? new JsonPointer(''))->withAppendedPath($key), ['found' => $key]);
         }
     }
 

--- a/src/JsonSchema/Constraints/Drafts/Draft06/RequiredConstraint.php
+++ b/src/JsonSchema/Constraints/Drafts/Draft06/RequiredConstraint.php
@@ -34,25 +34,7 @@ class RequiredConstraint implements ConstraintInterface
                 continue;
             }
 
-            $this->addError(ConstraintError::REQUIRED(), $this->incrementPath($path, $required), ['property' => $required]);
+            $this->addError(ConstraintError::REQUIRED(), ($path ?? new JsonPointer(''))->withAppendedPath($required), ['property' => $required]);
         }
-    }
-
-    /**
-     * @todo refactor as this was only copied from UndefinedConstraint
-     * Bubble down the path
-     *
-     * @param JsonPointer|null $path Current path
-     * @param mixed            $i    What to append to the path
-     */
-    protected function incrementPath(?JsonPointer $path, $i): JsonPointer
-    {
-        $path = $path ?? new JsonPointer('');
-
-        if ($i === null || $i === '') {
-            return $path;
-        }
-
-        return $path->withPropertyPaths(array_merge($path->getPropertyPaths(), [$i]));
     }
 }

--- a/src/JsonSchema/Constraints/Drafts/Draft07/AdditionalPropertiesConstraint.php
+++ b/src/JsonSchema/Constraints/Drafts/Draft07/AdditionalPropertiesConstraint.php
@@ -58,10 +58,15 @@ class AdditionalPropertiesConstraint implements ConstraintInterface
         if (is_object($schema->additionalProperties)) {
             foreach ($additionalProperties as $key => $additionalPropertiesValue) {
                 $schemaConstraint = $this->factory->createInstanceFor('schema');
-                $schemaConstraint->check($additionalPropertiesValue, $schema->additionalProperties, $path, $i); // @todo increment path
-                if ($schemaConstraint->isValid()) {
-                    unset($additionalProperties[$key]);
+                $schemaConstraint->check($additionalPropertiesValue, $schema->additionalProperties, ($path ?? new JsonPointer(''))->withAppendedPath($key), $i);
+
+                // The property is permitted by the schema, so it is never an "additional property"
+                // error; what it failed is the sub-schema, and those errors carry the reason.
+                if (!$schemaConstraint->isValid()) {
+                    $this->addErrors($schemaConstraint->getErrors());
                 }
+
+                unset($additionalProperties[$key]);
             }
         }
 

--- a/src/JsonSchema/Constraints/Drafts/Draft07/AdditionalPropertiesConstraint.php
+++ b/src/JsonSchema/Constraints/Drafts/Draft07/AdditionalPropertiesConstraint.php
@@ -71,7 +71,7 @@ class AdditionalPropertiesConstraint implements ConstraintInterface
         }
 
         foreach ($additionalProperties as $key => $additionalPropertiesValue) {
-            $this->addError(ConstraintError::ADDITIONAL_PROPERTIES(), $path, ['found' => $key]);
+            $this->addError(ConstraintError::ADDITIONAL_PROPERTIES(), ($path ?? new JsonPointer(''))->withAppendedPath($key), ['found' => $key]);
         }
     }
 

--- a/src/JsonSchema/Constraints/Drafts/Draft07/RequiredConstraint.php
+++ b/src/JsonSchema/Constraints/Drafts/Draft07/RequiredConstraint.php
@@ -34,25 +34,7 @@ class RequiredConstraint implements ConstraintInterface
                 continue;
             }
 
-            $this->addError(ConstraintError::REQUIRED(), $this->incrementPath($path, $required), ['property' => $required]);
+            $this->addError(ConstraintError::REQUIRED(), ($path ?? new JsonPointer(''))->withAppendedPath($required), ['property' => $required]);
         }
-    }
-
-    /**
-     * @todo refactor as this was only copied from UndefinedConstraint
-     * Bubble down the path
-     *
-     * @param JsonPointer|null $path Current path
-     * @param mixed            $i    What to append to the path
-     */
-    protected function incrementPath(?JsonPointer $path, $i): JsonPointer
-    {
-        $path = $path ?? new JsonPointer('');
-
-        if ($i === null || $i === '') {
-            return $path;
-        }
-
-        return $path->withPropertyPaths(array_merge($path->getPropertyPaths(), [$i]));
     }
 }

--- a/src/JsonSchema/Constraints/Drafts/Draft2019/AdditionalPropertiesConstraint.php
+++ b/src/JsonSchema/Constraints/Drafts/Draft2019/AdditionalPropertiesConstraint.php
@@ -58,10 +58,15 @@ class AdditionalPropertiesConstraint implements ConstraintInterface
         if (is_object($schema->additionalProperties)) {
             foreach ($additionalProperties as $key => $additionalPropertiesValue) {
                 $schemaConstraint = $this->factory->createInstanceFor('schema');
-                $schemaConstraint->check($additionalPropertiesValue, $schema->additionalProperties, $path, $i); // @todo increment path
-                if ($schemaConstraint->isValid()) {
-                    unset($additionalProperties[$key]);
+                $schemaConstraint->check($additionalPropertiesValue, $schema->additionalProperties, ($path ?? new JsonPointer(''))->withAppendedPath($key), $i);
+
+                // The property is permitted by the schema, so it is never an "additional property"
+                // error; what it failed is the sub-schema, and those errors carry the reason.
+                if (!$schemaConstraint->isValid()) {
+                    $this->addErrors($schemaConstraint->getErrors());
                 }
+
+                unset($additionalProperties[$key]);
             }
         }
 

--- a/src/JsonSchema/Constraints/Drafts/Draft2019/AdditionalPropertiesConstraint.php
+++ b/src/JsonSchema/Constraints/Drafts/Draft2019/AdditionalPropertiesConstraint.php
@@ -71,7 +71,7 @@ class AdditionalPropertiesConstraint implements ConstraintInterface
         }
 
         foreach ($additionalProperties as $key => $additionalPropertiesValue) {
-            $this->addError(ConstraintError::ADDITIONAL_PROPERTIES(), $path, ['found' => $key]);
+            $this->addError(ConstraintError::ADDITIONAL_PROPERTIES(), ($path ?? new JsonPointer(''))->withAppendedPath($key), ['found' => $key]);
         }
     }
 

--- a/src/JsonSchema/Constraints/Drafts/Draft2019/RequiredConstraint.php
+++ b/src/JsonSchema/Constraints/Drafts/Draft2019/RequiredConstraint.php
@@ -34,25 +34,7 @@ class RequiredConstraint implements ConstraintInterface
                 continue;
             }
 
-            $this->addError(ConstraintError::REQUIRED(), $this->incrementPath($path, $required), ['property' => $required]);
+            $this->addError(ConstraintError::REQUIRED(), ($path ?? new JsonPointer(''))->withAppendedPath($required), ['property' => $required]);
         }
-    }
-
-    /**
-     * @todo refactor as this was only copied from UndefinedConstraint
-     * Bubble down the path
-     *
-     * @param JsonPointer|null $path Current path
-     * @param mixed            $i    What to append to the path
-     */
-    protected function incrementPath(?JsonPointer $path, $i): JsonPointer
-    {
-        $path = $path ?? new JsonPointer('');
-
-        if ($i === null || $i === '') {
-            return $path;
-        }
-
-        return $path->withPropertyPaths(array_merge($path->getPropertyPaths(), [$i]));
     }
 }

--- a/src/JsonSchema/Entity/JsonPointer.php
+++ b/src/JsonSchema/Entity/JsonPointer.php
@@ -128,6 +128,25 @@ class JsonPointer
     }
 
     /**
+     * Returns a new pointer with one more segment appended.
+     *
+     * A null or empty segment yields the pointer unchanged, so that callers can
+     * pass through an index they have not resolved yet.
+     *
+     * @param mixed $propertyPath
+     *
+     * @return JsonPointer
+     */
+    public function withAppendedPath($propertyPath)
+    {
+        if ($propertyPath === null || $propertyPath === '') {
+            return $this;
+        }
+
+        return $this->withPropertyPaths(array_merge($this->propertyPaths, [$propertyPath]));
+    }
+
+    /**
      * @return string
      */
     public function getPropertyPathAsString()

--- a/tests/Constraints/AdditionalPropertiesTest.php
+++ b/tests/Constraints/AdditionalPropertiesTest.php
@@ -122,8 +122,8 @@ class AdditionalPropertiesTest extends BaseTestCase
                 Constraint::CHECK_MODE_STRICT,
                 [
                     [
-                        'property'   => '',
-                        'pointer'    => '',
+                        'property'   => 'extraProp',
+                        'pointer'    => '/extraProp',
                         'message'    => 'The property extraProp is not defined and the definition does not allow additional properties',
                         'constraint' => [
                             'name'   => 'additionalProp',
@@ -149,8 +149,8 @@ class AdditionalPropertiesTest extends BaseTestCase
                 Constraint::CHECK_MODE_STRICT,
                 [
                     [
-                        'property'   => '',
-                        'pointer'    => '',
+                        'property'   => 'extraProp',
+                        'pointer'    => '/extraProp',
                         'message'    => 'The property extraProp is not defined and the definition does not allow additional properties',
                         'constraint' => [
                             'name'   => 'additionalProp',

--- a/tests/Constraints/Draft06/AdditionalPropertiesConstraintTest.php
+++ b/tests/Constraints/Draft06/AdditionalPropertiesConstraintTest.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JsonSchema\Tests\Constraints\Draft06;
+
+use JsonSchema\Constraints\Drafts\Draft06\AdditionalPropertiesConstraint;
+use JsonSchema\Tests\Constraints\VeryBaseTestCase;
+
+class AdditionalPropertiesConstraintTest extends VeryBaseTestCase
+{
+    public function testSubSchemaErrorsAreReportedAtThePropertyPath(): void
+    {
+        $constraint = new AdditionalPropertiesConstraint();
+        $schema = json_decode('{"properties": {"foo": {}}, "additionalProperties": {"type": "integer"}}');
+        $value = json_decode('{"foo": "ok", "bar": "not-an-integer"}');
+
+        $constraint->check($value, $schema);
+
+        $errors = $constraint->getErrors();
+        $this->assertCount(1, $errors);
+        $this->assertSame('/bar', $errors[0]['pointer']);
+        $this->assertSame('type', $errors[0]['constraint']['name']);
+    }
+
+    public function testAPropertyMatchingTheSubSchemaIsNotReported(): void
+    {
+        $constraint = new AdditionalPropertiesConstraint();
+        $schema = json_decode('{"additionalProperties": {"type": "integer"}}');
+        $value = json_decode('{"bar": 1}');
+
+        $constraint->check($value, $schema);
+
+        $this->assertSame([], $constraint->getErrors());
+    }
+
+    public function testAdditionalPropertiesFalseStillReportsTheProperty(): void
+    {
+        $constraint = new AdditionalPropertiesConstraint();
+        $schema = json_decode('{"properties": {"foo": {}}, "additionalProperties": false}');
+        $value = json_decode('{"foo": "ok", "bar": 1}');
+
+        $constraint->check($value, $schema);
+
+        $errors = $constraint->getErrors();
+        $this->assertCount(1, $errors);
+        $this->assertSame('additionalProp', $errors[0]['constraint']['name']);
+    }
+}

--- a/tests/Constraints/Draft06/AdditionalPropertiesConstraintTest.php
+++ b/tests/Constraints/Draft06/AdditionalPropertiesConstraintTest.php
@@ -44,6 +44,7 @@ class AdditionalPropertiesConstraintTest extends VeryBaseTestCase
 
         $errors = $constraint->getErrors();
         $this->assertCount(1, $errors);
+        $this->assertSame('/bar', $errors[0]['pointer']);
         $this->assertSame('additionalProp', $errors[0]['constraint']['name']);
     }
 }

--- a/tests/Constraints/Draft07/AdditionalPropertiesConstraintTest.php
+++ b/tests/Constraints/Draft07/AdditionalPropertiesConstraintTest.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JsonSchema\Tests\Constraints\Draft07;
+
+use JsonSchema\Constraints\Drafts\Draft07\AdditionalPropertiesConstraint;
+use JsonSchema\Tests\Constraints\VeryBaseTestCase;
+
+class AdditionalPropertiesConstraintTest extends VeryBaseTestCase
+{
+    public function testSubSchemaErrorsAreReportedAtThePropertyPath(): void
+    {
+        $constraint = new AdditionalPropertiesConstraint();
+        $schema = json_decode('{"properties": {"foo": {}}, "additionalProperties": {"type": "integer"}}');
+        $value = json_decode('{"foo": "ok", "bar": "not-an-integer"}');
+
+        $constraint->check($value, $schema);
+
+        $errors = $constraint->getErrors();
+        $this->assertCount(1, $errors);
+        $this->assertSame('/bar', $errors[0]['pointer']);
+        $this->assertSame('type', $errors[0]['constraint']['name']);
+    }
+
+    public function testAPropertyMatchingTheSubSchemaIsNotReported(): void
+    {
+        $constraint = new AdditionalPropertiesConstraint();
+        $schema = json_decode('{"additionalProperties": {"type": "integer"}}');
+        $value = json_decode('{"bar": 1}');
+
+        $constraint->check($value, $schema);
+
+        $this->assertSame([], $constraint->getErrors());
+    }
+
+    public function testAdditionalPropertiesFalseStillReportsTheProperty(): void
+    {
+        $constraint = new AdditionalPropertiesConstraint();
+        $schema = json_decode('{"properties": {"foo": {}}, "additionalProperties": false}');
+        $value = json_decode('{"foo": "ok", "bar": 1}');
+
+        $constraint->check($value, $schema);
+
+        $errors = $constraint->getErrors();
+        $this->assertCount(1, $errors);
+        $this->assertSame('additionalProp', $errors[0]['constraint']['name']);
+    }
+}

--- a/tests/Constraints/Draft07/AdditionalPropertiesConstraintTest.php
+++ b/tests/Constraints/Draft07/AdditionalPropertiesConstraintTest.php
@@ -44,6 +44,7 @@ class AdditionalPropertiesConstraintTest extends VeryBaseTestCase
 
         $errors = $constraint->getErrors();
         $this->assertCount(1, $errors);
+        $this->assertSame('/bar', $errors[0]['pointer']);
         $this->assertSame('additionalProp', $errors[0]['constraint']['name']);
     }
 }

--- a/tests/Constraints/Draft2019/AdditionalPropertiesConstraintTest.php
+++ b/tests/Constraints/Draft2019/AdditionalPropertiesConstraintTest.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JsonSchema\Tests\Constraints\Draft2019;
+
+use JsonSchema\Constraints\Drafts\Draft2019\AdditionalPropertiesConstraint;
+use JsonSchema\Tests\Constraints\VeryBaseTestCase;
+
+class AdditionalPropertiesConstraintTest extends VeryBaseTestCase
+{
+    public function testSubSchemaErrorsAreReportedAtThePropertyPath(): void
+    {
+        $constraint = new AdditionalPropertiesConstraint();
+        $schema = json_decode('{"properties": {"foo": {}}, "additionalProperties": {"type": "integer"}}');
+        $value = json_decode('{"foo": "ok", "bar": "not-an-integer"}');
+
+        $constraint->check($value, $schema);
+
+        $errors = $constraint->getErrors();
+        $this->assertCount(1, $errors);
+        $this->assertSame('/bar', $errors[0]['pointer']);
+        $this->assertSame('type', $errors[0]['constraint']['name']);
+    }
+
+    public function testAPropertyMatchingTheSubSchemaIsNotReported(): void
+    {
+        $constraint = new AdditionalPropertiesConstraint();
+        $schema = json_decode('{"additionalProperties": {"type": "integer"}}');
+        $value = json_decode('{"bar": 1}');
+
+        $constraint->check($value, $schema);
+
+        $this->assertSame([], $constraint->getErrors());
+    }
+
+    public function testAdditionalPropertiesFalseStillReportsTheProperty(): void
+    {
+        $constraint = new AdditionalPropertiesConstraint();
+        $schema = json_decode('{"properties": {"foo": {}}, "additionalProperties": false}');
+        $value = json_decode('{"foo": "ok", "bar": 1}');
+
+        $constraint->check($value, $schema);
+
+        $errors = $constraint->getErrors();
+        $this->assertCount(1, $errors);
+        $this->assertSame('additionalProp', $errors[0]['constraint']['name']);
+    }
+}

--- a/tests/Constraints/Draft2019/AdditionalPropertiesConstraintTest.php
+++ b/tests/Constraints/Draft2019/AdditionalPropertiesConstraintTest.php
@@ -44,6 +44,7 @@ class AdditionalPropertiesConstraintTest extends VeryBaseTestCase
 
         $errors = $constraint->getErrors();
         $this->assertCount(1, $errors);
+        $this->assertSame('/bar', $errors[0]['pointer']);
         $this->assertSame('additionalProp', $errors[0]['constraint']['name']);
     }
 }


### PR DESCRIPTION
Closes #919 and #918.

Two corrections to the diagnosis in #919 came out of reproducing it, so the change is not the one-liner the issue suggests.

**The suggested fix could not compile.** `JsonPointer` has no `withAppendedPath()`. The equivalent lives as a `protected incrementPath()` copy-pasted into the `RequiredConstraint` of all three drafts, which is exactly what #918 asks to move onto `JsonPointer`. Fixing #919 on its own would have meant writing that helper a fourth, fifth and sixth time, so doing #918 first makes this the smaller change rather than a wider one. `JsonPointer::withAppendedPath()` is added, the three duplicates are gone.

**Incrementing the path alone changes nothing.** `AdditionalPropertiesConstraint` never propagates the sub-schema errors: it calls `check()`, reads `isValid()` as a boolean, and throws the errors away. So the reported symptom does not happen either. Reproducing the example from the issue in `CHECK_MODE_STRICT`, which is where the draft constraints are actually used:

```
before   pointer=''      constraint=additionalProp
after    pointer='/bar'  constraint=type
```

There was no type error at the root; there was no type error at all. The reason for the failure was discarded and replaced by an `additionalProperties` error pointing at the parent.

That second error is wrong on its own terms. When `additionalProperties` is a schema, the property **is** permitted, so "additional property found" is not what happened. `PropertiesConstraint` already does the right thing three files away, ending its loop with `$this->addErrors($schemaConstraint->getErrors())`. This aligns `AdditionalPropertiesConstraint` with it, and keeps the `additionalProperties` error for the `additionalProperties: false` case where it belongs.

### Verification

Nine tests added, three per draft: the sub-schema error lands at `/bar`, a property matching the sub-schema reports nothing, and `additionalProperties: false` still reports the property. Each fails without the change.

Full suite green at 3169 tests, including the official JSON-Schema-Test-Suite for draft06, draft07 and draft2019 in strict mode, which arbitrates the validity verdicts. PHPStan clean.

One caveat on style: `php-cs-fixer` pins itself to PHP 8.0 and I only have 8.5 here, so with `PHP_CS_FIXER_IGNORE_ENV` it proposes changes on 120 files, all of them the same bogus `&$value` to `& $value` rewrite. The only thing it says about the files touched here is that rewrite, on a signature line I did not modify, so I left it alone rather than commit noise.
