### PR TITLE
Report an unresolvable $ref instead of passing silently

### DIFF
--- a/src/JsonSchema/ConstraintError.php
+++ b/src/JsonSchema/ConstraintError.php
@@ -52,6 +52,7 @@ class ConstraintError extends Enum
     public const NOT = 'not';
     public const ONE_OF = 'oneOf';
     public const REQUIRED = 'required';
+    public const UNRESOLVABLE_REF = 'unresolvableRef';
     public const REQUIRES = 'requires';
     public const PATTERN = 'pattern';
     public const PREGEX_INVALID = 'pregrex';
@@ -114,6 +115,7 @@ class ConstraintError extends Enum
             self::NOT => 'Matched a schema which it should not',
             self::ONE_OF => 'Failed to match exactly one schema',
             self::REQUIRED => 'The property %s is required',
+            self::UNRESOLVABLE_REF => 'The $ref "%s" could not be resolved',
             self::REQUIRES => 'The presence of the property %s requires that %s also be present',
             self::PATTERN => 'Does not match the regex pattern %s',
             self::PREGEX_INVALID => 'The pattern %s is invalid',

--- a/src/JsonSchema/Constraints/Drafts/Draft06/RefConstraint.php
+++ b/src/JsonSchema/Constraints/Drafts/Draft06/RefConstraint.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace JsonSchema\Constraints\Drafts\Draft06;
 
+use JsonSchema\ConstraintError;
 use JsonSchema\Constraints\ConstraintInterface;
 use JsonSchema\Entity\ErrorBagProxy;
 use JsonSchema\Entity\JsonPointer;
@@ -30,6 +31,10 @@ class RefConstraint implements ConstraintInterface
         try {
             $refSchema = $this->factory->getSchemaStorage()->resolveRefSchema($schema);
         } catch (\Exception $e) {
+            // A $ref that cannot be resolved is a broken schema, not an absent keyword:
+            // returning here would let the value pass as if the $ref had not been written.
+            $this->addError(ConstraintError::UNRESOLVABLE_REF(), $path, ['ref' => $schema->{'$ref'}]);
+
             return;
         }
 

--- a/src/JsonSchema/Constraints/Drafts/Draft07/RefConstraint.php
+++ b/src/JsonSchema/Constraints/Drafts/Draft07/RefConstraint.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace JsonSchema\Constraints\Drafts\Draft07;
 
+use JsonSchema\ConstraintError;
 use JsonSchema\Constraints\ConstraintInterface;
 use JsonSchema\Entity\ErrorBagProxy;
 use JsonSchema\Entity\JsonPointer;
@@ -30,6 +31,10 @@ class RefConstraint implements ConstraintInterface
         try {
             $refSchema = $this->factory->getSchemaStorage()->resolveRefSchema($schema);
         } catch (\Exception $e) {
+            // A $ref that cannot be resolved is a broken schema, not an absent keyword:
+            // returning here would let the value pass as if the $ref had not been written.
+            $this->addError(ConstraintError::UNRESOLVABLE_REF(), $path, ['ref' => $schema->{'$ref'}]);
+
             return;
         }
 

--- a/src/JsonSchema/Constraints/Drafts/Draft2019/RefConstraint.php
+++ b/src/JsonSchema/Constraints/Drafts/Draft2019/RefConstraint.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace JsonSchema\Constraints\Drafts\Draft2019;
 
+use JsonSchema\ConstraintError;
 use JsonSchema\Constraints\ConstraintInterface;
 use JsonSchema\Entity\ErrorBagProxy;
 use JsonSchema\Entity\JsonPointer;
@@ -30,6 +31,10 @@ class RefConstraint implements ConstraintInterface
         try {
             $refSchema = $this->factory->getSchemaStorage()->resolveRefSchema($schema);
         } catch (\Exception $e) {
+            // A $ref that cannot be resolved is a broken schema, not an absent keyword:
+            // returning here would let the value pass as if the $ref had not been written.
+            $this->addError(ConstraintError::UNRESOLVABLE_REF(), $path, ['ref' => $schema->{'$ref'}]);
+
             return;
         }
 

--- a/tests/Constraints/Draft06/RefConstraintTest.php
+++ b/tests/Constraints/Draft06/RefConstraintTest.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JsonSchema\Tests\Constraints\Draft06;
+
+use JsonSchema\Constraints\Constraint;
+use JsonSchema\Tests\Constraints\VeryBaseTestCase;
+use JsonSchema\Validator;
+
+class RefConstraintTest extends VeryBaseTestCase
+{
+    private const DIALECT = 'http://json-schema.org/draft-06/schema#';
+
+    public function testAnUnresolvableRefIsReportedInsteadOfSilentlyPassing(): void
+    {
+        $validator = new Validator();
+        $data = new \stdClass();
+        $schema = json_decode('{"$schema": "' . self::DIALECT . '", "$ref": "#/$defs/nonExistent"}');
+
+        $validator->validate($data, $schema, Constraint::CHECK_MODE_STRICT);
+
+        self::assertFalse($validator->isValid());
+        $errors = $validator->getErrors();
+        self::assertCount(1, $errors);
+        self::assertSame('unresolvableRef', $errors[0]['constraint']['name']);
+    }
+
+    public function testAResolvableRefStillValidates(): void
+    {
+        $validator = new Validator();
+        $data = json_decode('{"child": 1}');
+        $schema = json_decode(
+            '{"$schema": "' . self::DIALECT . '", "$defs": {"num": {"type": "integer"}},'
+            . ' "properties": {"child": {"$ref": "#/$defs/num"}}}'
+        );
+
+        $validator->validate($data, $schema, Constraint::CHECK_MODE_STRICT);
+
+        self::assertTrue($validator->isValid(), (string) json_encode($validator->getErrors()));
+    }
+}

--- a/tests/Constraints/Draft07/RefConstraintTest.php
+++ b/tests/Constraints/Draft07/RefConstraintTest.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JsonSchema\Tests\Constraints\Draft07;
+
+use JsonSchema\Constraints\Constraint;
+use JsonSchema\Tests\Constraints\VeryBaseTestCase;
+use JsonSchema\Validator;
+
+class RefConstraintTest extends VeryBaseTestCase
+{
+    private const DIALECT = 'http://json-schema.org/draft-07/schema#';
+
+    public function testAnUnresolvableRefIsReportedInsteadOfSilentlyPassing(): void
+    {
+        $validator = new Validator();
+        $data = new \stdClass();
+        $schema = json_decode('{"$schema": "' . self::DIALECT . '", "$ref": "#/$defs/nonExistent"}');
+
+        $validator->validate($data, $schema, Constraint::CHECK_MODE_STRICT);
+
+        self::assertFalse($validator->isValid());
+        $errors = $validator->getErrors();
+        self::assertCount(1, $errors);
+        self::assertSame('unresolvableRef', $errors[0]['constraint']['name']);
+    }
+
+    public function testAResolvableRefStillValidates(): void
+    {
+        $validator = new Validator();
+        $data = json_decode('{"child": 1}');
+        $schema = json_decode(
+            '{"$schema": "' . self::DIALECT . '", "$defs": {"num": {"type": "integer"}},'
+            . ' "properties": {"child": {"$ref": "#/$defs/num"}}}'
+        );
+
+        $validator->validate($data, $schema, Constraint::CHECK_MODE_STRICT);
+
+        self::assertTrue($validator->isValid(), (string) json_encode($validator->getErrors()));
+    }
+}

--- a/tests/Constraints/Draft2019/RefConstraintTest.php
+++ b/tests/Constraints/Draft2019/RefConstraintTest.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JsonSchema\Tests\Constraints\Draft2019;
+
+use JsonSchema\Constraints\Constraint;
+use JsonSchema\Tests\Constraints\VeryBaseTestCase;
+use JsonSchema\Validator;
+
+class RefConstraintTest extends VeryBaseTestCase
+{
+    private const DIALECT = 'https://json-schema.org/draft/2019-09/schema';
+
+    public function testAnUnresolvableRefIsReportedInsteadOfSilentlyPassing(): void
+    {
+        $validator = new Validator();
+        $data = new \stdClass();
+        $schema = json_decode('{"$schema": "' . self::DIALECT . '", "$ref": "#/$defs/nonExistent"}');
+
+        $validator->validate($data, $schema, Constraint::CHECK_MODE_STRICT);
+
+        self::assertFalse($validator->isValid());
+        $errors = $validator->getErrors();
+        self::assertCount(1, $errors);
+        self::assertSame('unresolvableRef', $errors[0]['constraint']['name']);
+    }
+
+    public function testAResolvableRefStillValidates(): void
+    {
+        $validator = new Validator();
+        $data = json_decode('{"child": 1}');
+        $schema = json_decode(
+            '{"$schema": "' . self::DIALECT . '", "$defs": {"num": {"type": "integer"}},'
+            . ' "properties": {"child": {"$ref": "#/$defs/num"}}}'
+        );
+
+        $validator->validate($data, $schema, Constraint::CHECK_MODE_STRICT);
+
+        self::assertTrue($validator->isValid(), (string) json_encode($validator->getErrors()));
+    }
+}


### PR DESCRIPTION
Closes #916.

This takes option 1 from the issue, a validation error, and there is an argument for it beyond it being the least disruptive: **`CHECK_MODE_STRICT` is currently more permissive than the default mode.** Same schema, same data, on `main`:

```
default mode        : UnresolvableJsonPointerException thrown
CHECK_MODE_STRICT   : isValid = true, 0 errors
```

The legacy path already refuses to let a broken `$ref` through; it is only the draft-specific constraints that swallow it. So this is not just a missing feature, it is the strict mode being laxer than the mode it is supposed to tighten. After the change, strict mode reports one error and the default mode is untouched.

### On the error constant

The issue suggests `MISSING_ERROR` or a new one. `MISSING_ERROR` is not available: its message is commented out in `ConstraintError` with `Used for tests; this error is deliberately commented out`, so it is reserved. This adds `UNRESOLVABLE_REF` with the message `The $ref "%s" could not be resolved`, which also names the pointer that failed rather than leaving the reader to find it.

### On the offline case

The issue rightly raises unreachable remote schemas. Nothing changes there for anyone on the default mode, which already throws. For strict mode, a remote `$ref` that cannot be fetched now produces a validation error rather than a silent pass, which I think is the honest answer: the validator cannot claim a document conforms to a schema it never read. Option 3, gating on `CHECK_MODE_EXCEPTIONS`, remains available on top of this if you would rather make it configurable.

### Verification

Two tests per draft: an unresolvable `$ref` is reported with the new constraint name, and a resolvable one still validates. Each fails without the change.

Full suite green at 3166 tests, including the official JSON-Schema-Test-Suite, which is what I would have expected to break had the previous behaviour been load-bearing. PHPStan clean.
