### PR TITLE
fix: Correct changelog and changelog updates

### DIFF
--- a/.github/workflows/update-changelog.yml
+++ b/.github/workflows/update-changelog.yml
@@ -1,7 +1,7 @@
 name: "Update Changelog"
 
 on:
-  pull_request:
+  pull_request_target:
     types: [closed]
     branches:
       - main
@@ -16,7 +16,7 @@ jobs:
 
     steps:
       - name: "Checkout"
-        uses: "actions/checkout@v5"
+        uses: "actions/checkout@v7"
         with:
           ref: main
           fetch-depth: 0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Fix RFC 3339 date-time validation with high-precision fractional seconds ([#940](https://github.com/jsonrainbow/json-schema/pull/940))
+
+### Added
+- Define minimal permissions on every workflow ([#941](https://github.com/jsonrainbow/json-schema/pull/941))
+- feat: Add --allow-invalid-content-type-endpoint option to validate-json ([#932](https://github.com/jsonrainbow/json-schema/pull/932))
+
+
 ## [6.11.0] - 2026-08-21
 
 ### Fixed
-- Fix RFC 3339 date-time validation with high-precision fractional seconds ([#940]
 - fix: Handle null byte when validating date/time formats ([#939](https://github.com/jsonrainbow/json-schema/pull/939))
 - fix: Correct php-cs-fixer setup ([#938](https://github.com/jsonrainbow/json-schema/pull/938))
 - fix: Ignore Content-Type header parameters when checking media type ([#934](https://github.com/jsonrainbow/json-schema/pull/934))
@@ -21,8 +28,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Update README with Draft 7 badge correction and include JetBrains logo ([#921](https://github.com/jsonrainbow/json-schema/pull/921))
 
 ### Added
-- feat: Add --allow-invalid-content-type-endpoint option to validate-json ([#932](https://github.com/jsonrainbow/json-schema/pull/932))
-- Define minimal permissions on every workflow ([#941](https://github.com/jsonrainbow/json-schema/pull/941))
 - Update composer.json authors to reflect current active maintainer ([#928](https://github.com/jsonrainbow/json-schema/pull/928))
 
 


### PR DESCRIPTION
## Description
In #908 it was already reported changelog entries would fail when PR where coming from a forked repo.
This PR will:
- Correct the changelog putting unreleased items back into the **Unreleased section**
- Correct the workflow target from `pull_request` to `pull_request_target` to allow for a token with write permissions. The workflow uses `ref: main` which means main repo and not the fork.
- Bump checkout in the changelog workflow to v7 to block checkout forked pr code, see https://github.com/actions/checkout/pull/2454

## Related Issue

Solves #908 

## Type of Change

<!-- Mark the appropriate option with an "x" -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Code refactoring
- [ ] Other (please describe):

## Checklist

<!-- Mark completed items with an "x" -->

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) guidelines
- [x] My code follows the code style of this project
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] All new and existing tests pass
- [x] I have updated the documentation accordingly
- [x] My changes generate no new warnings

## Additional Notes

<!-- Add any additional information that might be helpful for reviewers -->
