### PR TITLE
Stop inheriting the query and fragment of the base URI

### DIFF
--- a/src/JsonSchema/Uri/UriResolver.php
+++ b/src/JsonSchema/Uri/UriResolver.php
@@ -107,6 +107,21 @@ class UriResolver implements UriResolverInterface
         $basePath = $baseComponents['path'];
 
         $baseComponents['path'] = self::combineRelativePathWithBasePath($path, $basePath);
+
+        // RFC 3986 section 5.3: a reference carrying a path replaces the query of the base,
+        // whether or not it has one of its own. Only a reference without a path, such as a
+        // bare fragment, keeps it.
+        if ('' !== $path) {
+            unset($baseComponents['query']);
+        }
+        // parse() reports an empty query for a bare fragment, and generate() drops an empty
+        // one anyway, so only a query with a value is carried over
+        if (isset($components['query']) && '' !== $components['query']) {
+            $baseComponents['query'] = $components['query'];
+        }
+
+        // the fragment always comes from the reference and is never inherited
+        unset($baseComponents['fragment']);
         if (isset($components['fragment'])) {
             $baseComponents['fragment'] = $components['fragment'];
         }

--- a/src/JsonSchema/Uri/UriResolver.php
+++ b/src/JsonSchema/Uri/UriResolver.php
@@ -93,7 +93,7 @@ class UriResolver implements UriResolverInterface
             }
         }
 
-        if ($uri == '') {
+        if ($uri === '' && (null === $baseUri || '' === $baseUri)) {
             return $baseUri;
         }
 
@@ -108,15 +108,16 @@ class UriResolver implements UriResolverInterface
 
         $baseComponents['path'] = self::combineRelativePathWithBasePath($path, $basePath);
 
-        // RFC 3986 section 5.3: a reference carrying a path replaces the query of the base,
-        // whether or not it has one of its own. Only a reference without a path, such as a
-        // bare fragment, keeps it.
-        if ('' !== $path) {
+        // RFC 3986 section 5.2.2: the query of the base survives only for a reference that
+        // carries neither a path nor a query of its own, such as a bare fragment. parse()
+        // cannot tell an empty query from an absent one, both being '', so the delimiter is
+        // looked for in the reference itself.
+        $hasQuery = false !== strpos(explode('#', $uri, 2)[0], '?');
+
+        if ('' !== $path || $hasQuery) {
             unset($baseComponents['query']);
         }
-        // parse() reports an empty query for a bare fragment, and generate() drops an empty
-        // one anyway, so only a query with a value is carried over
-        if (isset($components['query']) && '' !== $components['query']) {
+        if ($hasQuery && '' !== $components['query']) {
             $baseComponents['query'] = $components['query'];
         }
 

--- a/tests/Uri/UriResolverTest.php
+++ b/tests/Uri/UriResolverTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace JsonSchema\Tests\Uri;
 
 use JsonSchema\Uri\UriResolver;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
 class UriResolverTest extends TestCase
@@ -186,6 +187,38 @@ class UriResolverTest extends TestCase
                 'http://example.org/foo/bar.json'
             )
         );
+    }
+
+    /**
+     * @dataProvider queryAndFragmentInheritanceCases
+     */
+    #[DataProvider('queryAndFragmentInheritanceCases')]
+    public function testResolveDoesNotInheritQueryAndFragmentFromBase(string $expected, string $uri, string $baseUri): void
+    {
+        $this->assertEquals($expected, $this->resolver->resolve($uri, $baseUri));
+    }
+
+    /**
+     * @return array<string, array{string, string, string}>
+     */
+    public static function queryAndFragmentInheritanceCases(): array
+    {
+        $base = 'http://example.org/foo/x.json?old#frag';
+
+        return [
+            // RFC 3986 section 5.3: neither is inherited when the reference has a path
+            'plain reference' => ['http://example.org/foo/bar.json', 'bar.json', $base],
+            'reference with its own query' => ['http://example.org/foo/bar.json?new', 'bar.json?new', $base],
+            'reference with its own fragment' => ['http://example.org/foo/bar.json#f2', 'bar.json#f2', $base],
+            'reference with both' => ['http://example.org/foo/bar.json?new#f2', 'bar.json?new#f2', $base],
+            'absolute path reference' => ['http://example.org/abs.json', '/abs.json', $base],
+            // a reference without a path keeps the query of the base
+            'bare fragment' => [
+                'http://example.org/schema.json?q=1#/definitions/x',
+                '#/definitions/x',
+                'http://example.org/schema.json?q=1',
+            ],
+        ];
     }
 
     public function testReversable(): void

--- a/tests/Uri/UriResolverTest.php
+++ b/tests/Uri/UriResolverTest.php
@@ -189,6 +189,17 @@ class UriResolverTest extends TestCase
         );
     }
 
+    public function testResolveEmptyDropsTheFragmentOfTheBase(): void
+    {
+        $this->assertEquals(
+            'http://example.org/foo/bar.json?q=1',
+            $this->resolver->resolve(
+                '',
+                'http://example.org/foo/bar.json?q=1#frag'
+            )
+        );
+    }
+
     /**
      * @dataProvider queryAndFragmentInheritanceCases
      */
@@ -212,12 +223,15 @@ class UriResolverTest extends TestCase
             'reference with its own fragment' => ['http://example.org/foo/bar.json#f2', 'bar.json#f2', $base],
             'reference with both' => ['http://example.org/foo/bar.json?new#f2', 'bar.json?new#f2', $base],
             'absolute path reference' => ['http://example.org/abs.json', '/abs.json', $base],
-            // a reference without a path keeps the query of the base
+            // a reference without a path or query of its own keeps the query of the base
             'bare fragment' => [
                 'http://example.org/schema.json?q=1#/definitions/x',
                 '#/definitions/x',
                 'http://example.org/schema.json?q=1',
             ],
+            // an empty query is supplied, not absent, so it replaces the one of the base
+            'empty query' => ['http://example.org/foo/x.json', '?', $base],
+            'empty query with a fragment' => ['http://example.org/foo/x.json#f2', '?#f2', $base],
         ];
     }
 


### PR DESCRIPTION
Fixes #948.

`resolve()` reused the parsed base components wholesale, so the base query and fragment survived into the resolved URI.

While reproducing it I found a second half you did not mention: the query of the *reference* was dropped entirely, not just the base one kept.

```php
$resolver->resolve('bar.json?new', 'http://example.org/foo/x.json?old#frag');
// before: http://example.org/foo/bar.json?old#frag
// after:  http://example.org/foo/bar.json?new
```

So the rule now follows RFC 3986 section 5.3: a reference carrying a path replaces the query of the base whether or not it has one of its own, only a reference without a path keeps it, and the fragment always comes from the reference.

One detail worth flagging, because it is the trap here. `isset($components['query'])` is not enough: `parse('#/definitions/x')` reports an empty query, so testing the key alone would drop the base query for every bare fragment, which is the most common `$ref` shape in this library. The condition therefore tests for a non-empty value, which is consistent with `generate()` already omitting an empty query.

#### Testing

Six cases in a data provider. Five of them fail on `main`, the sixth is the bare fragment against a base with a query, which already worked and is there to keep it working.

Full suite green (3187 tests), same warning and skips as `main`, and PHPStan reports no errors.
