### PR TITLE
Discard parent segments that climb past the root

### DIFF
--- a/src/JsonSchema/Uri/UriResolver.php
+++ b/src/JsonSchema/Uri/UriResolver.php
@@ -144,14 +144,12 @@ class UriResolver implements UriResolverInterface
         while ($combinedSegments) {
             $segment = array_shift($combinedSegments);
             if ($segment === '..') {
-                if (count($collapsedSegments) <= 1) {
-                    // Do not remove the top level (domain)
-                    // This is not ideal - the domain should not be part of the path here. parse() and generate()
-                    // should handle the "domain" separately, like the schema.
-                    // Then the if-condition here would be `if (!$collapsedSegments) {`.
-                    throw new UriResolverException(sprintf("Unable to resolve URI '%s' from base '%s'", $relativePath, $basePath));
+                // RFC 3986 section 5.2.4: a parent segment climbing past the root is
+                // discarded rather than being an error. The leading empty segment of an
+                // absolute path is the root itself, so it is never popped.
+                if ([] !== $collapsedSegments && [''] !== $collapsedSegments) {
+                    array_pop($collapsedSegments);
                 }
-                array_pop($collapsedSegments);
             } else {
                 $collapsedSegments[] = $segment;
             }

--- a/tests/Uri/UriResolverTest.php
+++ b/tests/Uri/UriResolverTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace JsonSchema\Tests\Uri;
 
 use JsonSchema\Uri\UriResolver;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
 class UriResolverTest extends TestCase
@@ -102,6 +103,37 @@ class UriResolverTest extends TestCase
                 '../../../schema/UuidSchema.json',
                 '/var/packages/foo/tests/UnitTests/DemoData/../../../schema/Foo/FooSchema_latest.json'
             )
+        );
+    }
+
+    /**
+     * @dataProvider excessParentSegmentCases
+     */
+    #[DataProvider('excessParentSegmentCases')]
+    public function testCombineRelativePathWithBasePathDiscardsExcessParentSegments(string $expected, string $relativePath, string $basePath): void
+    {
+        $this->assertEquals($expected, UriResolver::combineRelativePathWithBasePath($relativePath, $basePath));
+    }
+
+    /**
+     * @return array<string, array{string, string, string}>
+     */
+    public static function excessParentSegmentCases(): array
+    {
+        return [
+            // RFC 3986 section 5.2.4: a parent segment climbing past the root is discarded
+            'more parents than segments' => ['/bar.json', '../../../bar.json', '/a/'],
+            'parent against the root itself' => ['/bar.json', '../bar.json', '/'],
+            // the root is never popped, but a real leading segment still is
+            'parent against a relative base' => ['bar.json', '../bar.json', 'foo/baz.json'],
+        ];
+    }
+
+    public function testResolveDiscardsExcessParentSegments(): void
+    {
+        $this->assertEquals(
+            'http://example.org/bar.json',
+            $this->resolver->resolve('../../../bar.json', 'http://example.org/a/')
         );
     }
 

--- a/tests/Uri/UriRetrieverTest.php
+++ b/tests/Uri/UriRetrieverTest.php
@@ -8,7 +8,6 @@ use JsonSchema\DraftIdentifiers;
 use JsonSchema\Exception\InvalidSchemaMediaTypeException;
 use JsonSchema\Exception\JsonDecodingException;
 use JsonSchema\Exception\ResourceNotFoundException;
-use JsonSchema\Exception\UriResolverException;
 use JsonSchema\Uri\UriRetriever;
 use JsonSchema\Validator;
 use PHPUnit\Framework\TestCase;
@@ -220,9 +219,11 @@ EOF;
     {
         $retriever = new UriRetriever();
 
-        $this->expectException(UriResolverException::class);
-        $retriever->resolve(
-            '../schema.json#', 'http://example.org/schema.json#'
+        // RFC 3986 section 5.2.4: the parent segment climbs past the root, so it is
+        // discarded instead of making the reference unresolvable
+        $this->assertEquals(
+            'http://example.org/schema.json',
+            $retriever->resolve('../schema.json#', 'http://example.org/schema.json#')
         );
     }
 


### PR DESCRIPTION
Fixes #950.

`combineRelativePathWithBasePath()` threw when a `..` segment could not be popped. RFC 3986 section 5.2.4 discards those instead, so it now does.

The guard had a second problem beyond the one in the issue: `count($collapsedSegments) <= 1` also refused to pop a *real* first segment, so `../bar.json` against a relative base `foo/baz.json` threw rather than resolving to `bar.json`. The condition now protects only what it meant to, the leading empty segment that stands for the root of an absolute path.

**One thing that needs your call.** `UriRetrieverTest::testResolveExcessLevelUp` asserted the exception this change removes:

```php
$this->expectException(UriResolverException::class);
$retriever->resolve('../schema.json#', 'http://example.org/schema.json#');
```

Your acceptance list mentions `UriResolverTest`, so I suspect this one was not on the radar. I turned it into an assertion on the resolved value (`http://example.org/schema.json`) rather than deleting it, but it is a deliberate behaviour change and it is yours to confirm.

Note this does not on its own make the exact example from the issue work: `resolve('../bar.json', 'internal://mySchema')` still stops earlier, on the empty base path, until #947 lands. The two are independent, as you noted, and the `..` handling is what this PR covers.

#### Testing

Four new cases, all failing without the change.

Full suite green (3185 tests), same warning and skips as `main`, and PHPStan reports no errors.

On the measurement you asked for, with `shouldNotYieldTest()` disabled: **7037 tests, 30 errors, 550 failures, identical before and after**. So this neither fixes nor breaks anything in the official suite. One caveat on that run: the vendored suite here has a `v1` directory that is not in `$skippedDrafts`, which makes the data provider throw `v1 is not a valid constraint name` (that is the single warning already present on `main`). I excluded it for the measurement only, nothing of that is in this PR.
